### PR TITLE
refactor(plugin-media): adopt shared shadcn primitives from plumix/admin/ui

### DIFF
--- a/packages/plugins/media/src/admin/MediaLibrary.tsx
+++ b/packages/plugins/media/src/admin/MediaLibrary.tsx
@@ -6,6 +6,19 @@ import {
   useMutation,
   useQueryClient,
 } from "@tanstack/react-query";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Button,
+  Input,
+  Skeleton,
+} from "plumix/admin/ui";
 import { Trans, useLingui } from "plumix/i18n";
 
 // Descriptors that need runtime indirection — used outside JSX (aria
@@ -526,7 +539,7 @@ export function MediaLibrary({
             {isPicker ? i18n._(M.titlePicker) : i18n._(M.titleLibrary)}
           </h1>
           <div className="flex items-center gap-2">
-            <input
+            <Input
               type="search"
               role="searchbox"
               value={search}
@@ -540,9 +553,7 @@ export function MediaLibrary({
               aria-label={i18n._(M.searchPlaceholder)}
               maxLength={200}
               data-testid="media-library-search"
-              // Classes mirror the admin's vendored Input (components/ui/
-              // input) — unreachable from plugin code behind the @/ alias.
-              className="border-input bg-background focus-visible:ring-ring h-9 w-56 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:outline-none"
+              className="w-56"
             />
             <UploadButton onSelect={(files) => void startUpload(files)} />
           </div>
@@ -656,17 +667,18 @@ export function MediaLibrary({
             data-testid="media-library-picker-footer"
             className="bg-background sticky bottom-0 -mx-2 flex items-center justify-end gap-2 border-t px-2 py-3"
           >
-            <button
+            <Button
               type="button"
-              className="hover:bg-muted rounded px-3 py-1.5 text-sm"
+              variant="ghost"
+              size="sm"
               onClick={() => onCancel?.()}
               data-testid="media-library-picker-cancel"
             >
               <Trans id="plugin.media.library.pickerCancel" message="Cancel" />
-            </button>
-            <button
+            </Button>
+            <Button
               type="button"
-              className="bg-primary text-primary-foreground hover:bg-primary/90 rounded px-3 py-1.5 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+              size="sm"
               disabled={pickerSelectedId === null}
               onClick={() => {
                 if (pickerSelectedId !== null) {
@@ -679,7 +691,7 @@ export function MediaLibrary({
                 id="plugin.media.library.pickerUseSelection"
                 message="Use selection"
               />
-            </button>
+            </Button>
           </footer>
         )}
       </div>
@@ -806,14 +818,16 @@ function ErrorBanner({
       className="text-destructive flex items-center justify-between gap-3 text-sm"
     >
       <span>{message}</span>
-      <button
+      <Button
         type="button"
+        variant="link"
+        size="sm"
         data-testid={`${testIdRoot}-dismiss`}
         onClick={onDismiss}
-        className="text-xs underline"
+        className="text-destructive h-auto p-0 text-xs"
       >
         <Trans id="plugin.media.banner.dismiss" message="Dismiss" />
-      </button>
+      </Button>
     </div>
   );
 }
@@ -1043,9 +1057,9 @@ function MediaSkeletonGrid(): ReactNode {
           aria-hidden="true"
           className="border-border bg-card flex flex-col gap-2 rounded-lg border p-3"
         >
-          <div className="aspect-square w-full animate-pulse rounded-sm bg-white/10" />
-          <div className="h-3.5 w-[70%] rounded-sm bg-white/[0.06]" />
-          <div className="h-[0.7rem] w-[40%] rounded-sm bg-white/[0.04]" />
+          <Skeleton className="aspect-square w-full rounded-sm" />
+          <Skeleton className="h-3.5 w-[70%] rounded-sm" />
+          <Skeleton className="h-[0.7rem] w-[40%] rounded-sm" />
         </div>
       ))}
     </div>
@@ -1143,15 +1157,17 @@ function MediaDetailDrawer({
         <span className="text-xs tracking-wider opacity-70">
           <Trans id="plugin.media.detail.heading" message="ASSET DETAILS" />
         </span>
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          size="icon-sm"
           onClick={onClose}
           aria-label={i18n._(M.closeDetailsAria)}
           data-testid="media-detail-close"
-          className="cursor-pointer rounded px-1.5 py-0.5 text-base leading-none"
+          className="text-base leading-none"
         >
           ×
-        </button>
+        </Button>
       </div>
 
       <div className="bg-muted aspect-square w-full overflow-hidden">
@@ -1225,44 +1241,49 @@ function MediaDetailDrawer({
             >
               {absoluteUrl}
             </code>
-            <button
+            <Button
               type="button"
+              variant="outline"
+              size="xs"
               onClick={() => void copy()}
               data-testid="media-detail-copy"
-              className="border-border flex-shrink-0 cursor-pointer rounded border bg-transparent px-2 py-1 text-[0.7rem]"
+              className="flex-shrink-0 text-[0.7rem]"
             >
               {copied ? (
                 <Trans id="plugin.media.detail.copied" message="Copied" />
               ) : (
                 <Trans id="plugin.media.detail.copy" message="Copy" />
               )}
-            </button>
+            </Button>
           </div>
         </div>
 
         <div className="border-border flex gap-2 border-t pt-2">
-          <a
-            // Always go through the worker serve route with
-            // ?attachment=1 — the HTML `download` attribute is ignored
-            // cross-origin (e.g. when `publicUrlBase` is configured),
-            // but the route always sends `Content-Disposition:
-            // attachment` for this query param, so downloads work
-            // regardless of which mode `item.url` is in.
-            href={`${pluginBasePath()}/_plumix/media/serve/${String(item.id)}?attachment=1`}
-            download={item.title}
-            data-testid="media-detail-download"
-            className="bg-card hover:bg-muted flex-1 rounded border px-3 py-2 text-center text-xs no-underline"
-          >
-            <Trans id="plugin.media.detail.download" message="Download" />
-          </a>
-          <button
+          <Button asChild variant="outline" size="sm" className="flex-1">
+            <a
+              // Always go through the worker serve route with
+              // ?attachment=1 — the HTML `download` attribute is ignored
+              // cross-origin (e.g. when `publicUrlBase` is configured),
+              // but the route always sends `Content-Disposition:
+              // attachment` for this query param, so downloads work
+              // regardless of which mode `item.url` is in.
+              href={`${pluginBasePath()}/_plumix/media/serve/${String(item.id)}?attachment=1`}
+              download={item.title}
+              data-testid="media-detail-download"
+            >
+              <Trans id="plugin.media.detail.download" message="Download" />
+            </a>
+          </Button>
+          <Button
             type="button"
+            variant="outline"
+            size="sm"
             data-testid="media-detail-delete"
             onClick={() => setConfirmingDelete(true)}
-            className="border-border flex-1 cursor-pointer rounded border bg-transparent px-3 py-2 text-xs"
+            className="flex-1"
           >
             <Trans id="plugin.media.detail.delete" message="Delete" />
-          </button>
+          </Button>
         </div>
       </div>
       {confirmingDelete && (
@@ -1297,7 +1318,6 @@ function ConfirmDialog({
   title,
   description,
   confirmLabel,
-  cancelLabel,
   danger = false,
   onCancel,
   onConfirm,
@@ -1305,71 +1325,46 @@ function ConfirmDialog({
   title: ReactNode;
   description?: string;
   confirmLabel?: ReactNode;
-  cancelLabel?: ReactNode;
   danger?: boolean;
   onCancel: () => void;
   onConfirm: () => void;
 }): ReactNode {
-  // Close on ESC; trap obvious-bg click as cancel.
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent): void => {
-      if (e.key === "Escape") onCancel();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onCancel]);
-
+  // Mounted only while confirming (parent renders conditionally), so the
+  // dialog is always open while present; closing via ESC, the overlay, or
+  // Cancel routes through `onOpenChange` → `onCancel`. Radix handles the
+  // focus trap + ESC that this component used to wire by hand.
   return (
-    <div
-      data-testid="confirm-dialog-overlay"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="confirm-dialog-title"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onCancel();
+    <AlertDialog
+      open
+      onOpenChange={(next) => {
+        if (!next) onCancel();
       }}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
     >
-      <div className="border-border bg-card flex w-full max-w-md flex-col gap-3 rounded-lg border p-5">
-        <h3
-          id="confirm-dialog-title"
-          data-testid="confirm-dialog-title"
-          className="m-0 text-base font-semibold"
-        >
-          {title}
-        </h3>
-        {description && (
-          <p className="m-0 text-sm leading-snug opacity-75">{description}</p>
-        )}
-        <div className="mt-2 flex justify-end gap-2">
-          <button
-            type="button"
-            data-testid="confirm-dialog-cancel"
-            onClick={onCancel}
-            className="border-border cursor-pointer rounded border bg-transparent px-3.5 py-2 text-[0.8rem]"
-          >
-            {cancelLabel ?? (
-              <Trans id="plugin.media.dialog.cancel" message="Cancel" />
-            )}
-          </button>
-          <button
-            type="button"
+      <AlertDialogContent data-testid="confirm-dialog-overlay">
+        <AlertDialogHeader>
+          <AlertDialogTitle data-testid="confirm-dialog-title">
+            {title}
+          </AlertDialogTitle>
+          {description ? (
+            <AlertDialogDescription>{description}</AlertDialogDescription>
+          ) : null}
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel data-testid="confirm-dialog-cancel">
+            <Trans id="plugin.media.dialog.cancel" message="Cancel" />
+          </AlertDialogCancel>
+          <AlertDialogAction
             data-testid="confirm-dialog-confirm"
+            variant={danger ? "destructive" : "default"}
             onClick={onConfirm}
-            autoFocus
-            className={`cursor-pointer rounded border px-3.5 py-2 text-[0.8rem] font-semibold ${
-              danger
-                ? "border-destructive bg-destructive text-white"
-                : "border-primary bg-primary text-primary-foreground"
-            }`}
           >
             {confirmLabel ?? (
               <Trans id="plugin.media.dialog.confirm" message="Confirm" />
             )}
-          </button>
-        </div>
-      </div>
-    </div>
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }
 
@@ -1436,7 +1431,7 @@ function AltEditor({
 
   return (
     <div className="relative">
-      <input
+      <Input
         data-testid={`${testIdPrefix}-${String(cardId)}-alt`}
         type="text"
         value={draft}
@@ -1459,7 +1454,6 @@ function AltEditor({
             e.currentTarget.blur();
           }
         }}
-        className="border-border focus:border-primary w-full rounded-md border bg-white/[0.03] px-2.5 py-2 text-[0.8125rem] leading-snug outline-none focus:bg-white/5"
       />
       {savedFlash && (
         <span

--- a/packages/plugins/media/src/admin/MediaListPickerField.tsx
+++ b/packages/plugins/media/src/admin/MediaListPickerField.tsx
@@ -1,7 +1,8 @@
 import type { MessageDescriptor } from "plumix/i18n";
 import type { MetaBoxFieldManifestEntry } from "plumix/plugin";
 import type { ReactNode } from "react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import { Button, Dialog, DialogContent, DialogTitle } from "plumix/admin/ui";
 import { useLingui } from "plumix/i18n";
 
 import { MediaLibrary } from "./MediaLibrary.js";
@@ -209,9 +210,10 @@ export function MediaListPickerField({
         </ul>
       )}
       <div className="flex items-center gap-2">
-        <button
+        <Button
           type="button"
-          className="hover:bg-muted rounded border px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+          variant="outline"
+          size="sm"
           disabled={disabled || atMax}
           onClick={() => setOpen(true)}
           data-testid={`${testId}-add`}
@@ -219,7 +221,7 @@ export function MediaListPickerField({
           {value.length === 0
             ? i18n._(M.buttonSelect)
             : i18n._(M.buttonAddMore)}
-        </button>
+        </Button>
         {max !== undefined ? (
           <span
             className="text-muted-foreground text-xs"
@@ -287,9 +289,10 @@ function MediaListItem({
           </p>
         )}
       </div>
-      <button
+      <Button
         type="button"
-        className="hover:bg-muted rounded px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50"
+        variant="ghost"
+        size="icon-xs"
         disabled={disabled || index === 0}
         onClick={() => onMove(index, -1)}
         aria-label={i18n._(M.moveUpAria.id, ariaValues, {
@@ -298,10 +301,11 @@ function MediaListItem({
         data-testid={`${rowTestId}-up`}
       >
         ↑
-      </button>
-      <button
+      </Button>
+      <Button
         type="button"
-        className="hover:bg-muted rounded px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50"
+        variant="ghost"
+        size="icon-xs"
         disabled={disabled || index === count - 1}
         onClick={() => onMove(index, 1)}
         aria-label={i18n._(M.moveDownAria.id, ariaValues, {
@@ -310,10 +314,11 @@ function MediaListItem({
         data-testid={`${rowTestId}-down`}
       >
         ↓
-      </button>
-      <button
+      </Button>
+      <Button
         type="button"
-        className="hover:bg-muted rounded px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50"
+        variant="ghost"
+        size="icon-xs"
         disabled={disabled}
         onClick={() => onRemove(index)}
         aria-label={i18n._(M.removeAria.id, ariaValues, {
@@ -322,15 +327,16 @@ function MediaListItem({
         data-testid={`${rowTestId}-remove`}
       >
         ✕
-      </button>
+      </Button>
     </li>
   );
 }
 
-// Modal that hosts MediaLibrary in picker mode. Doesn't close on
-// `onSelect` — multi-select stays open until the user clicks Cancel
-// or the parent's effect closes it on `atMax`. Window-level Escape
-// listener mirrors the single-pick modal in MediaPickerField.
+// Modal that hosts MediaLibrary in picker mode, on the shared `Dialog`
+// from `plumix/admin/ui`. Doesn't close on `onSelect` — multi-select
+// stays open until the user clicks Cancel or the parent closes it on
+// reaching `max`. Radix handles the focus trap, Escape, and backdrop
+// dismiss (routed through `onOpenChange` → `onCancel`).
 function MediaListPickerModal({
   accept,
   onSelect,
@@ -343,36 +349,30 @@ function MediaListPickerModal({
   readonly testId: string;
 }): ReactNode {
   const { i18n } = useLingui();
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent): void => {
-      if (e.key === "Escape") onCancel();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onCancel]);
 
   return (
-    <div
-      data-testid={testId}
-      role="dialog"
-      aria-modal="true"
-      aria-label={i18n._(M.modalAria)}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onCancel();
+    <Dialog
+      open
+      onOpenChange={(next) => {
+        if (!next) onCancel();
       }}
     >
-      <div
-        className="bg-background relative flex max-h-[90vh] w-full max-w-5xl flex-col overflow-y-auto rounded-lg p-4 shadow-lg"
-        data-testid={`${testId}-panel`}
+      <DialogContent
+        data-testid={testId}
+        showCloseButton={false}
+        className="flex max-h-[90vh] max-w-5xl flex-col overflow-y-auto"
       >
+        {/* MediaLibrary renders its own visible heading + footer controls;
+            this names the dialog for assistive tech without duplicating it
+            on screen. */}
+        <DialogTitle className="sr-only">{i18n._(M.modalAria)}</DialogTitle>
         <MediaLibrary
           mode="picker"
           accept={accept}
           onSelect={onSelect}
           onCancel={onCancel}
         />
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/packages/plugins/media/src/admin/MediaPickerField.tsx
+++ b/packages/plugins/media/src/admin/MediaPickerField.tsx
@@ -1,7 +1,8 @@
 import type { MessageDescriptor } from "plumix/i18n";
 import type { MetaBoxFieldManifestEntry } from "plumix/plugin";
 import type { ReactNode } from "react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import { Button, Dialog, DialogContent, DialogTitle } from "plumix/admin/ui";
 import { Trans, useLingui } from "plumix/i18n";
 
 import { MediaLibrary } from "./MediaLibrary.js";
@@ -126,25 +127,27 @@ export function MediaPickerField({
           </p>
         )}
       </div>
-      <button
+      <Button
         type="button"
-        className="hover:bg-muted rounded border px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+        variant="outline"
+        size="sm"
         disabled={disabled}
         onClick={() => setOpen(true)}
         data-testid={`${testId}-open`}
       >
         {value ? i18n._(M.buttonChange) : i18n._(M.buttonSelect)}
-      </button>
+      </Button>
       {value && !required ? (
-        <button
+        <Button
           type="button"
-          className="hover:bg-muted rounded px-2 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+          variant="ghost"
+          size="sm"
           disabled={disabled}
           onClick={handleClear}
           data-testid={`${testId}-clear`}
         >
           <Trans id="plugin.media.pickerField.clear" message="Clear" />
-        </button>
+        </Button>
       ) : null}
       {open ? (
         <MediaPickerModal
@@ -193,11 +196,11 @@ function MediaPreview({
   );
 }
 
-// Fixed-position modal hosting the MediaLibrary in picker mode.
-// Mirrors the `ConfirmDialog` pattern in MediaLibrary.tsx (no shadcn
-// `Dialog` shim is exposed to plugin chunks, so the plugin can't
-// import it). Backdrop click + Escape dismiss. Body scroll is locked
-// while open by the surrounding admin route layout.
+// Modal hosting the MediaLibrary in picker mode, built on the shared
+// `Dialog` from `plumix/admin/ui` — radix handles the focus trap, Escape,
+// and backdrop dismiss that this used to wire by hand. Mounted only while
+// open (parent renders conditionally), so closing routes through
+// `onOpenChange` → `onCancel`.
 function MediaPickerModal({
   accept,
   onSelect,
@@ -210,42 +213,30 @@ function MediaPickerModal({
   readonly testId: string;
 }): ReactNode {
   const { i18n } = useLingui();
-  const modalAria = i18n._(M.modalAria);
-  // Window-level Escape listener — React's `onKeyDown` only fires when
-  // focus is inside the modal. If the user clicked the backdrop (focus
-  // goes to body) or focus drifted outside, the React handler misses
-  // the event. Mounted only while the modal is open so it doesn't
-  // intercept keystrokes on the rest of the admin.
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent): void => {
-      if (e.key === "Escape") onCancel();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onCancel]);
 
   return (
-    <div
-      data-testid={testId}
-      role="dialog"
-      aria-modal="true"
-      aria-label={modalAria}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onCancel();
+    <Dialog
+      open
+      onOpenChange={(next) => {
+        if (!next) onCancel();
       }}
     >
-      <div
-        className="bg-background relative flex max-h-[90vh] w-full max-w-5xl flex-col overflow-y-auto rounded-lg p-4 shadow-lg"
-        data-testid={`${testId}-panel`}
+      <DialogContent
+        data-testid={testId}
+        showCloseButton={false}
+        className="flex max-h-[90vh] max-w-5xl flex-col overflow-y-auto"
       >
+        {/* MediaLibrary renders its own visible heading + footer controls;
+            this names the dialog for assistive tech without duplicating it
+            on screen. */}
+        <DialogTitle className="sr-only">{i18n._(M.modalAria)}</DialogTitle>
         <MediaLibrary
           mode="picker"
           accept={accept}
           onSelect={onSelect}
           onCancel={onCancel}
         />
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }


### PR DESCRIPTION
The first real plugin to consume `plumix/admin/ui` — the payoff for the shared-UI work in #1095.

The media admin UI hand-rolled its buttons, inputs, skeletons and modals because the shadcn primitives were unreachable from plugin chunks; the source literally commented that it was *"mirroring the admin's vendored Input"* and *"no shadcn `Dialog` shim is exposed to plugin chunks, so the plugin can't import it."* Now it can.

**What changed**
- raw `<button>` → `Button` (ghost / outline / link / icon variants)
- search + alt-text `<input>` → `Input`
- loading placeholders → `Skeleton`
- the bespoke `ConfirmDialog` (manual `keydown` ESC listener + overlay-click handler) → shared `AlertDialog`
- both picker modals (which embed the library) → shared `Dialog`

Radix now provides the focus trap + Escape the modals wired by hand. Net −15 lines despite richer components.

**Bundle impact:** the components are bundled into the plugin chunk, but their `radix-ui` / `tailwind-merge` imports resolve to the host runtime shims, so the chunk carries **no radix copy** (verified via the alias-seam build), and the `plumix/admin/ui` barrel **tree-shakes** to only the five components used (button, input, skeleton, dialog, alert-dialog) — the other 27 stay out.

**Behavior preserved:** all `data-testid`s kept; the delete-confirm flow (`media-detail-delete` → `confirm-dialog-confirm`) is intact and the media unit suite (139 tests) stays green. One intentional UX change: the delete `AlertDialog` no longer dismisses on backdrop click (radix default) — better for a destructive confirm. Picker modals pass `showCloseButton={false}` since the library renders its own footer controls.

_Couldn't run the media Playwright e2e locally (needs a dev server); it validates in CI._