### PR TITLE
feat: publish future-dated entries on a cron

### DIFF
--- a/examples/blog/wrangler.jsonc
+++ b/examples/blog/wrangler.jsonc
@@ -24,8 +24,9 @@
     "not_found_handling": "none",
   },
   // Fires plumix's scheduled tasks. `0 3 * * *` matches the core
-  // session-cleanup task (daily reap of expired sessions).
+  // session-cleanup task (daily); `*/5 * * * *` matches publish-scheduled
+  // (publishes due future-dated entries within 5 minutes).
   "triggers": {
-    "crons": ["0 3 * * *"],
+    "crons": ["0 3 * * *", "*/5 * * * *"],
   },
 }

--- a/examples/minimal/wrangler.jsonc
+++ b/examples/minimal/wrangler.jsonc
@@ -18,8 +18,9 @@
     "not_found_handling": "none"
   },
   // Fires plumix's scheduled tasks. `0 3 * * *` matches the core
-  // session-cleanup task (daily reap of expired sessions).
+  // session-cleanup task (daily); `*/5 * * * *` matches publish-scheduled
+  // (publishes due future-dated entries within 5 minutes).
   "triggers": {
-    "crons": ["0 3 * * *"]
+    "crons": ["0 3 * * *", "*/5 * * * *"]
   }
 }

--- a/packages/core/src/rpc/procedures/entry/create.test.ts
+++ b/packages/core/src/rpc/procedures/entry/create.test.ts
@@ -18,6 +18,45 @@ describe("entry.create", () => {
     expect(created.publishedAt).toBeNull();
   });
 
