### PR TITLE
fix: repair admin RTL direction context and add shadcn CLI for admin-ui

### DIFF
--- a/packages/admin-ui/README.md
+++ b/packages/admin-ui/README.md
@@ -1,0 +1,32 @@
+# @plumix/admin-ui
+
+The shared shadcn/ui primitives rendered by the admin shell (`@plumix/admin`)
+**and** by plugin admin chunks (via `plumix/admin/ui`). One vendored source of
+truth so the shell and plugins stay visually consistent.
+
+## Adding a component
+
+```sh
+pnpm --filter @plumix/admin-ui ui:add <component>   # e.g. dialog, badge
+```
+
+This runs `shadcn add` against this package's `components.json` (components
+land flat in `src/`, `cn` imports resolve to `@plumix/admin-ui`) and formats
+the result. After adding, export it from `src/index.ts` and add a subpath to
+`exports` in `package.json` so consumers can `import … from
+"@plumix/admin-ui/<component>"`.
+
+## Theme
+
+`components.json` points `tailwind.css` at a placeholder (`unused.css`):
+the design tokens live in `@plumix/admin`'s `src/styles/globals.css`, which
+already `@source`s this package so the shell CSS carries every component's
+classes (plugin chunks inherit them). If a newly-added component needs new
+CSS variables or keyframes, add them there.
+
+## Sharing with plugins
+
+The thin wrappers ship as bundled source through `plumix/admin/ui`; their
+`radix-ui` / `sonner` / `tailwind-merge` imports are aliased to the host
+runtime shims at plugin build time, so plugin chunks reuse the shell's single
+radix/sonner/tailwind-merge instance instead of bundling their own.

