### PR TITLE
feat: constrain slot block children via allowedBlocks

### DIFF
--- a/packages/admin/src/editor/field-type-translator.tsx
+++ b/packages/admin/src/editor/field-type-translator.tsx
@@ -76,7 +76,14 @@ export function translateField(
       };
     }
     case "slot":
-      return { type: "slot", label };
+      // `allowedBlocks` (when set) restricts which blocks the editor lets
+      // authors drop into this slot — Puck's component keys are the plumix
+      // block names, so the whitelist passes straight through.
+      return {
+        type: "slot",
+        label,
+        ...(input.allowedBlocks ? { allow: [...input.allowedBlocks] } : {}),
+      };
     case "richtext":
       return {
         type: "richtext",

--- a/packages/blocks/src/block-registry.ts
+++ b/packages/blocks/src/block-registry.ts
@@ -14,6 +14,13 @@ export interface BlockInput {
   readonly type: string;
   readonly label?: Label;
   readonly options?: readonly BlockInputOption[];
+  /**
+   * Slot inputs only: the block names this slot accepts as children.
+   * Omitted = any block (general content slots). Enforced at write-time
+   * validation and surfaced to the editor so the slot only takes valid
+   * children. Mirrors Gutenberg's `allowedBlocks`.
+   */
+  readonly allowedBlocks?: readonly string[];
 }
 
 export type BlockVariationScope = "inserter" | "block" | "transform";

--- a/packages/blocks/src/buttons/index.tsx
+++ b/packages/blocks/src/buttons/index.tsx
@@ -32,7 +32,12 @@ export const buttonsBlock = defineBlock({
       options: ALIGNS.map((a) => ({ label: a, value: a })),
     },
     { name: "gap", type: "text", label: "Gap" },
-    { name: "items", type: "slot", label: "Buttons" },
+    {
+      name: "items",
+      type: "slot",
+      label: "Buttons",
+      allowedBlocks: ["core/button"],
+    },
   ],
   defaults: { align: "start" },
   render: ({ attrs }): ReactNode => {

--- a/packages/blocks/src/table/index.tsx
+++ b/packages/blocks/src/table/index.tsx
@@ -19,7 +19,12 @@ export const tableBlock = defineBlock({
   inputs: [
     { name: "striped", type: "checkbox", label: "Striped" },
     { name: "bordered", type: "checkbox", label: "Bordered" },
-    { name: "rows", type: "slot", label: "Rows" },
+    {
+      name: "rows",
+      type: "slot",
+      label: "Rows",
+      allowedBlocks: ["core/table-header-row", "core/table-body-row"],
+    },
   ],
   defaults: {},
   render: ({ attrs }): ReactNode => {
@@ -41,7 +46,14 @@ export const tableHeaderRowBlock = defineBlock({
   category: "text",
   inline: true,
   inserter: false,
-  inputs: [{ name: "cells", type: "slot", label: "Cells" }],
+  inputs: [
+    {
+      name: "cells",
+      type: "slot",
+      label: "Cells",
+      allowedBlocks: ["core/table-header-cell"],
+    },
+  ],
   defaults: {},
   render: ({ attrs }): ReactNode => {
     const Cells = attrs.cells as (() => ReactNode) | undefined;
@@ -56,7 +68,14 @@ export const tableBodyRowBlock = defineBlock({
   category: "text",
   inline: true,
   inserter: false,
-  inputs: [{ name: "cells", type: "slot", label: "Cells" }],
+  inputs: [
+    {
+      name: "cells",
+      type: "slot",
+      label: "Cells",
+      allowedBlocks: ["core/table-cell"],
+    },
+  ],
   defaults: {},
   render: ({ attrs }): ReactNode => {
     const Cells = attrs.cells as (() => ReactNode) | undefined;

--- a/packages/blocks/src/validate-content.test.ts
+++ b/packages/blocks/src/validate-content.test.ts
@@ -1,12 +1,40 @@
 import { describe, expect, test } from "vitest";
 
+import type { BlockSpec } from "./block-registry.js";
+import { createBlockRegistry } from "./block-registry.js";
+import { headingBlock } from "./heading/index.js";
+import {
+  tableBlock,
+  tableBodyRowBlock,
+  tableCellBlock,
+  tableHeaderCellBlock,
+  tableHeaderRowBlock,
+} from "./table/index.js";
 import { validateEntryContent } from "./validate-content.js";
 
+const leaf = (name: string): BlockSpec => ({ name, render: () => null });
 const registry = {
-  has(name: string): boolean {
-    return name === "core/heading" || name === "core/group";
+  get(name: string): BlockSpec | undefined {
+    if (name === "core/heading") return leaf(name);
+    // A content slot with no `allowedBlocks` — unconstrained.
+    if (name === "core/group")
+      return {
+        name,
+        render: () => null,
+        inputs: [{ name: "content", type: "slot" }],
+      };
+    return undefined;
   },
 };
+
+const tableRegistry = createBlockRegistry([
+  tableBlock,
+  tableHeaderRowBlock,
+  tableBodyRowBlock,
+  tableHeaderCellBlock,
+  tableCellBlock,
+  headingBlock,
+]);
 
 describe("validateEntryContent", () => {
   test("accepts a valid leaf-block envelope", () => {
@@ -99,6 +127,73 @@ describe("validateEntryContent", () => {
         ],
       },
       registry,
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("rejects a child a slot's allowedBlocks doesn't permit", () => {
+    const result = validateEntryContent(
+      {
+        version: "plumix.v2",
+        blocks: [
+          {
+            id: "t1",
+            name: "core/table",
+            attrs: {
+              rows: [
+                {
+                  id: "h1",
+                  name: "core/heading",
+                  attrs: { level: 2, text: "nope" },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      tableRegistry,
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({
+        code: "disallowed_child",
+        nodeName: "core/heading",
+        slotName: "rows",
+        path: "blocks[0].rows[0]",
+      }),
+    );
+  });
+
+  test("accepts a valid table tree", () => {
+    const result = validateEntryContent(
+      {
+        version: "plumix.v2",
+        blocks: [
+          {
+            id: "t1",
+            name: "core/table",
+            attrs: {
+              rows: [
+                {
+                  id: "r1",
+                  name: "core/table-body-row",
+                  attrs: {
+                    cells: [
+                      {
+                        id: "c1",
+                        name: "core/table-cell",
+                        attrs: { text: "x" },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      tableRegistry,
     );
     expect(result).toEqual({ ok: true });
   });

--- a/packages/blocks/src/validate-content.ts
+++ b/packages/blocks/src/validate-content.ts
@@ -1,3 +1,4 @@
+import type { BlockSpec } from "./block-registry.js";
 import type { EntryContent } from "./entry-content.js";
 import type { BlockNode } from "./render-block-tree.js";
 import type { BlockContentValidationIssue } from "./validation-errors.js";
@@ -10,11 +11,15 @@ export type BlockContentValidationResult =
       readonly errors: readonly BlockContentValidationIssue[];
     };
 
+interface SpecLookup {
+  get(name: string): BlockSpec | undefined;
+}
+
 // Issues use the path grammar `blocks[i]` at the root and
 // `blocks[i].<slotKey>[j]` for nested slot children.
 export function validateEntryContent(
   content: EntryContent,
-  registry: { has(name: string): boolean },
+  registry: SpecLookup,
 ): BlockContentValidationResult {
   const errors: BlockContentValidationIssue[] = [];
   walk(content.blocks, "blocks", errors, registry);
@@ -26,11 +31,12 @@ function walk(
   nodes: readonly BlockNode[],
   basePath: string,
   out: BlockContentValidationIssue[],
-  registry: { has(name: string): boolean },
+  registry: SpecLookup,
 ): void {
   nodes.forEach((node, i) => {
     const path = `${basePath}[${i}]`;
-    if (!registry.has(node.name)) {
+    const spec = registry.get(node.name);
+    if (!spec) {
       out.push({
         code: "unknown_block_type",
         message: `Unknown block type "${node.name}" at ${path}.`,
@@ -40,9 +46,25 @@ function walk(
       return;
     }
     for (const [key, value] of Object.entries(node.attrs ?? {})) {
-      if (isBlockNodeArray(value)) {
-        walk(value, `${path}.${key}`, out, registry);
+      if (!isBlockNodeArray(value)) continue;
+      // Absent `allowedBlocks` = any child (general content slots), by design.
+      const allowed = spec.inputs?.find(
+        (input) => input.name === key,
+      )?.allowedBlocks;
+      if (allowed) {
+        value.forEach((child, j) => {
+          if (allowed.includes(child.name)) return;
+          const childPath = `${path}.${key}[${String(j)}]`;
+          out.push({
+            code: "disallowed_child",
+            message: `Block "${child.name}" is not allowed in slot "${key}" of "${node.name}" at ${childPath}.`,
+            path: childPath,
+            nodeName: child.name,
+            slotName: key,
+          });
+        });
       }
+      walk(value, `${path}.${key}`, out, registry);
     }
   });
 }

--- a/packages/blocks/src/validation-errors.ts
+++ b/packages/blocks/src/validation-errors.ts
@@ -5,7 +5,9 @@ import type { BlockContentValidationResult } from "./validate-content.js";
  * only what's actually produced — so admin clients dispatching on `code`
  * don't get a false sense of coverage.
  */
-export type BlockContentValidationCode = "unknown_block_type";
+export type BlockContentValidationCode =
+  | "unknown_block_type"
+  | "disallowed_child";
 
 export interface BlockContentValidationIssue {
   readonly code: BlockContentValidationCode;
@@ -13,6 +15,8 @@ export interface BlockContentValidationIssue {
   readonly path: string;
   readonly nodeName?: string;
   readonly attributeName?: string;
+  /** For `disallowed_child`: the slot key the offending child landed in. */
+  readonly slotName?: string;
 }
 
 export class BlockContentValidationError extends Error {


### PR DESCRIPTION
Slot blocks accepted *any* child at every layer — the `BlockInput` primitive couldn't express a constraint, the Puck editor let any block drop into any slot, and write-validation only checked that a block was registered. So a `core/heading` could be dropped into a `core/table`'s rows slot (→ `<table><div>…</div></table>`), a paragraph into `core/buttons`, etc., and it would persist.

**Primitive.** `BlockInput` gains `allowedBlocks?: readonly string[]` (omitted = any child, for general content slots; mirrors Gutenberg's `allowedBlocks`). The table family and buttons declare theirs:
- `core/table` · `rows` → `core/table-header-row`, `core/table-body-row`
- `core/table-header-row` · `cells` → `core/table-header-cell` (and body-row → `core/table-cell`)
- `core/buttons` · `items` → `core/button`

**Two enforcement points.**
- **Write validation** (`validateEntryContent`) — registry param widened `{has}`→`{get}` so it can read the parent slot's whitelist; a child outside it produces a new `disallowed_child` issue. This is the integrity gate: `entry.create`/`update`/revision-restore call `assertContentValidAgainstRegistries`, which throws `INVALID_BLOCK_CONTENT` — so malformed trees from the API, import, or paste are rejected, not just editor actions.
- **Editor** — the Puck `slot` field receives `allow: [...allowedBlocks]` (Puck's component keys are the plumix block names), so the canvas only permits valid drops.

General content slots (`group`/`columns`/`details`/`callout` content) are left unconstrained by design. The inverse `parent` constraint (a block declaring its valid parents) is deliberately deferred — the sub-blocks are already `inserter: false`.

Reviewed by senpai (verified the write gate is real + no validation bypass) and the simplifier.