### PR TITLE
test: harden the shared plumix/admin/ui surface

### DIFF
--- a/packages/admin-ui/README.md
+++ b/packages/admin-ui/README.md
@@ -30,3 +30,22 @@ The thin wrappers ship as bundled source through `plumix/admin/ui`; their
 `radix-ui` / `sonner` / `tailwind-merge` imports are aliased to the host
 runtime shims at plugin build time, so plugin chunks reuse the shell's single
 radix/sonner/tailwind-merge instance instead of bundling their own.
+
+## Stability
+
+`plumix/admin/ui` is a public API for third-party plugin authors, but these are
+vendored shadcn components we own and edit (via `ui:add`). It carries no
+guarantee beyond plumix's repo-wide policy: **pre-1.0, minor versions may
+contain breaking changes — pin your version.** A `ui:add` re-generation or a
+hand-edit to a component's markup/props counts as a breaking change under that
+policy, not a patch. Plugin authors should pin `plumix` and test their admin
+chunk against each minor before upgrading.
+
+## Conventions
+
+**Destructive actions.** A standalone or primary destructive button (a delete
+button, a confirm dialog's action) uses `<Button variant="destructive">`. A
+destructive action sitting inline among non-destructive peers (a ghost action
+toolbar, a per-row "Remove") uses `variant="ghost"` plus the shared
+`destructiveGhostClassName` — never a hand-rolled `text-destructive` string, so
+the surfaces can't drift on what "destructive" looks like.

--- a/packages/admin-ui/src/destructive.ts
+++ b/packages/admin-ui/src/destructive.ts
@@ -1,0 +1,12 @@
+// House style for destructive actions:
+//   - A standalone/primary destructive button (a delete button, a confirm
+//     dialog's action) uses `<Button variant="destructive">`.
+//   - A destructive action sitting *inline among non-destructive peers*
+//     (a ghost action toolbar, a per-row "Remove") uses `variant="ghost"`
+//     plus this shared tint — never a hand-rolled `text-destructive` string,
+//     so the surfaces can't drift on what "destructive" looks like.
+//
+// `hover:text-destructive` is explicit because the ghost variant otherwise
+// recolours its text on hover, which would wash out the destructive cue.
+export const destructiveGhostClassName =
+  "text-destructive hover:text-destructive";

--- a/packages/admin-ui/src/index.ts
+++ b/packages/admin-ui/src/index.ts
@@ -9,6 +9,7 @@ export * from "./card.js";
 export * from "./checkbox.js";
 export * from "./color-picker.js";
 export * from "./command.js";
+export * from "./destructive.js";
 export * from "./dialog.js";
 export * from "./dropdown-menu.js";
 export * from "./empty.js";

--- a/packages/admin/e2e/app-shell.spec.ts
+++ b/packages/admin/e2e/app-shell.spec.ts
@@ -41,4 +41,49 @@ test.describe("admin shell", () => {
     );
     expect(display).toBe("block");
   });
+
+  // RTL is a shipped launch locale (`ar`), so prove the direction context
+  // reaches radix primitives in a real browser — the unit guard in
+  // App.direction.test.tsx can't, since radix's behaviour depends on its
+  // own resolved package instance at runtime. SSR normally sets
+  // `<html dir>`; the SPA preview has no SSR, so seed it the same way the
+  // locale-switch reload path does, before the bundle boots.
+  //
+  // The assertion reads the `dir` attribute radix writes onto the menu's
+  // `role="menu"` element *from its DirectionProvider context* — not the
+  // CSS `direction`, which the portaled content would inherit from
+  // `<html dir>` regardless of whether the provider chain works. If the
+  // provider ever re-splits from the primitives (the original bug), this
+  // attribute reads "ltr" even under `<html dir="rtl">`.
+  test("radix primitives inherit RTL from the direction provider under ar", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      // At document-start `document.documentElement` isn't parsed yet, so
+      // defer to DOMContentLoaded — still well before the admin's deferred
+      // `createRoot().render()` reads `<html dir>` via `useDir()`.
+      const apply = (): void => {
+        document.documentElement.setAttribute("dir", "rtl");
+        document.documentElement.setAttribute("lang", "ar");
+      };
+      if (document.documentElement) apply();
+      else document.addEventListener("DOMContentLoaded", apply, { once: true });
+    });
+    await mockManifest(page, MANIFEST_WITH_POST);
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/entry/stats": [],
+      "/entry/recentActivity": [],
+    });
+    await page.goto("");
+
+    await page.getByTestId("user-menu-trigger").click();
+
+    const signOut = page.getByTestId("user-menu-sign-out");
+    await expect(signOut).toBeVisible();
+    const menuDir = await signOut.evaluate(
+      (el) => el.closest('[role="menu"]')?.getAttribute("dir") ?? null,
+    );
+    expect(menuDir).toBe("rtl");
+  });
 });