--- a/packages/admin-ui/components.json
+++ b/packages/admin-ui/components.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "unused.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "src/",
+    "ui": "src/",
+    "utils": "@plumix/admin-ui",
+    "lib": "src/",
+    "hooks": "src/"
+  },
+  "iconLibrary": "lucide"
+}

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -150,7 +150,8 @@
     "clean": "git clean -xdf .cache .turbo dist node_modules",
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "lint": "eslint",
-    "typecheck": "tsc --noEmit --emitDeclarationOnly false"
+    "typecheck": "tsc --noEmit --emitDeclarationOnly false",
+    "ui:add": "pnpm dlx shadcn@latest add && prettier --write src --ignore-path ../../.gitignore"
   },
   "dependencies": {
     "@dnd-kit/core": "catalog:",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -27,7 +27,6 @@
     "@orpc/tanstack-query": "catalog:",
     "@plumix/admin-ui": "workspace:*",
     "@puckeditor/core": "0.21.2",
-    "@radix-ui/react-direction": "1.1.1",
     "@tanstack/react-query": "catalog:",
     "@tanstack/react-router": "catalog:",
     "@tanstack/react-table": "^8.21.3",

--- a/packages/admin/src/App.direction.test.tsx
+++ b/packages/admin/src/App.direction.test.tsx
@@ -1,0 +1,37 @@
+import { cleanup, render } from "@testing-library/react";
+import { Direction } from "radix-ui";
+import { afterEach, describe, expect, test } from "vitest";
+
+// Regression guard for the RTL direction-context bug. The admin shell mounts
+// `Direction.DirectionProvider` (App.tsx); every shadcn/radix primitive
+// behind it reads direction via `Direction.useDirection` — the exact hook
+// probed here. Both MUST come from the same `@radix-ui/react-direction`
+// instance, which is why App imports `Direction` from the `radix-ui`
+// umbrella (the version the primitives are built against) rather than the
+// standalone `@radix-ui/react-direction` package. When those diverged, the
+// provider produced a context the primitives never read and RTL fell back to
+// LTR for the `ar` locale. If a future radix bump re-splits the umbrella's
+// provider from its `useDirection`, this fails.
+function DirectionProbe() {
+  return <span data-testid="resolved-dir">{Direction.useDirection()}</span>;
+}
+
+describe("admin RTL direction context", () => {
+  afterEach(cleanup);
+
+  test("the umbrella DirectionProvider feeds the direction radix primitives read", () => {
+    const { getByTestId } = render(
+      <Direction.DirectionProvider dir="rtl">
+        <DirectionProbe />
+      </Direction.DirectionProvider>,
+    );
+
+    expect(getByTestId("resolved-dir")).toHaveTextContent("rtl");
+  });
+
+  test("falls back to ltr without a provider", () => {
+    const { getByTestId } = render(<DirectionProbe />);
+
+    expect(getByTestId("resolved-dir")).toHaveTextContent("ltr");
+  });
+});

--- a/packages/admin/src/App.tsx
+++ b/packages/admin/src/App.tsx
@@ -3,11 +3,11 @@ import { useState } from "react";
 import { useDir } from "@/lib/use-dir.js";
 import { i18n } from "@lingui/core";
 import { I18nProvider } from "@lingui/react";
-import { DirectionProvider } from "@radix-ui/react-direction";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { RouterProvider } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
+import { Direction } from "radix-ui";
 
 import {
   createQueryClient,
@@ -27,9 +27,16 @@ export function App(): ReactNode {
   // behind shadcn (dialog, dropdown, popover, …). Without it they read
   // `dir` from a fallback chain that doesn't include `<html dir>`.
   // Source is `<html dir>` set by SSR + the locale-switch reload path.
+  //
+  // MUST come from the `radix-ui` umbrella, not the standalone
+  // `@radix-ui/react-direction`: the shadcn primitives consume direction
+  // via the umbrella's bundled `useDirection`, and the standalone package
+  // can resolve to a different version (a separate React context) — in
+  // which case the provider is invisible to the primitives and RTL silently
+  // falls back to LTR. See App.direction.test.tsx.
   return (
     <I18nProvider i18n={i18n}>
-      <DirectionProvider dir={useDir()}>
+      <Direction.DirectionProvider dir={useDir()}>
         <ThemeProvider defaultTheme="system">
           <QueryClientProvider client={queryClient}>
             <RouterProvider router={router} />
@@ -41,7 +48,7 @@ export function App(): ReactNode {
             ) : null}
           </QueryClientProvider>
         </ThemeProvider>
-      </DirectionProvider>
+      </Direction.DirectionProvider>
     </I18nProvider>
   );
 }

--- a/packages/admin/src/components/shell/command-palette.test.tsx
+++ b/packages/admin/src/components/shell/command-palette.test.tsx
@@ -5,9 +5,9 @@ import {
 } from "@/lib/palette-commands.js";
 import { recordRecentNav } from "@/lib/recent-nav.js";
 import { createQueryClient } from "@/providers/query-client.js";
-import { DirectionProvider } from "@radix-ui/react-direction";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import { Direction } from "radix-ui";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { renderWithI18n } from "../../../test/render-with-i18n.js";
@@ -320,9 +320,9 @@ describe("CommandPalette", () => {
 
   test("mounts under an RTL direction provider without crashing", async () => {
     renderPalette(
-      <DirectionProvider dir="rtl">
+      <Direction.DirectionProvider dir="rtl">
         <CommandPalette capabilities={[]} />
-      </DirectionProvider>,
+      </Direction.DirectionProvider>,
     );
     pressCmdK();
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -304,9 +304,6 @@ importers:
       '@puckeditor/core':
         specifier: 0.21.2
         version: 0.21.2(@floating-ui/dom@1.7.6)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
-      '@radix-ui/react-direction':
-        specifier: 1.1.1
-        version: 1.1.1(@types/react@19.2.16)(react@19.2.7)
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.101.0(react@19.2.7)
@@ -3628,15 +3625,6 @@ packages:
       '@types/react':
         optional: true
       '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-direction@1.1.1':
-    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
         optional: true
 
   '@radix-ui/react-direction@1.1.2':
@@ -9635,12 +9623,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
-
-  '@radix-ui/react-direction@1.1.1(@types/react@19.2.16)(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.16
 
   '@radix-ui/react-direction@1.1.2(@types/react@19.2.16)(react@19.2.7)':
     dependencies:


### PR DESCRIPTION
Two admin-UI changes that surfaced from #1095's review.

## RTL direction context (bug fix)

RTL was silently broken for radix primitives (dialogs, dropdowns, popovers, …) under the `ar` locale. `App.tsx` mounted `DirectionProvider` from the standalone `@radix-ui/react-direction` (pinned `1.1.1`), while the shadcn primitives read direction via the `radix-ui` umbrella's bundled `useDirection` (`1.1.2`). Two resolved versions → two physical modules → **two different React contexts**, so the provider was invisible to the primitives and direction fell back to LTR regardless of `<html dir="rtl">`.

**Fix:** mount the provider from the umbrella's `Direction` namespace so it shares the instance the primitives consume, and drop the now-unused standalone `@radix-ui/react-direction` dependency. A regression test (`App.direction.test.tsx`) asserts the umbrella provider feeds the direction radix primitives read — it fails if a future radix bump re-splits them or if App reverts to the standalone package.

## shadcn CLI config for @plumix/admin-ui (DX)

New shadcn components should land in the shared package, not the admin app. Adds a `components.json` (new-york / neutral / lucide, matching the admin's existing config) targeting the package's flat `src/` layout with `cn` resolving to `@plumix/admin-ui`, plus a `ui:add` script wrapping `shadcn add` + prettier — the create-t3-turbo pattern, adapted. `tailwind.css` points at a placeholder since the tokens live in the admin's `globals.css` (which already `@source`s this package); a short README documents the flow.