### PR TITLE
feat: honor per-task cron schedules and reap stale sessions

### DIFF
--- a/examples/blog/wrangler.jsonc
+++ b/examples/blog/wrangler.jsonc
@@ -23,4 +23,9 @@
     "binding": "ASSETS",
     "not_found_handling": "none",
   },
+  // Fires plumix's scheduled tasks. `0 3 * * *` matches the core
+  // session-cleanup task (daily reap of expired sessions).
+  "triggers": {
+    "crons": ["0 3 * * *"],
+  },
 }

--- a/examples/minimal/wrangler.jsonc
+++ b/examples/minimal/wrangler.jsonc
@@ -16,5 +16,10 @@
     "directory": ".plumix/public",
     "binding": "ASSETS",
     "not_found_handling": "none"
+  },
+  // Fires plumix's scheduled tasks. `0 3 * * *` matches the core
+  // session-cleanup task (daily reap of expired sessions).
+  "triggers": {
+    "crons": ["0 3 * * *"]
   }
 }

--- a/packages/core/src/auth/sessions.test.ts
+++ b/packages/core/src/auth/sessions.test.ts
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm";
 import { describe, expect, test } from "vitest";
 
 import type { SessionPolicy } from "./sessions.js";
+import { sessions } from "../db/schema/sessions.js";
 import { users } from "../db/schema/users.js";
 import { userFactory } from "../test/factories.js";
 import { createTestDb } from "../test/harness.js";
@@ -9,9 +10,42 @@ import {
   createSession,
   DEFAULT_SESSION_POLICY,
   invalidateSession,
+  pruneExpiredSessions,
   validateSession,
 } from "./sessions.js";
 import { hashToken } from "./tokens.js";
