### PR TITLE
feat(admin): render inserter blocks as square 2-column tiles

### DIFF
--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -856,7 +856,10 @@ function PlumixBlocksTab({
           wrap — a Drawer.Item maps to a component TYPE and can't carry a
           variation's preset attrs, so variations stay click-only. */}
       <Drawer>
-        <ul className="flex flex-col gap-1 p-4" data-testid="plumix-blocks-tab">
+        <ul
+          className="grid grid-cols-2 gap-2 p-4"
+          data-testid="plumix-blocks-tab"
+        >
           {entries.map((entry) => {
             const row = (
               <InsertableEntryRow

--- a/packages/admin/src/editor/InsertableEntryRow.tsx
+++ b/packages/admin/src/editor/InsertableEntryRow.tsx
@@ -37,13 +37,19 @@ export function InsertableEntryRow({
 }: InsertableEntryRowProps): ReactElement {
   const renderLabel = useLabel();
   if (!isVariation(entry)) {
+    // Square tile (Builder.io-style): centered icon above a centered label,
+    // sized to fill a 2-column grid cell so the block list matches the
+    // pattern/variation card posture instead of a horizontal pill.
     const className =
-      "hover:bg-muted flex w-full cursor-pointer items-center gap-2 rounded border px-3 py-2 text-start text-sm";
+      "hover:bg-muted hover:border-foreground/20 flex aspect-square w-full cursor-pointer flex-col items-center justify-center gap-2 rounded-md border p-2 text-center text-xs leading-tight focus:outline-none focus-visible:ring";
     const testId = `plumix-blocks-tab-item-${entryKey(entry)}`;
     const content = (
       <>
-        <BlockIcon name={entry.icon} />
-        <span className="truncate">{renderLabel(entry.title)}</span>
+        <BlockIcon
+          name={entry.icon}
+          className="text-muted-foreground h-5 w-5 shrink-0"
+        />
+        <span className="line-clamp-2">{renderLabel(entry.title)}</span>
       </>
     );
     if (!interactive) {


### PR DESCRIPTION
The editor's block inserter rendered plain blocks as full-width **horizontal pills** (icon + label side by side), inconsistent with the variation and pattern cards in the same panel. This renders them as **square 2-column tiles** — centered icon over a centered label, Builder.io-style — so the block list matches the card posture used elsewhere.

Styling only (`InsertableEntryRow` tile className + the blocks `<ul>` → `grid grid-cols-2`); no logic, testids unchanged. Patterns below stay as wide preview cards by design — they show a live preview of real content that earns the width, the same asymmetry Builder.io uses (basic blocks = square tiles, templates = larger preview cards).

Also adds a keyboard focus ring to the tiles for parity with the variation cards (a pre-existing gap on the pill).

Verified: admin lint/typecheck/test + knip green; the full editor e2e (56 tests incl. axe-core a11y + block insertion) passes.

Before / after:

| Before (pills) | After (tiles) |
|---|---|
| full-width horizontal rows | 2-col square tiles |