--- a/packages/admin/e2e/fixtures/runtime-proof-plugin/src/MediaLibrary.tsx
+++ b/packages/admin/e2e/fixtures/runtime-proof-plugin/src/MediaLibrary.tsx
@@ -112,6 +112,17 @@ export function MediaLibrary(): ReactNode {
         </TooltipContent>
       </Tooltip>
 
+      {/* A variant the admin shell never renders — proves shell CSS ships
+          every admin-ui cva variant via its `@source admin-ui/src` scan. */}
+      <Button
+        variant="ghost"
+        size="icon-xs"
+        data-testid="runtime-proof-ui-icon-button"
+        aria-label="icon"
+      >
+        +
+      </Button>
+
       <Link
         to="/"
         data-testid="runtime-proof-link"

--- a/packages/admin/e2e/plugins.spec.ts
+++ b/packages/admin/e2e/plugins.spec.ts
@@ -187,6 +187,21 @@ test.describe("plugin runtime alias seam", () => {
     await sharedButton.hover();
     await expect(page.getByTestId("runtime-proof-ui-tooltip")).toBeVisible();
 
+    // (5d) A shared-component *variant the admin shell never renders*
+    // (`size="icon-xs"`) still lands styled. The shell's globals.css
+    // `@source`s `admin-ui/src`, so Tailwind extracts every cva variant
+    // string from `button.tsx` — `icon-xs` → `size-6` ships in shell CSS
+    // even though no shell route uses it. Without that scan a plugin
+    // reaching an unused variant would render unstyled. `size-6` is
+    // 24×24 with no padding/border, so a styled button measures exactly
+    // 24px; an unstyled one sizes to its glyph.
+    const iconButton = page.getByTestId("runtime-proof-ui-icon-button");
+    const iconBox = await iconButton.evaluate((el) => {
+      const s = getComputedStyle(el);
+      return { width: s.width, height: s.height };
+    });
+    expect(iconBox).toEqual({ width: "24px", height: "24px" });
+
     // (6) Router hook navigates inside admin
     await page.getByTestId("runtime-proof-navigate").click();
     await expect(page).toHaveURL(/\/_plumix\/admin\/?$/);

--- a/packages/admin/src/App.direction.test.tsx
+++ b/packages/admin/src/App.direction.test.tsx
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { cleanup, render } from "@testing-library/react";
 import { Direction } from "radix-ui";
 import { afterEach, describe, expect, test } from "vitest";
@@ -34,4 +37,42 @@ describe("admin RTL direction context", () => {
 
     expect(getByTestId("resolved-dir")).toHaveTextContent("ltr");
   });
+});
+
+// The render test above proves the provider and hook agree *today*. It can't
+// catch the original failure mode: two copies of `@radix-ui/react-direction`
+// resolved in the tree (a direct dep pinned to one version, the `radix-ui`
+// umbrella pulling another) → two context instances → the provider feeds a
+// context the primitives never read. That's a dependency-graph fault, not a
+// rendering one, so it's guarded at the lockfile. If a future radix bump (or a
+// stray direct dep) re-forks one of these context-bearing packages, this fails
+// — extend the list when a new radix context package proves it can bite.
+const SINGLETON_RADIX_CONTEXT_PACKAGES = ["@radix-ui/react-direction"] as const;
+
+describe("radix context packages resolve to a single instance", () => {
+  const lockfile = readFileSync(
+    resolve(dirname(fileURLToPath(import.meta.url)), "../../../pnpm-lock.yaml"),
+    "utf8",
+  );
+
+  test.each(SINGLETON_RADIX_CONTEXT_PACKAGES)(
+    "%s has exactly one resolved version",
+    (pkg) => {
+      const escaped = pkg.replace(/[/\\^$*+?.()|[\]{}]/g, "\\$&");
+      const versions = new Set(
+        [
+          ...lockfile.matchAll(
+            new RegExp(`${escaped}@(\\d+\\.\\d+\\.\\d+)`, "g"),
+          ),
+        ].map((m) => m[1]),
+      );
+
+      expect(
+        [...versions],
+        `${pkg} resolved to multiple versions — run \`pnpm dedupe\` or add a ` +
+          `pnpm.overrides pin. Duplicate React-context packages split the ` +
+          `provider from its consumers (the RTL direction bug).`,
+      ).toHaveLength(1);
+    },
+  );
 });

--- a/packages/admin/src/components/shell/user-menu.tsx
+++ b/packages/admin/src/components/shell/user-menu.tsx
@@ -58,6 +58,7 @@ export function UserMenu({ user }: { user: UserIdentity }): ReactNode {
       <DropdownMenuTrigger asChild>
         <SidebarMenuButton
           size="lg"
+          data-testid="user-menu-trigger"
           className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
         >
           <Avatar className="size-8">

--- a/packages/plugins/comments/src/admin/CommentsShell.tsx
+++ b/packages/plugins/comments/src/admin/CommentsShell.tsx
@@ -1,6 +1,11 @@
 import type { MessageDescriptor } from "plumix/i18n";
 import { useState } from "react";
-import { Button, Checkbox, Input } from "plumix/admin/ui";
+import {
+  Button,
+  Checkbox,
+  destructiveGhostClassName,
+  Input,
+} from "plumix/admin/ui";
 import { Trans, useLingui } from "plumix/i18n";
 
 import type {
@@ -52,11 +57,9 @@ const ACTION_LABELS = {
 } satisfies Record<ModerationAction, MessageDescriptor>;
 
 // Approve/restore move a comment into a queue; everything else (spam,
-// trash, purge) is destructive and gets a red tint. `hover:text-destructive`
-// is explicit because the ghost Button variant otherwise recolors text on
-// hover. Shared by the bulk bar and the per-row actions so the two can't
-// drift on which actions count as destructive.
-const DESTRUCTIVE_ACTION_CLASS = "text-destructive hover:text-destructive";
+// trash, purge) is destructive and gets the shared ghost tint. Used by both
+// the bulk bar and the per-row actions so the two can't drift on which
+// actions count as destructive.
 function isDestructiveAction(action: string): boolean {
   return action !== "approve" && action !== "restore";
 }
@@ -198,7 +201,7 @@ export function CommentsShell(): React.ReactElement {
                 onClick={() => runBulk(action)}
                 className={
                   isDestructiveAction(action)
-                    ? DESTRUCTIVE_ACTION_CLASS
+                    ? destructiveGhostClassName
                     : undefined
                 }
               >
@@ -277,7 +280,7 @@ export function CommentsShell(): React.ReactElement {
                       }
                       className={
                         isDestructiveAction(action)
-                          ? DESTRUCTIVE_ACTION_CLASS
+                          ? destructiveGhostClassName
                           : undefined
                       }
                     >

--- a/packages/plugins/menu/src/admin/MenuItemEditor.tsx
+++ b/packages/plugins/menu/src/admin/MenuItemEditor.tsx
@@ -18,7 +18,12 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useQueryClient } from "@tanstack/react-query";
-import { Button, Checkbox, Input } from "plumix/admin/ui";
+import {
+  Button,
+  Checkbox,
+  destructiveGhostClassName,
+  Input,
+} from "plumix/admin/ui";
 import { Trans, useLingui } from "plumix/i18n";
 
 import type {
@@ -326,11 +331,10 @@ function DeleteMenuButton({ termId }: { readonly termId: number }): ReactNode {
   return (
     <Button
       type="button"
-      variant="outline"
+      variant="destructive"
       size="sm"
       data-testid="menu-delete-button"
       disabled={remove.isPending}
-      className="text-destructive border-destructive hover:bg-destructive/10 hover:text-destructive"
       onClick={() => {
         if (
           typeof window !== "undefined" &&
@@ -738,7 +742,7 @@ function SortableTreeRow({
         size="xs"
         data-testid={`menu-item-remove-${String(id)}`}
         disabled={isUnauthorized}
-        className="text-destructive hover:text-destructive"
+        className={destructiveGhostClassName}
         onClick={(event) => {
           event.stopPropagation();
           dispatch({ type: "removeItem", key: item.key });

--- a/packages/plugins/menu/src/admin/MenusShell.test.tsx
+++ b/packages/plugins/menu/src/admin/MenusShell.test.tsx
@@ -620,7 +620,7 @@ describe("MenusShell", () => {
     test("delete-menu button matches the save button's size and is destructive-styled", async () => {
       // Both render the shared `Button size="sm"`, so the size classes match
       // by construction (the original regression was hand-rolled buttons with
-      // mismatched padding). Delete adds the destructive text/border.
+      // mismatched padding). Delete uses the destructive variant (solid).
       window.history.replaceState(
         {},
         "",
@@ -650,8 +650,7 @@ describe("MenusShell", () => {
         expect(save.classList.contains(cls)).toBe(true);
         expect(del.classList.contains(cls)).toBe(true);
       }
-      expect(del.classList.contains("text-destructive")).toBe(true);
-      expect(del.classList.contains("border-destructive")).toBe(true);
+      expect(del.classList.contains("bg-destructive")).toBe(true);
     });
 
     test("a non-custom source tab is independently selectable and shows its panel", async () => {

--- a/packages/plumix/src/admin/ui.ts
+++ b/packages/plumix/src/admin/ui.ts
@@ -12,5 +12,10 @@
  * `radix-ui` / `sonner` / `tailwind-merge` imports are aliased to the shared
  * runtime shims — so the chunk carries only the thin wrappers (~1KB each),
  * not radix.
+ *
+ * Stability: these are vendored shadcn components we own and edit (via
+ * `ui:add`). This surface carries no guarantee beyond plumix's repo-wide
+ * pre-1.0 policy — minor versions may break it; pin `plumix`. See
+ * packages/admin-ui/README.md.
  */
 export * from "@plumix/admin-ui";


### PR DESCRIPTION
Follow-ups to the shared-shadcn adoption work ([#1097](https://github.com/withplumix/plumix/pull/1097)–[#1100](https://github.com/withplumix/plumix/pull/1100)), closing the review gaps that decide whether `plumix/admin/ui` actually holds up for third-party plugin authors. Each is its own commit; the organizing principle is verifying or locking in invariants the adoption work assumed but never tested.

- **Shell-unused variants ship styled.** The whole "plugins reuse shell CSS" value rested on an untested assumption. `globals.css` `@source`s `admin-ui/src`, so Tailwind extracts every cva variant string from `button.tsx` even for variants no shell route renders. A new e2e renders an `icon-xs` button in the runtime-proof fixture and asserts its measured 24×24 box — turning the assumption into a contract.
- **Destructive buttons standardized.** Three plugins expressed destructive intent three ways. House style is now: standalone/primary → `variant="destructive"`; inline among ghost peers → the shared `destructiveGhostClassName` from admin-ui. Menu's delete button goes solid; menu's per-item remove and comments' bulk/row actions drop their hand-rolled `text-destructive` strings.
- **Radix single-instance guard.** The RTL bug was two copies of `@radix-ui/react-direction` in the tree. The existing render test can't see a dependency-graph fork, so a lockfile assertion now fails CI if a context-bearing radix package resolves to more than one version.
- **RTL verified in a browser.** `ar` is a shipped launch locale with no prior browser coverage. A new e2e seeds `<html dir>`, opens the shell's radix dropdown, and asserts the `dir` attribute radix writes from its provider context (not inherited CSS direction) — so a future provider re-split reads `ltr` and fails.
- **Stability documented.** `plumix/admin/ui` is public but ships vendored shadcn we edit via `ui:add`. The README + the public doc-comment now state it carries no guarantee beyond the repo-wide pre-1.0 policy and that a `ui:add` regeneration is a breaking change.

Out of scope: the publish blocker (`plumix/admin/ui` re-exports the private `@plumix/admin-ui`, same as `plumix/blocks`/`plumix/core`). It is one uniform problem already tracked for the 0.1.0 gauntlet in `PLAN.md`; whatever inlines/publishes the private workspace deps must cover `admin-ui`, but there is nothing actionable before then.

Review order: the two e2e specs (`plugins.spec.ts`, `app-shell.spec.ts`) first, then the destructive refactor across admin-ui + the two plugins.