### PR TITLE
refactor(plugin-menu): adopt shared shadcn primitives from plumix/admin/ui

### DIFF
--- a/packages/plugins/menu/src/admin/MenuItemEditor.tsx
+++ b/packages/plugins/menu/src/admin/MenuItemEditor.tsx
@@ -18,6 +18,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useQueryClient } from "@tanstack/react-query";
+import { Button, Checkbox, Input } from "plumix/admin/ui";
 import { Trans, useLingui } from "plumix/i18n";
 
 import type {
@@ -142,11 +143,10 @@ function LocationsBindings({
             data-testid={`menu-settings-location-row-${row.id}`}
             className="flex items-center gap-2 text-sm"
           >
-            <input
-              type="checkbox"
+            <Checkbox
               data-testid={`menu-settings-location-${row.id}`}
               checked={isBound}
-              onChange={() => {
+              onCheckedChange={() => {
                 assign.mutate({
                   location: row.id,
                   termSlug: isBound ? null : slug,
@@ -198,10 +198,11 @@ function MenuSettingsPanel({
             id="plugin.menu.itemEditor.conflictBanner"
             message="Another editor saved changes since you loaded this menu."
           />
-          <button
+          <Button
             type="button"
+            variant="outline"
+            size="sm"
             data-testid="menu-conflict-reload"
-            className="border-border hover:bg-muted rounded border bg-transparent px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
             onClick={() => {
               setDismissedAt(state.version);
               save.reset();
@@ -214,15 +215,15 @@ function MenuSettingsPanel({
               id="plugin.menu.itemEditor.conflictReload"
               message="Reload to see latest"
             />
-          </button>
+          </Button>
         </div>
       ) : null}
       <div className="flex items-center gap-2">
-        <button
+        <Button
           type="button"
+          size="sm"
           data-testid="menu-save-button"
           disabled={save.isPending}
-          className="bg-primary text-primary-foreground hover:bg-primary/90 rounded px-3 py-1.5 text-sm disabled:cursor-not-allowed disabled:opacity-50"
           onClick={() => {
             // Snapshot the keys at click time so onSuccess can reattach
             // ids to the right items even if the user mutated state
@@ -251,7 +252,7 @@ function MenuSettingsPanel({
           }}
         >
           <Trans id="plugin.menu.itemEditor.saveButton" message="Save menu" />
-        </button>
+        </Button>
         <DeleteMenuButton termId={state.termId} />
       </div>
     </div>
@@ -289,7 +290,7 @@ function MaxDepthField({
       className="flex items-center gap-2 text-sm font-medium"
     >
       <Trans id="plugin.menu.itemEditor.maxDepthLabel" message="Max depth" />
-      <input
+      <Input
         type="number"
         data-testid="menu-settings-max-depth"
         min={0}
@@ -302,7 +303,7 @@ function MaxDepthField({
             dispatch({ type: "updateMaxDepth", value: nextParsed });
           }
         }}
-        className="border-input bg-background focus-visible:ring-ring h-9 w-20 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:outline-none"
+        className="w-20"
       />
       {rejected ? (
         <span
@@ -323,11 +324,13 @@ function DeleteMenuButton({ termId }: { readonly termId: number }): ReactNode {
   const { i18n } = useLingui();
   const remove = useDeleteMenu();
   return (
-    <button
+    <Button
       type="button"
+      variant="outline"
+      size="sm"
       data-testid="menu-delete-button"
       disabled={remove.isPending}
-      className="text-destructive border-destructive hover:bg-destructive/10 rounded border bg-transparent px-3 py-1.5 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+      className="text-destructive border-destructive hover:bg-destructive/10 hover:text-destructive"
       onClick={() => {
         if (
           typeof window !== "undefined" &&
@@ -339,7 +342,7 @@ function DeleteMenuButton({ termId }: { readonly termId: number }): ReactNode {
       }}
     >
       <Trans id="plugin.menu.itemEditor.deleteButton" message="Delete menu" />
-    </button>
+    </Button>
   );
 }
 
@@ -382,16 +385,17 @@ function ItemsPicker({
               { message: M.relinkBanner.message },
             )}
           </span>
-          <button
+          <Button
             type="button"
+            variant="outline"
+            size="sm"
             data-testid="menu-picker-relink-cancel"
-            className="border-border hover:bg-muted rounded border bg-transparent px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
             onClick={() => {
               dispatch({ type: "cancelRelink" });
             }}
           >
             <Trans id="plugin.menu.itemEditor.cancelButton" message="Cancel" />
-          </button>
+          </Button>
         </div>
       ) : null}
       <div
@@ -401,20 +405,19 @@ function ItemsPicker({
         {tabs.map((tab) => {
           const key = tabKey(tab);
           return (
-            <button
+            <Button
               key={key}
               type="button"
+              variant={activeTab === key ? "secondary" : "ghost"}
+              size="sm"
               data-testid={`menu-picker-tab-${key}`}
               aria-selected={activeTab === key}
               onClick={() => {
                 setActiveTab(key);
               }}
-              className={`hover:bg-muted rounded px-3 py-1.5 text-sm ${
-                activeTab === key ? "bg-muted font-medium" : ""
-              }`}
             >
               {tab.tabLabel}
-            </button>
+            </Button>
           );
         })}
       </div>
@@ -463,28 +466,30 @@ function CustomUrlPickerPanel({
       data-testid="menu-picker-custom-panel"
       className="border-border bg-card flex flex-wrap items-center gap-2 rounded-lg border p-4"
     >
-      <input
+      <Input
         type="text"
         data-testid="menu-picker-custom-url"
         value={url}
         onChange={(event) => {
           setUrl(event.target.value);
         }}
-        className="border-input bg-background focus-visible:ring-ring h-9 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:outline-none"
+        // `flex-1` constrains the shared Input's default `w-full` so the url,
+        // label, and Add button stay on one row instead of each wrapping.
+        className="flex-1"
       />
-      <input
+      <Input
         type="text"
         data-testid="menu-picker-custom-label"
         value={label}
         onChange={(event) => {
           setLabel(event.target.value);
         }}
-        className="border-input bg-background focus-visible:ring-ring h-9 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:outline-none"
+        className="flex-1"
       />
-      <button
+      <Button
         type="button"
+        size="sm"
         data-testid="menu-picker-custom-add"
-        className="bg-primary text-primary-foreground hover:bg-primary/90 rounded px-3 py-1.5 text-sm disabled:cursor-not-allowed disabled:opacity-50"
         onClick={() => {
           if (url.trim() === "") return;
           if (relinkTargetKey !== null) {
@@ -515,7 +520,7 @@ function CustomUrlPickerPanel({
             message="Add to menu"
           />
         )}
-      </button>
+      </Button>
     </div>
   );
 }
@@ -695,10 +700,11 @@ function SortableTreeRow({
       </span>
       {isBroken ? (
         <>
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="xs"
             data-testid={`menu-item-relink-${String(id)}`}
-            className="hover:bg-muted rounded px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50"
             onClick={(event) => {
               event.stopPropagation();
               dispatch({ type: "startRelink", key: item.key });
@@ -708,11 +714,12 @@ function SortableTreeRow({
               id="plugin.menu.itemEditor.relinkButton"
               message="Re-link…"
             />
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
+            variant="ghost"
+            size="xs"
             data-testid={`menu-item-convert-${String(id)}`}
-            className="hover:bg-muted rounded px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50"
             onClick={(event) => {
               event.stopPropagation();
               dispatch({ type: "convertToCustom", key: item.key });
@@ -722,21 +729,23 @@ function SortableTreeRow({
               id="plugin.menu.itemEditor.convertButton"
               message="Convert to Custom URL"
             />
-          </button>
+          </Button>
         </>
       ) : null}
-      <button
+      <Button
         type="button"
+        variant="ghost"
+        size="xs"
         data-testid={`menu-item-remove-${String(id)}`}
         disabled={isUnauthorized}
-        className="text-destructive hover:bg-muted rounded px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50"
+        className="text-destructive hover:text-destructive"
         onClick={(event) => {
           event.stopPropagation();
           dispatch({ type: "removeItem", key: item.key });
         }}
       >
         <Trans id="plugin.menu.itemEditor.removeButton" message="Remove" />
-      </button>
+      </Button>
     </div>
   );
 }
@@ -758,11 +767,10 @@ function ItemDetailPanel({
       data-testid="menu-item-detail-panel"
       className="border-border bg-card flex flex-col gap-1 rounded-lg border p-4"
     >
-      <input
+      <Input
         type="text"
         data-testid="menu-item-detail-title"
         value={selected.title ?? ""}
-        className="border-input bg-background focus-visible:ring-ring h-9 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:outline-none"
         onChange={(event) => {
           const next = event.target.value;
           dispatch({

--- a/packages/plugins/menu/src/admin/MenusShell.test.tsx
+++ b/packages/plugins/menu/src/admin/MenusShell.test.tsx
@@ -617,10 +617,10 @@ describe("MenusShell", () => {
       expect(input.termId).toBe(7);
     });
 
-    test("delete-menu button matches the save button's padding and is destructive-styled", async () => {
-      // Regression: Delete rendered smaller (py-1) than Save (py-1.5) and
-      // without a destructive border. Both must share the size classes;
-      // Delete carries the destructive text/border.
+    test("delete-menu button matches the save button's size and is destructive-styled", async () => {
+      // Both render the shared `Button size="sm"`, so the size classes match
+      // by construction (the original regression was hand-rolled buttons with
+      // mismatched padding). Delete adds the destructive text/border.
       window.history.replaceState(
         {},
         "",
@@ -646,7 +646,7 @@ describe("MenusShell", () => {
 
       const save = await screen.findByTestId("menu-save-button");
       const del = await screen.findByTestId("menu-delete-button");
-      for (const cls of ["px-3", "py-1.5", "text-sm", "rounded"]) {
+      for (const cls of ["h-8", "px-3", "text-sm", "rounded-md"]) {
         expect(save.classList.contains(cls)).toBe(true);
         expect(del.classList.contains(cls)).toBe(true);
       }
@@ -734,15 +734,15 @@ describe("MenusShell", () => {
 
       renderShell();
 
-      const primary = await screen.findByTestId<HTMLInputElement>(
+      // The shared `Checkbox` renders a radix `<button role="checkbox">`,
+      // so checked-ness is `aria-checked`, not the native `.checked` prop.
+      const primary = await screen.findByTestId(
         "menu-settings-location-primary",
       );
-      expect(primary.checked).toBe(true);
+      expect(primary).toHaveAttribute("aria-checked", "true");
 
-      const footer = await screen.findByTestId<HTMLInputElement>(
-        "menu-settings-location-footer",
-      );
-      expect(footer.checked).toBe(false);
+      const footer = await screen.findByTestId("menu-settings-location-footer");
+      expect(footer).toHaveAttribute("aria-checked", "false");
 
       const user = userEvent.setup();
       await user.click(footer);

--- a/packages/plugins/menu/src/admin/MenusShell.tsx
+++ b/packages/plugins/menu/src/admin/MenusShell.tsx
@@ -1,6 +1,7 @@
 import type { MessageDescriptor } from "plumix/i18n";
 import type { ReactNode } from "react";
 import { useState } from "react";
+import { Button } from "plumix/admin/ui";
 import { Trans, useLingui } from "plumix/i18n";
 
 import type { MenuListItem, MenuLocationRow } from "./rpc.js";
@@ -132,29 +133,30 @@ function MenuSelector({
       className="flex flex-wrap items-center gap-2"
     >
       {menus.map((menu) => (
-        <button
+        <Button
           key={menu.id}
           type="button"
+          variant="outline"
+          size="sm"
           data-testid={`menus-selector-option-${menu.slug}`}
           onClick={() => {
             onSelect(menu.slug);
           }}
-          className="border-border hover:bg-muted rounded border bg-transparent px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
         >
           {menu.name}
-        </button>
+        </Button>
       ))}
-      <button
+      <Button
         type="button"
+        size="sm"
         data-testid="menus-selector-create-new"
         onClick={onCreate}
-        className="bg-primary text-primary-foreground hover:bg-primary/90 rounded px-3 py-1.5 text-sm disabled:cursor-not-allowed disabled:opacity-50"
       >
         <Trans
           id="plugin.menu.shell.createButton"
           message="+ Create new menu"
         />
-      </button>
+      </Button>
     </div>
   );
 }
@@ -173,20 +175,19 @@ function Tabs({
       className="border-border flex items-center gap-1 border-b"
     >
       {TABS.map((entry) => (
-        <button
+        <Button
           key={entry.id}
           type="button"
+          variant={activeTab === entry.id ? "secondary" : "ghost"}
+          size="sm"
           data-testid={`menus-tab-${entry.id}`}
           aria-selected={activeTab === entry.id}
           onClick={() => {
             onChange(entry.id);
           }}
-          className={`hover:bg-muted rounded px-3 py-1.5 text-sm ${
-            activeTab === entry.id ? "bg-muted font-medium" : ""
-          }`}
         >
           {i18n._(entry.label)}
-        </button>
+        </Button>
       ))}
     </div>
   );


### PR DESCRIPTION
Third plugin onto `plumix/admin/ui` (after media #1097 and comments #1098). The largest hand-rolled surface — ~19 buttons/inputs + a checkbox across the menus shell and item editor.

**Migrated**
- menu selector / tab / save / delete / picker-tab / relink / convert / remove / add `<button>` → `Button`
- max-depth, custom url+label, item-title `<input>` → `Input`
- location-binding `<input type="checkbox">` → `Checkbox`

**Deliberately left raw**
- the drag-handle `<button>` — it spreads dnd-kit `{...attributes} {...listeners}` and is e2e-pinned for reordering; wrapping it adds risk for no visual gain.
- the location-assignment `<select>` — a native select is simpler and more test-robust than a radix Select.

**Notes:** the custom url/label inputs get `flex-1` so the shared Input's `w-full` keeps them on one row (caught in review). Delete keeps the subtle outline-destructive look and row-removes use a red tint — matching comments' restraint for many-per-row actions rather than media's solid `destructive` (which suits a single prominent delete).

Chunk carries no radix copy (Checkbox resolves radix to the host shim) and the barrel tree-shakes to button/input/checkbox. Tests updated for the radix Checkbox (`aria-checked` not `.checked`) and shared Button size classes; menu suite (243 tests) green.

After this, **audit-log** is the only plugin left with hand-rolled admin UI.