### PR TITLE
fix: rich-text stored XSS, publish-transition, and meta-walker (audit findings)

### DIFF
--- a/packages/blocks/src/rich-text/index.test.tsx
+++ b/packages/blocks/src/rich-text/index.test.tsx
@@ -21,6 +21,22 @@ describe("core/rich-text walker render", () => {
     );
   });
 
+  test("strips a <script> from a string body so stored markup can't XSS", () => {
+    const registry = createBlockRegistry([richTextBlock]);
+    const tree: readonly BlockNode[] = [
+      {
+        id: "r1",
+        name: "core/rich-text",
+        attrs: { body: "<p>hi</p><script>alert(1)</script>" },
+      },
+    ];
+
+    const html = renderToStaticMarkup(renderBlockTree(tree, registry));
+
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("<p>hi</p>");
+  });
+
   test("returns the admin's React-element body verbatim so Tiptap mounts inline", () => {
     // The admin Puck preview wraps `attrs.body` as a <RichTextRender>
     // element before calling the block render. Wrapping that element in

--- a/packages/blocks/src/rich-text/index.tsx
+++ b/packages/blocks/src/rich-text/index.tsx
@@ -1,8 +1,38 @@
 import type { ReactNode } from "react";
 import { isValidElement } from "react";
 
+import type { BlockNodeRenderProps } from "../render-block-tree.js";
 import { defineBlock } from "../block-registry.js";
+import { useHtmlAllowlist } from "../html/context.js";
+import { sanitizeHtml } from "../html/sanitize.js";
 import { expandShortcodes } from "../shortcodes/expand.js";
+
+// The trust boundary is the stored bytes: a string body is authored HTML and
+// is sanitised at render like `core/html`, which also covers content stored
+// before this gate. A React-element body is the editor's own live buffer
+// (admin Puck preview), so it surfaces verbatim.
+function RichTextBlockRender({
+  attrs,
+  context,
+}: BlockNodeRenderProps): ReactNode {
+  const allowlist = useHtmlAllowlist();
+  if (isValidElement(attrs.body)) return attrs.body;
+  if (typeof attrs.body !== "string") return <div />;
+  // Shortcode output is escaped, so a single sanitise over the expansion
+  // covers both the body and the expanded result.
+  const expanded = context.shortcodes
+    ? expandShortcodes(attrs.body, context.shortcodes, {
+        siteSettings: context.siteSettings,
+        locale: context.locale,
+        entry: context.entry,
+      })
+    : attrs.body;
+  return (
+    <div
+      dangerouslySetInnerHTML={{ __html: sanitizeHtml(expanded, allowlist) }}
+    />
+  );
+}
 
 export const richTextBlock = defineBlock({
   name: "core/rich-text",
@@ -16,26 +46,5 @@ export const richTextBlock = defineBlock({
   keywords: ["paragraph", "text", "body"],
   inputs: [{ name: "body", type: "richtext", label: "Body" }],
   defaults: { body: "<p></p>" },
-  // Mirrors `paragraph/index.tsx` — admin Puck preview hands `attrs.body`
-  // wrapped as a <RichTextRender> React element, SSR / walker callers see
-  // the raw HTML string. TODO(#XXX): sanitize the HTML at the
-  // entry.update ingest — the trust boundary is the stored bytes, not
-  // the editor.
-  render: ({ attrs, context }): ReactNode => {
-    if (isValidElement(attrs.body)) return attrs.body;
-    if (typeof attrs.body === "string") {
-      // Expand `[year]`-style macros over the already-sanitized HTML string
-      // before output. Only registered tags expand; shortcode output is
-      // escaped, so no new sanitiser surface is introduced.
-      const body = context.shortcodes
-        ? expandShortcodes(attrs.body, context.shortcodes, {
-            siteSettings: context.siteSettings,
-            locale: context.locale,
-            entry: context.entry,
-          })
-        : attrs.body;
-      return <div dangerouslySetInnerHTML={{ __html: body }} />;
-    }
-    return <div />;
-  },
+  render: RichTextBlockRender,
 });

--- a/packages/core/src/revisions/restore.test.ts
+++ b/packages/core/src/revisions/restore.test.ts
@@ -54,6 +54,38 @@ describe("entry.revisions.restore", () => {
     expect(live?.title).toBe("Second");
   });
 
+  test("restoring a published revision onto a future-scheduled entry resets publishedAt to now", async () => {
+    const h = await createRpcHarness({
+      authAs: "editor",
+      plugins: registryWithRevisions(),
+    });
+    const created = await h.client.entry.create({
+      title: "Post",
+      slug: "post",
+    });
+    // Publish → captures a `published` revision.
+    await h.client.entry.update({ id: created.id, status: "published" });
+    const [revision] = await h.db.query.entries.findMany({
+      where: eq(entries.type, REVISION_TYPE),
+    });
+    if (!revision) throw new Error("expected a captured revision");
+    // Reschedule into the future, then restore the published revision.
+    const future = new Date(Date.now() + 86_400_000);
+    await h.client.entry.update({
+      id: created.id,
+      status: "scheduled",
+      publishedAt: future,
+    });
+
+    const restored = await h.client.entry.revisions.restore({
+      revisionId: revision.id,
+    });
+
+    expect(restored.status).toBe("published");
+    // Not the leftover future date — that would sort it to the top of feeds.
+    expect(restored.publishedAt?.getTime()).toBeLessThan(future.getTime());
+  });
+
   test("does NOT snapshot the post-restore state — restore is invisible to history", async () => {
     const { h, entryId, revisionId } = await seedEntryWithRevision();
     await h.client.entry.update({ id: entryId, title: "Third" });

--- a/packages/core/src/rpc/meta/core.ts
+++ b/packages/core/src/rpc/meta/core.ts
@@ -625,6 +625,54 @@ export async function validateMetaReferencesForRpc(
  * `termTaxonomies`, `roles`, …) so out-of-scope ids fall out of the
  * result naturally and read as orphans.
  */
+interface ReferenceOccurrence {
+  /** Top-level meta key — the storage location and error key. */
+  readonly key: string;
+  readonly target: ReferenceTarget;
+  readonly value: unknown;
+  /** Set when the reference is a subField inside a repeater row. */
+  readonly nested?: {
+    readonly rowIdx: number;
+    readonly subKey: string;
+  };
+}
+
+/**
+ * Yield every reference-field occurrence in a decoded meta bag: top-level
+ * reference fields, plus reference subFields inside each repeater row. One
+ * structural walk so the orphan-strip pass doesn't reinline the
+ * top-level/repeater traversal twice.
+ */
+function* referenceOccurrences(
+  entries: Iterable<readonly [string, unknown]>,
+  findField: (key: string) => MetaBoxField | undefined,
+): Generator<ReferenceOccurrence> {
+  for (const [key, value] of entries) {
+    const field = findField(key);
+    const target = referenceTargetOf(field);
+    if (target) {
+      yield { key, target, value };
+      continue;
+    }
+    if (!isRepeaterField(field)) continue;
+    if (!Array.isArray(value)) continue;
+    for (const [rowIdx, row] of value.entries()) {
+      if (!row || typeof row !== "object" || Array.isArray(row)) continue;
+      const rowObj = row as Record<string, unknown>;
+      for (const subField of field.subFields) {
+        const subTarget = referenceTargetOf(subField);
+        if (!subTarget) continue;
+        yield {
+          key,
+          target: subTarget,
+          value: rowObj[subField.key],
+          nested: { rowIdx, subKey: subField.key },
+        };
+      }
+    }
+  }
+}
+
 export async function filterMetaOrphans(
   ctx: AppContext,
   findField: (key: string) => MetaBoxField | undefined,
@@ -655,66 +703,31 @@ export async function filterMetaOrphans(
       readonly ids: Set<string>;
     }
   >();
-  for (const [key, value] of Object.entries(decoded)) {
-    const field = findField(key);
-    const target = referenceTargetOf(field);
-    if (target) {
-      const registered = ctx.plugins.lookupAdapters.get(target.kind);
-      if (!registered) continue;
-      const ids = orphanCandidateIds(target, value);
-      if (ids === null) continue; // non-array multi / non-string single — leave untouched
-      const groupKey = referenceGroupKey(target);
-      candidates.push({
-        key,
-        multiple: target.multiple === true,
-        valueShape: target.valueShape ?? "id",
-        groupKey,
-        ids,
-      });
-      if (ids.length === 0) continue;
-      let group = groups.get(groupKey);
-      if (!group) {
-        group = { registered, scope: target.scope, ids: new Set() };
-        groups.set(groupKey, group);
-      }
-      for (const id of ids) group.ids.add(id);
-      continue;
+  // Top-level refs and repeater-row subField refs get identical orphan-strip
+  // treatment, so the single `referenceOccurrences` walk feeds both. Nested
+  // candidates carry their `rowIdx`/`subKey`; Pass 3 rewrites the row slot in
+  // a per-key clone so the caller's `decoded` bag stays untouched.
+  for (const occ of referenceOccurrences(Object.entries(decoded), findField)) {
+    const registered = ctx.plugins.lookupAdapters.get(occ.target.kind);
+    if (!registered) continue;
+    const ids = orphanCandidateIds(occ.target, occ.value);
+    if (ids === null) continue; // non-array multi / non-string single — leave untouched
+    const groupKey = referenceGroupKey(occ.target);
+    candidates.push({
+      key: occ.key,
+      multiple: occ.target.multiple === true,
+      valueShape: occ.target.valueShape ?? "id",
+      groupKey,
+      ids,
+      nested: occ.nested,
+    });
+    if (ids.length === 0) continue;
+    let group = groups.get(groupKey);
+    if (!group) {
+      group = { registered, scope: occ.target.scope, ids: new Set() };
+      groups.set(groupKey, group);
     }
-    if (!isRepeaterField(field)) continue;
-    if (!Array.isArray(value)) continue;
-    // Repeater rows: each row's reference subField gets the same
-    // orphan-strip treatment top-level refs receive — caller passes
-    // `decoded` as a freshly-decoded bag, so we mutate the row
-    // objects in place inside the eventual shallow-copy below.
-    for (const [rowIdx, row] of value.entries()) {
-      if (!row || typeof row !== "object" || Array.isArray(row)) continue;
-      const rowObj = row as Record<string, unknown>;
-      for (const subField of field.subFields) {
-        const subTarget = referenceTargetOf(subField);
-        if (!subTarget) continue;
-        const registered = ctx.plugins.lookupAdapters.get(subTarget.kind);
-        if (!registered) continue;
-        const subValue = rowObj[subField.key];
-        const ids = orphanCandidateIds(subTarget, subValue);
-        if (ids === null) continue;
-        const groupKey = referenceGroupKey(subTarget);
-        candidates.push({
-          key,
-          multiple: subTarget.multiple === true,
-          valueShape: subTarget.valueShape ?? "id",
-          groupKey,
-          ids,
-          nested: { rowIdx, subKey: subField.key },
-        });
-        if (ids.length === 0) continue;
-        let group = groups.get(groupKey);
-        if (!group) {
-          group = { registered, scope: subTarget.scope, ids: new Set() };
-          groups.set(groupKey, group);
-        }
-        for (const id of ids) group.ids.add(id);
-      }
-    }
+    for (const id of ids) group.ids.add(id);
   }
 
   // Pass 2: one `list({ ids })` per group, keyed for O(1) apply lookup.

--- a/packages/core/src/rpc/procedures/entry/lifecycle.ts
+++ b/packages/core/src/rpc/procedures/entry/lifecycle.ts
@@ -50,6 +50,20 @@ export async function fireEntryPublished(
   await ctx.hooks.doAction("entry:published", entry);
 }
 
+/**
+ * The `publishedAt` to stamp when an entry transitions to `published`, or
+ * `undefined` to leave the existing one. Stamps `now` when there's no publish
+ * time yet, or when promoting a scheduled entry whose time is still in the
+ * future (a future date would sort it to the top of feeds). Shared by the
+ * editor update and revision-restore publish paths so they can't diverge.
+ */
+export function publishedAtForTransition(
+  existing: Date | null,
+): Date | undefined {
+  if (existing === null || existing.getTime() > Date.now()) return new Date();
+  return undefined;
+}
+
 export async function fireEntryUpdated(
   ctx: AppContext,
   entry: Entry,

--- a/packages/core/src/rpc/procedures/entry/revisions.ts
+++ b/packages/core/src/rpc/procedures/entry/revisions.ts
@@ -37,6 +37,7 @@ import {
   fireEntryRevisionRestored,
   fireEntryTransition,
   fireEntryUpdated,
+  publishedAtForTransition,
 } from "./lifecycle.js";
 
 const listInput = v.object({
@@ -262,8 +263,9 @@ export const restore = base
       parentId: decodedEnvelope?.parentId ?? live.parentId,
       meta: snapshotMeta,
     };
-    if (isPublishTransition && !live.publishedAt) {
-      patch.publishedAt = new Date();
+    if (isPublishTransition) {
+      const stamped = publishedAtForTransition(live.publishedAt);
+      if (stamped) patch.publishedAt = stamped;
     }
 
     const prepared = await applyEntryBeforeSave(context, live.type, {

--- a/packages/core/src/rpc/procedures/entry/update.ts
+++ b/packages/core/src/rpc/procedures/entry/update.ts
@@ -22,6 +22,7 @@ import {
   fireEntryTransition,
   fireEntryUpdated,
   loadReadableParent,
+  publishedAtForTransition,
   wouldCreateParentCycle,
 } from "./lifecycle.js";
 import {
@@ -303,14 +304,9 @@ export const update = base
     }
 
     const patch: Partial<NewEntry> = stripUndefined(changes);
-    // On a publish transition, stamp `now` when there's no publish time yet —
-    // or when promoting a scheduled entry early (its `publishedAt` is still in
-    // the future); otherwise a future date would sort it to the top of feeds.
-    if (
-      isPublishTransition &&
-      (!existing.publishedAt || existing.publishedAt.getTime() > Date.now())
-    ) {
-      patch.publishedAt = new Date();
+    if (isPublishTransition) {
+      const stamped = publishedAtForTransition(existing.publishedAt);
+      if (stamped) patch.publishedAt = stamped;
     }
 
     // Scheduling: validate the target time only when actually (re)scheduling —


### PR DESCRIPTION
Three changes, all surfaced by a `fallow` audit of the branch.

**Stored XSS in `core/rich-text` (security — `fallow security`).** The rich-text block rendered authored HTML through `dangerouslySetInnerHTML` with no sanitization — a standing `TODO`. Any user with entry-edit rights could store `<script>` that executed for public visitors and for an admin previewing the draft. It now sanitizes at render via the HTML allowlist, mirroring `core/html`. Render-time (rather than the TODO's "sanitize at ingest") also defends content stored before the gate existed. Verified non-bypassable in review: shortcode output is escaped so sanitize-after-expand is sound, the unsanitized element branch only handles the live editor buffer (never stored bytes, which are always a string), and the block render is rich-text's only output path.

**Publish-transition `publishedAt` (correctness).** The editor update path resets a future `publishedAt` to now when promoting a scheduled entry (so it doesn't sort to the top of feeds), but the revision-restore path kept the old `!publishedAt` guard and would leave the future date. Extracted `publishedAtForTransition` and applied it to both publish paths so they can't diverge. (Divergence introduced in #1089.)

**`filterMetaOrphans` complexity (refactor).** Extracted a `referenceOccurrences` generator so the orphan-strip pass stops reinlining and duplicating the top-level + repeater-row traversal. Behavior-preserving (full meta/entry/repeater suites green); cognitive complexity 74 → 29 — the audit's worst hotspot. `validateMetaReferences` left untouched.

Reviewed by senpai (including a security pass on the XSS fix — no bypass found) and the code-simplifier.