+  test("author can schedule a future publish (status scheduled + publishedAt)", async () => {
+    const h = await createRpcHarness({ authAs: "author" });
+    // Whole-second date — SQLite stores timestamps at second precision.
+    const when = new Date(Math.floor((Date.now() + 3_600_000) / 1000) * 1000);
+    const created = await h.client.entry.create({
+      title: "Later",
+      slug: "later",
+      status: "scheduled",
+      publishedAt: when,
+    });
+    expect(created.status).toBe("scheduled");
+    expect(created.publishedAt).toEqual(when);
+  });
+
+  test("scheduled status without a publishedAt is rejected", async () => {
+    const h = await createRpcHarness({ authAs: "author" });
+    await expect(
+      h.client.entry.create({ title: "x", slug: "x", status: "scheduled" }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      data: { reason: "scheduled_requires_future_date" },
+    });
+  });
+
+  test("scheduled status with a past publishedAt is rejected", async () => {
+    const h = await createRpcHarness({ authAs: "author" });
+    await expect(
+      h.client.entry.create({
+        title: "x",
+        slug: "x",
+        status: "scheduled",
+        publishedAt: new Date(Date.now() - 1000),
+      }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      data: { reason: "scheduled_requires_future_date" },
+    });
+  });
+
   test("INVALID_BLOCK_CONTENT when v2 content carries an unknown block type", async () => {
     const h = await createRpcHarness({ authAs: "contributor" });
     const error = await h.client.entry

--- a/packages/core/src/rpc/procedures/entry/create.ts
+++ b/packages/core/src/rpc/procedures/entry/create.ts
@@ -22,6 +22,7 @@ import {
   validateEntryMetaReferences,
   writeEntryMeta,
 } from "./meta.js";
+import { scheduledDateInvalid } from "./publish-scheduled.js";
 import { entryCreateInputSchema } from "./schemas.js";
 import {
   applyTermPatch,
@@ -57,6 +58,12 @@ export const create = base
       if (!context.auth.can(publishCapability)) {
         throw errors.FORBIDDEN({ data: { capability: publishCapability } });
       }
+    }
+
+    if (scheduledDateInvalid(filtered.status, filtered.publishedAt)) {
+      throw errors.BAD_REQUEST({
+        data: { reason: "scheduled_requires_future_date" },
+      });
     }
 
     if (filtered.parentId != null) {
@@ -114,6 +121,15 @@ export const create = base
       );
     }
 
+    // `published` goes live now; `scheduled` carries its future target time;
+    // anything else has no publish time.
+    let publishedAt: Date | null = null;
+    if (filtered.status === "published") {
+      publishedAt = new Date();
+    } else if (filtered.status === "scheduled") {
+      publishedAt = filtered.publishedAt ?? null;
+    }
+
     const candidate: NewEntry = {
       type: filtered.type,
       title: filtered.title,
@@ -124,7 +140,7 @@ export const create = base
       parentId: filtered.parentId ?? null,
       sortOrder: filtered.sortOrder,
       authorId: context.user.id,
-      publishedAt: filtered.status === "published" ? new Date() : null,
+      publishedAt,
     };
 
     const prepared = await applyEntryBeforeSave(

--- a/packages/core/src/rpc/procedures/entry/publish-scheduled.test.ts
+++ b/packages/core/src/rpc/procedures/entry/publish-scheduled.test.ts
@@ -1,0 +1,76 @@
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+
+import type { AppContext } from "../../../context/app.js";
+import { entries } from "../../../db/schema/entries.js";
+import { HookRegistry } from "../../../hooks/registry.js";
+import { entryFactory, userFactory } from "../../../test/factories.js";
+import { createTestDb } from "../../../test/harness.js";
+import { publishDueScheduledEntries } from "./publish-scheduled.js";
+
+const silentLogger = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+};
+
+async function setup() {
+  const db = await createTestDb();
+  const user = await userFactory.transient({ db }).create({ role: "admin" });
+  const hooks = new HookRegistry();
+  const published: number[] = [];
+  hooks.addAction("entry:published", (entry: { id: number }) => {
+    published.push(entry.id);
+  });
+  const ctx = { db, hooks, logger: silentLogger } as unknown as AppContext;
+  return { db, user, hooks, published, ctx };
+}
+
+async function statusOf(
+  db: Awaited<ReturnType<typeof createTestDb>>,
+  id: number,
+): Promise<string | undefined> {
+  const [row] = await db
+    .select({ status: entries.status })
+    .from(entries)
+    .where(eq(entries.id, id));
+  return row?.status;
+}
+
+describe("publishDueScheduledEntries", () => {
+  it("publishes only scheduled entries whose publishedAt has passed, firing entry:published", async () => {
+    const { db, user, published, ctx } = await setup();
+    const due = await entryFactory.transient({ db }).create({
+      authorId: user.id,
+      status: "scheduled",
+      publishedAt: new Date(Date.now() - 1000),
+    });
+    const notYet = await entryFactory.transient({ db }).create({
+      authorId: user.id,
+      status: "scheduled",
+      publishedAt: new Date(Date.now() + 60_000),
+    });
+
+    const count = await publishDueScheduledEntries(ctx);
+
+    expect(count).toBe(1);
+    expect(await statusOf(db, due.id)).toBe("published");
+    expect(await statusOf(db, notYet.id)).toBe("scheduled");
+    expect(published).toEqual([due.id]);
+  });
+
+  it("does nothing when no scheduled entry is due", async () => {
+    const { db, user, published, ctx } = await setup();
+    await entryFactory.transient({ db }).create({
+      authorId: user.id,
+      status: "scheduled",
+      publishedAt: new Date(Date.now() + 60_000),
+    });
+
+    const count = await publishDueScheduledEntries(ctx);
+
+    expect(count).toBe(0);
+    expect(published).toEqual([]);
+  });
+});

--- a/packages/core/src/rpc/procedures/entry/publish-scheduled.ts
+++ b/packages/core/src/rpc/procedures/entry/publish-scheduled.ts
@@ -1,0 +1,71 @@
+import type { AppContext } from "../../../context/app.js";
+import { and, eq, isNotNull, lte } from "../../../db/index.js";
+import { entries } from "../../../db/schema/entries.js";
+import {
+  fireEntryPublished,
+  fireEntryTransition,
+  fireEntryUpdated,
+} from "./lifecycle.js";
+
+/**
+ * True when a `scheduled` write lacks a valid target time. A scheduled entry
+ * must carry a future `publishedAt` — without one the cron can never pick it
+ * up, so the write is rejected rather than silently stranded.
+ */
+export function scheduledDateInvalid(
+  status: string | undefined,
+  publishedAt: Date | undefined,
+): boolean {
+  return (
+    status === "scheduled" &&
+    (publishedAt === undefined || publishedAt.getTime() <= Date.now())
+  );
+}
+
+/**
+ * Publish every scheduled entry whose target `publishedAt` has arrived,
+ * returning how many were published. Driven by the core `publish-scheduled`
+ * cron task. Each transition flips `status` to `published` (keeping the
+ * scheduled `publishedAt` as the publish time, WordPress-style) and fires the
+ * same lifecycle hooks the editor's publish path does — so cache-purge,
+ * sitemap invalidation, and audit all run.
+ *
+ * Unlike the editor path this skips `entry:before_save` and revision capture:
+ * a cron run has no `ctx.user`, so there's no actor to attribute a revision to
+ * and the content was already snapshotted when it was scheduled.
+ */
+export async function publishDueScheduledEntries(
+  ctx: AppContext,
+): Promise<number> {
+  const now = new Date();
+  const due = await ctx.db
+    .select()
+    .from(entries)
+    .where(
+      and(
+        eq(entries.status, "scheduled"),
+        isNotNull(entries.publishedAt),
+        lte(entries.publishedAt, now),
+      ),
+    );
+
+  let published = 0;
+  for (const entry of due) {
+    // Re-assert `status='scheduled'` in the write so a manual publish that
+    // raced this run flips the row once and fires hooks once.
+    const flipped = await ctx.db
+      .update(entries)
+      .set({ status: "published" })
+      .where(and(eq(entries.id, entry.id), eq(entries.status, "scheduled")))
+      .returning({ id: entries.id });
+    if (flipped.length === 0) continue;
+
+    published += 1;
+    const updated = { ...entry, status: "published" as const };
+    await fireEntryUpdated(ctx, updated, entry);
+    await fireEntryTransition(ctx, updated, entry.status);
+    await fireEntryPublished(ctx, updated);
+  }
+
+  return published;
+}

--- a/packages/core/src/rpc/procedures/entry/schemas.ts
+++ b/packages/core/src/rpc/procedures/entry/schemas.ts
@@ -81,6 +81,8 @@ export const entryCreateInputSchema = v.object({
   sortOrder: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0)), 0),
   terms: v.optional(postTermsSchema),
   meta: v.optional(entryMetaInputSchema),