+
+describe("pruneExpiredSessions", () => {
+  test("removes only rows whose expiresAt has passed, returning the count", async () => {
+    const db = await createTestDb();
+    const user = await userFactory.transient({ db }).create({ role: "admin" });
+
+    // Two expired rows + one live — seed expiry directly (the point of the test).
+    await db.insert(sessions).values([
+      {
+        id: "expired-1",
+        userId: user.id,
+        expiresAt: new Date(Date.now() - 1000),
+      },
+      {
+        id: "expired-2",
+        userId: user.id,
+        expiresAt: new Date(Date.now() - 60_000),
+      },
+      {
+        id: "live-1",
+        userId: user.id,
+        expiresAt: new Date(Date.now() + 60_000),
+      },
+    ]);
+
+    const deleted = await pruneExpiredSessions(db);
+
+    expect(deleted).toBe(2);
+    const remaining = await db.select({ id: sessions.id }).from(sessions);
+    expect(remaining).toEqual([{ id: "live-1" }]);
+  });
+});
 
 describe("session lifecycle", () => {
   test("round-trips a token while storing only its SHA-256 hash in the DB", async () => {

--- a/packages/core/src/auth/sessions.ts
+++ b/packages/core/src/auth/sessions.ts
@@ -201,7 +201,15 @@ export async function invalidateAllSessionsForUser(
   await db.delete(sessions).where(eq(sessions.userId, userId));
 }
 
-/** Bulk-delete expired rows. Caller decides cadence (cron / on-demand). */
-export async function pruneExpiredSessions(db: Db): Promise<void> {
-  await db.delete(sessions).where(lt(sessions.expiresAt, new Date()));
+/**
+ * Bulk-delete expired rows, returning how many were reaped. Caller decides
+ * cadence (cron / on-demand). `returning()` gives a driver-portable count
+ * (SQLite `DELETE ... RETURNING` on both libsql and D1).
+ */
+export async function pruneExpiredSessions(db: Db): Promise<number> {
+  const deleted = await db
+    .delete(sessions)
+    .where(lt(sessions.expiresAt, new Date()))
+    .returning({ id: sessions.id });
+  return deleted.length;
 }

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -1263,13 +1263,14 @@ export interface RegisteredLoginLink extends LoginLinkOptions {
  * `defer` as a normal request, but `user` is `null` and `request` is
  * an internal marker.
  *
- * v1 dispatch fires every registered task on every scheduled
- * invocation regardless of `cron`. Operators are responsible for
- * configuring `wrangler.toml [triggers] crons` to match the intended
- * cadence; per-task cron filtering is a follow-up.
+ * A task with a `cron` runs only on the invocation whose fired schedule
+ * (`event.cron`) byte-matches it; a task without one runs on every
+ * invocation. The operator must declare a matching `wrangler` `triggers.crons`
+ * entry for a `cron`-tagged task to ever fire — the strings must be identical.
  */
 export interface ScheduledTask {
   readonly id: string;
+  /** Cron expression; must byte-match a `wrangler` `triggers.crons` entry. */
   readonly cron?: string;
   readonly handler: (ctx: AppContext) => void | Promise<void>;
 }

--- a/packages/core/src/runtime/app.ts
+++ b/packages/core/src/runtime/app.ts
@@ -55,6 +55,7 @@ import { isTemplate } from "../template.js";
 import { ThemeRegistrationError } from "../theme-errors.js";
 import { validateDocumentManifest } from "../theme.js";
 import { AppBootError } from "./errors.js";
+import { registerCoreScheduledTasks } from "./register-core-scheduled-tasks.js";
 import { assembleShortcodeRegistry } from "./shortcode-registry.js";
 
 export interface OAuthProviderSummary {
@@ -226,6 +227,7 @@ export async function buildApp(
   registerCoreLookupAdapters(seededRegistry);
   registerCoreTemplateDeps(seededRegistry);
   registerCoreSettings(seededRegistry);
+  registerCoreScheduledTasks(seededRegistry);
   const { registry, appContextExtensions } = await installPlugins({
     hooks,
     plugins: config.plugins,

--- a/packages/core/src/runtime/register-core-scheduled-tasks.test.ts
+++ b/packages/core/src/runtime/register-core-scheduled-tasks.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import type { AppContext } from "../context/app.js";
+import { sessions } from "../db/schema/sessions.js";
+import { createPluginRegistry } from "../plugin/manifest.js";
+import { userFactory } from "../test/factories.js";
+import { createTestDb } from "../test/harness.js";
+import { registerCoreScheduledTasks } from "./register-core-scheduled-tasks.js";
+
+const silentLogger = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+};
+
+describe("registerCoreScheduledTasks", () => {
+  it("registers a daily session-cleanup task that prunes expired sessions", async () => {
+    const registry = createPluginRegistry();
+    registerCoreScheduledTasks(registry);
+
+    const task = registry.scheduledTasks.find(
+      (t) => t.id === "session-cleanup",
+    );
+    expect(task).toBeDefined();
+    expect(task?.cron).toBe("0 3 * * *");
+    expect(task?.registeredBy).toBe("core");
+
+    const db = await createTestDb();
+    const user = await userFactory.transient({ db }).create({ role: "admin" });
+    await db.insert(sessions).values([
+      {
+        id: "expired",
+        userId: user.id,
+        expiresAt: new Date(Date.now() - 1000),
+      },
+      { id: "live", userId: user.id, expiresAt: new Date(Date.now() + 60_000) },
+    ]);
+
+    await task?.handler({ db, logger: silentLogger } as unknown as AppContext);
+
+    const rows = await db.select({ id: sessions.id }).from(sessions);
+    expect(rows).toEqual([{ id: "live" }]);
+  });
+});

--- a/packages/core/src/runtime/register-core-scheduled-tasks.ts
+++ b/packages/core/src/runtime/register-core-scheduled-tasks.ts
@@ -1,0 +1,31 @@
+import type { MutablePluginRegistry } from "../plugin/manifest.js";
+import { pruneExpiredSessions } from "../auth/sessions.js";
+
+// Daily at 03:00 UTC. Only fires if the deploy declares a matching
+// `triggers.crons` entry in wrangler config; otherwise expired sessions
+// stay filtered-at-read and simply accumulate (harmless, just rows).
+const SESSION_CLEANUP_CRON = "0 3 * * *";
+
+/**
+ * Register core's built-in scheduled tasks. Called at app boot before plugins
+ * install, so their tasks join `app.scheduledTasks` alongside plugin ones.
+ */
+export function registerCoreScheduledTasks(
+  registry: MutablePluginRegistry,
+): void {
+  registry.scheduledTasks.push({
+    id: "session-cleanup",
+    cron: SESSION_CLEANUP_CRON,
+    registeredBy: "core",
+    handler: async (ctx) => {
+      const reaped = await pruneExpiredSessions(ctx.db);
+      if (reaped > 0) {
+        ctx.logger.info(
+          `[plumix] session-cleanup reaped ${String(reaped)} expired session${
+            reaped === 1 ? "" : "s"
+          }`,
+        );
+      }
+    },
+  });
+}

--- a/packages/core/src/runtime/scheduled.test.ts
+++ b/packages/core/src/runtime/scheduled.test.ts
@@ -120,4 +120,62 @@ describe("runScheduledTasks", () => {
     expect(ctx.logger.error).toHaveBeenCalledTimes(1);
     expect(String(ctx.logger.error.mock.calls[0]?.[0])).toContain("async-boom");
   });
+
+  test("with a fired cron, runs only matching-cron tasks plus untagged ones", async () => {
+    const calls: string[] = [];
+    const tasks: RegisteredScheduledTask[] = [
+      {
+        id: "daily",
+        registeredBy: "p",
+        cron: "0 3 * * *",
+        handler: () => {
+          calls.push("daily");
+        },
+      },
+      {
+        id: "frequent",
+        registeredBy: "p",
+        cron: "*/5 * * * *",
+        handler: () => {
+          calls.push("frequent");
+        },
+      },
+      {
+        id: "always",
+        registeredBy: "p",
+        handler: () => {
+          calls.push("always");
+        },
+      },
+    ];
+
+    await runScheduledTasks(fakeApp(tasks), fakeCtx(), "0 3 * * *");
+
+    expect(calls).toEqual(["daily", "always"]);
+  });
+
+  test("with no fired cron, runs every task regardless of declared cron", async () => {
+    const calls: string[] = [];
+    const tasks: RegisteredScheduledTask[] = [
+      {
+        id: "daily",
+        registeredBy: "p",
+        cron: "0 3 * * *",
+        handler: () => {
+          calls.push("daily");
+        },
+      },
+      {
+        id: "always",
+        registeredBy: "p",
+        handler: () => {
+          calls.push("always");
+        },
+      },
+    ];
+
+    await runScheduledTasks(fakeApp(tasks), fakeCtx());
+
+    expect(calls).toEqual(["daily", "always"]);
+  });
 });

--- a/packages/core/src/runtime/scheduled.ts
+++ b/packages/core/src/runtime/scheduled.ts
@@ -2,10 +2,14 @@ import type { AppContext } from "../context/app.js";
 import type { PlumixApp } from "./app.js";
 
 /**
- * Run every plugin-registered scheduled task against the given
- * `AppContext`. Each task is wrapped in its own `try/catch` so a
- * single failure can't abort siblings — failures are surfaced
- * through `ctx.logger.error` with `{ taskId, cron }` metadata.
+ * Run the registered scheduled tasks against the given `AppContext`. Each task
+ * is wrapped in its own `try/catch` so a single failure can't abort siblings —
+ * failures are surfaced through `ctx.logger.error` with `{ taskId, cron }`.
+ *
+ * `firedCron` is the schedule that triggered this invocation (Cloudflare's
+ * `event.cron`). A task with a declared `cron` runs only when it matches; a
+ * task with no `cron` runs on every invocation. When `firedCron` is omitted
+ * (tests, runtimes that don't surface it), every task runs.
  *
  * Runtime adapters call this from their `buildScheduledHandler` after
  * constructing a scheduled-flavor `AppContext`.
@@ -13,8 +17,16 @@ import type { PlumixApp } from "./app.js";
 export async function runScheduledTasks(
   app: PlumixApp,
   ctx: AppContext,
+  firedCron?: string,
 ): Promise<void> {
   for (const task of app.scheduledTasks) {
+    if (
+      firedCron !== undefined &&
+      task.cron !== undefined &&
+      task.cron !== firedCron
+    ) {
+      continue;
+    }
     try {
       await task.handler(ctx);
     } catch (error) {

--- a/packages/runtimes/cloudflare/src/adapter.ts
+++ b/packages/runtimes/cloudflare/src/adapter.ts
@@ -295,7 +295,9 @@ function buildScheduled(app: PlumixApp): ScheduledHandler {
     });
 
     try {
-      await requestStore.run(appCtx, () => runScheduledTasks(app, appCtx));
+      await requestStore.run(appCtx, () =>
+        runScheduledTasks(app, appCtx, event.cron),
+      );
       // `commit` finalizes the scoped write (e.g. flushing the D1 batch).
       // Synchronous return — same shape as buildFetch's `finalize`.
       if (scoped) scoped.commit(new Response(null));


### PR DESCRIPTION
First of two cron passes. plumix already had the scheduled-task plumbing (`registerScheduledTask`, `runScheduledTasks`, the worker `scheduled` export, and audit-log's retention-purge as a working precedent) — but `cron` was informational (every task fired on every invocation), no core task used it, and no example declared a cron trigger.

**Per-task cron matching.** `runScheduledTasks(app, ctx, firedCron?)` now skips a `cron`-tagged task unless the fired schedule (`event.cron`) byte-matches it; untagged tasks run every invocation, and an omitted `firedCron` runs all (back-compat for tests / non-CF runtimes). The match is exact-string against the deploy's own `triggers.crons`, so different tasks can ride different schedules.

**Stale-session reaping.** Expired sessions were filtered at read but never deleted, so the table grew unbounded. A core `session-cleanup` task (daily `0 3 * * *`) now reaps them. `pruneExpiredSessions` — previously an unused `void` helper — returns the reaped count via a driver-portable `DELETE ... RETURNING` (the same pattern device-flow and api-tokens already use). It's always registered but inert until the deploy declares a matching trigger, so there's no surprise reaping; `expiresAt < now` only ever deletes already-dead rows.

**Examples wired.** `examples/{blog,minimal}/wrangler.jsonc` declare `triggers.crons: ["0 3 * * *"]` so the task fires on deploy (and the scaffolder templates carry it forward).

Reviewed by senpai + simplifier — no blocking findings; fixed a stale `ScheduledTask` doc comment that still called per-task filtering "a follow-up".

Next pass: future-dated publishing (transition `scheduled` → `published` on cron, firing `entry:published` so the edge cache purges).