+  /** Target publish time; required (and must be future) when `status: "scheduled"`. */
+  publishedAt: v.optional(v.date()),
 });
 
 export const entryUpdateInputSchema = v.object({
@@ -94,6 +96,8 @@ export const entryUpdateInputSchema = v.object({
   sortOrder: v.optional(v.pipe(v.number(), v.integer(), v.minValue(0))),
   terms: v.optional(postTermsSchema),
   meta: v.optional(entryMetaInputSchema),
+  /** Target publish time; required (and must be future) when `status: "scheduled"`. */
+  publishedAt: v.optional(v.date()),
   /**
    * Optimistic-concurrency token: the live entry's `updatedAt` at the
    * moment the caller loaded it. When provided, the server rejects

--- a/packages/core/src/rpc/procedures/entry/update.test.ts
+++ b/packages/core/src/rpc/procedures/entry/update.test.ts
@@ -108,6 +108,79 @@ describe("entry.update", () => {
     onTransition.assertCalledOnce();
   });
 
+  test("scheduling a draft stores the future publishedAt and keeps status scheduled", async () => {
+    const h = await createRpcHarness({ authAs: "author" });
+    const own = await h.factory.draft.create({
+      authorId: h.user.id,
+      slug: "to-schedule",
+    });
+    const when = new Date(Math.floor((Date.now() + 3_600_000) / 1000) * 1000);
+
+    const updated = await h.client.entry.update({
+      id: own.id,
+      status: "scheduled",
+      publishedAt: when,
+    });
+
+    expect(updated.status).toBe("scheduled");
+    expect(updated.publishedAt).toEqual(when);
+  });
+
+  test("scheduling a draft without a publishedAt is rejected", async () => {
+    const h = await createRpcHarness({ authAs: "author" });
+    const own = await h.factory.draft.create({
+      authorId: h.user.id,
+      slug: "no-date",
+    });
+
+    await expect(
+      h.client.entry.update({ id: own.id, status: "scheduled" }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      data: { reason: "scheduled_requires_future_date" },
+    });
+  });
+
+  test("editing a past-due scheduled entry (awaiting the cron) is not rejected", async () => {
+    const h = await createRpcHarness({ authAs: "author" });
+    // Seed directly: a row scheduled for a moment that's already passed,
+    // still `scheduled` because the cron hasn't fired yet.
+    const due = await h.factory.entry.create({
+      authorId: h.user.id,
+      slug: "due",
+      status: "scheduled",
+      publishedAt: new Date(Date.now() - 1000),
+    });
+
+    const updated = await h.client.entry.update({
+      id: due.id,
+      title: "fixed a typo",
+    });
+
+    expect(updated.title).toBe("fixed a typo");
+    expect(updated.status).toBe("scheduled");
+  });
+
+  test("manually publishing a future-scheduled entry resets publishedAt to now", async () => {
+    const h = await createRpcHarness({ authAs: "author" });
+    const tomorrow = new Date(Date.now() + 86_400_000);
+    const scheduled = await h.factory.entry.create({
+      authorId: h.user.id,
+      slug: "early",
+      status: "scheduled",
+      publishedAt: tomorrow,
+    });
+
+    const updated = await h.client.entry.update({
+      id: scheduled.id,
+      status: "published",
+    });
+
+    expect(updated.status).toBe("published");
+    // Stamped ~now, not the original future date.
+    expect(updated.publishedAt?.getTime()).toBeLessThan(tomorrow.getTime());
+  });
+
   test("contributor cannot promote their own draft to published", async () => {
     const h = await createRpcHarness({ authAs: "contributor" });
     const own = await h.factory.draft.create({

--- a/packages/core/src/rpc/procedures/entry/update.ts
+++ b/packages/core/src/rpc/procedures/entry/update.ts
@@ -32,6 +32,7 @@ import {
   validateEntryMetaReferences,
   writeEntryMeta,
 } from "./meta.js";
+import { scheduledDateInvalid } from "./publish-scheduled.js";
 import { entryUpdateInputSchema } from "./schemas.js";
 import {
   applyTermPatch,
@@ -269,6 +270,7 @@ export const update = base
       meta: metaInput,
       expectedLiveUpdatedAt: _expectedLiveUpdatedAt,
       saveAs: _saveAs,
+      publishedAt: publishedAtInput,
       ...changes
     } = filtered;
     const metaPatch = sanitizeMetaForRpc(
@@ -301,8 +303,34 @@ export const update = base
     }
 
     const patch: Partial<NewEntry> = stripUndefined(changes);
-    if (isPublishTransition && !existing.publishedAt) {
+    // On a publish transition, stamp `now` when there's no publish time yet —
+    // or when promoting a scheduled entry early (its `publishedAt` is still in
+    // the future); otherwise a future date would sort it to the top of feeds.
+    if (
+      isPublishTransition &&
+      (!existing.publishedAt || existing.publishedAt.getTime() > Date.now())
+    ) {
       patch.publishedAt = new Date();
+    }
+
+    // Scheduling: validate the target time only when actually (re)scheduling —
+    // moving status to `scheduled` or supplying a new date. An incidental edit
+    // to an already-scheduled entry (e.g. fixing a typo while it waits for the
+    // cron, its date now in the past) must not be rejected. The supplied date
+    // is written only while scheduling, so it can't backdate a published entry.
+    if (
+      (filtered.status === "scheduled" || publishedAtInput !== undefined) &&
+      (filtered.status ?? existing.status) === "scheduled"
+    ) {
+      const effective = publishedAtInput ?? existing.publishedAt ?? undefined;
+      if (scheduledDateInvalid("scheduled", effective)) {
+        throw errors.BAD_REQUEST({
+          data: { reason: "scheduled_requires_future_date" },
+        });
+      }
+      if (publishedAtInput !== undefined) {
+        patch.publishedAt = publishedAtInput;
+      }
     }
 
     // Nothing to write anywhere? Short-circuit without firing hooks, but

--- a/packages/core/src/runtime/register-core-scheduled-tasks.test.ts
+++ b/packages/core/src/runtime/register-core-scheduled-tasks.test.ts
@@ -42,4 +42,16 @@ describe("registerCoreScheduledTasks", () => {
     const rows = await db.select({ id: sessions.id }).from(sessions);
     expect(rows).toEqual([{ id: "live" }]);
   });
+
+  it("registers a publish-scheduled task on a 5-minute cron", () => {
+    const registry = createPluginRegistry();
+    registerCoreScheduledTasks(registry);
+
+    const task = registry.scheduledTasks.find(
+      (t) => t.id === "publish-scheduled",
+    );
+    expect(task).toBeDefined();
+    expect(task?.cron).toBe("*/5 * * * *");
+    expect(task?.registeredBy).toBe("core");
+  });
 });

--- a/packages/core/src/runtime/register-core-scheduled-tasks.ts
+++ b/packages/core/src/runtime/register-core-scheduled-tasks.ts
@@ -1,10 +1,15 @@
 import type { MutablePluginRegistry } from "../plugin/manifest.js";
 import { pruneExpiredSessions } from "../auth/sessions.js";
+import { publishDueScheduledEntries } from "../rpc/procedures/entry/publish-scheduled.js";
 
 // Daily at 03:00 UTC. Only fires if the deploy declares a matching
 // `triggers.crons` entry in wrangler config; otherwise expired sessions
 // stay filtered-at-read and simply accumulate (harmless, just rows).
 const SESSION_CLEANUP_CRON = "0 3 * * *";
+
+// Every 5 minutes — the worst-case lag between an entry's scheduled time and
+// its actual publish. Needs a matching `triggers.crons` entry to fire.
+const PUBLISH_SCHEDULED_CRON = "*/5 * * * *";
 
 /**
  * Register core's built-in scheduled tasks. Called at app boot before plugins
@@ -23,6 +28,22 @@ export function registerCoreScheduledTasks(
         ctx.logger.info(
           `[plumix] session-cleanup reaped ${String(reaped)} expired session${
             reaped === 1 ? "" : "s"
+          }`,
+        );
+      }
+    },
+  });
+
+  registry.scheduledTasks.push({
+    id: "publish-scheduled",
+    cron: PUBLISH_SCHEDULED_CRON,
+    registeredBy: "core",
+    handler: async (ctx) => {
+      const published = await publishDueScheduledEntries(ctx);
+      if (published > 0) {
+        ctx.logger.info(
+          `[plumix] publish-scheduled published ${String(published)} entr${
+            published === 1 ? "y" : "ies"
           }`,
         );
       }

--- a/packages/core/src/runtime/scheduled.ts
+++ b/packages/core/src/runtime/scheduled.ts
@@ -1,5 +1,6 @@
 import type { AppContext } from "../context/app.js";
 import type { PlumixApp } from "./app.js";
+import { flushPurgeTags } from "../cache/purge.js";
 
 /**
  * Run the registered scheduled tasks against the given `AppContext`. Each task
@@ -38,4 +39,7 @@ export async function runScheduledTasks(
       );
     }
   }
+  // A scheduled publish fires `entry:published`; flush the batched edge-cache
+  // purge it accumulated, the same request-end seam the dispatcher uses.
+  flushPurgeTags(ctx);
 }

--- a/packages/runtimes/cloudflare/src/adapter.ts
+++ b/packages/runtimes/cloudflare/src/adapter.ts
@@ -268,6 +268,10 @@ function buildScheduled(app: PlumixApp): ScheduledHandler {
       : database.connect(env, syntheticRequest, app.schema).db;
 
     const storage = app.config.storage?.connect(env);
+    // Scheduled publishes fire `entry:published`, which accumulates edge-cache
+    // purge tags; wire the cache so the flush at the end of `runScheduledTasks`
+    // can reach it.
+    const cache = app.config.cache?.connect(env) ?? undefined;
 
     const appCtx = createAppContext({
       db: db as Db,
@@ -281,6 +285,7 @@ function buildScheduled(app: PlumixApp): ScheduledHandler {
       defer,
       assets: readAssetsBinding(env),
       storage,
+      cache,
       imageDelivery: app.config.imageDelivery,
       imageRemotePatterns: app.config.images?.remotePatterns,
       mailer: app.config.mailer,


### PR DESCRIPTION
Second of two cron passes (per-task cron matching + session-cleanup landed in #1088). Scheduled entries now publish themselves.

**WordPress model, no schema change.** A `scheduled` entry stores its target time in the existing `entries.publishedAt`; a core `publish-scheduled` task on a 5-minute cron flips entries whose time has arrived to `published`. The transition fires the real lifecycle hooks (`entry:updated` / `entry:transition` / `entry:published`) — not a raw `UPDATE` — so edge-cache purge, sitemap invalidation, and audit logging all run exactly as they do for an editor publish.

**Scheduling via the RPC.** `entry.create` / `entry.update` accept a `publishedAt` and reject `status: "scheduled"` without a future one (so a scheduled entry can never be stranded with no time). The supplied date is honored *only* while scheduling, so it can't backdate or postdate a `published` entry. Promoting a scheduled entry early resets its still-future `publishedAt` to now (otherwise it would sort to the top of feeds).

**Cron is idempotent + cache-aware.** The flip re-asserts `status='scheduled'` in the `UPDATE` and fires hooks only for the row it actually flipped, so a manual publish racing the cron can't double-fire. The cloudflare scheduled context now wires the edge cache, and `runScheduledTasks` flushes the batched purge a scheduled publish accumulates. The example wrangler configs add the `*/5 * * * *` trigger.

Reviewed by senpai + simplifier. senpai caught three real issues, all fixed with tests: editing a past-due-but-not-yet-published scheduled entry was wrongly rejected; manually publishing a future-scheduled entry kept the future date; and the cron `UPDATE` lacked a race guard. Cron publishes deliberately skip revision capture (no actor — a cron run has no `ctx.user`).

This is the future-publishing follow-up the edge-cache PRD flagged (the scheduled path now wires the cache it noted was missing).