### PR TITLE
refactor: route raw throws through named error factories

### DIFF
--- a/packages/core/src/config.errors.ts
+++ b/packages/core/src/config.errors.ts
@@ -1,0 +1,27 @@
+type ConfigErrorCode = "magic_link_requires_mailer";
+
+/**
+ * Cross-field config invariant violated in {@link plumix} — surfaced at app
+ * build time rather than on the first request. Mirrors the named-error
+ * convention (umbrella #232).
+ */
+export class ConfigError extends Error {
+  static {
+    ConfigError.prototype.name = "ConfigError";
+  }
+
+  readonly code: ConfigErrorCode;
+
+  private constructor(code: ConfigErrorCode, message: string) {
+    super(message);
+    this.code = code;
+  }
+
+  static magicLinkRequiresMailer(): ConfigError {
+    return new ConfigError(
+      "magic_link_requires_mailer",
+      "plumix(): `auth.magicLink` requires a top-level `mailer` " +
+        "(use `consoleMailer()` for dev or pass your own `Mailer`).",
+    );
+  }
+}

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -15,6 +15,7 @@ import type {
 } from "./runtime/slots.js";
 import type { ThemeDescriptor } from "./theme.js";
 import { normalizeBasePath } from "./base-path.js";
+import { ConfigError } from "./config.errors.js";
 import { resolveLocales } from "./i18n/locale-registry.js";
 import { welcomeTheme } from "./welcome-theme.js";
 
@@ -166,11 +167,7 @@ export function plumix(config: PlumixConfigInput): PlumixConfig {
   // today) need a configured mailer at the top level. Surface this at
   // app build time rather than letting it crash on the first request.
   if (config.auth.magicLink && !config.mailer) {
-    // eslint-disable-next-line no-restricted-syntax -- TODO migrate to a named factory in a follow-up slice
-    throw new Error(
-      "plumix(): `auth.magicLink` requires a top-level `mailer` " +
-        "(use `consoleMailer()` for dev or pass your own `Mailer`).",
-    );
+    throw ConfigError.magicLinkRequiresMailer();
   }
   return {
     runtime: config.runtime,

--- a/packages/core/src/context/app.ts
+++ b/packages/core/src/context/app.ts
@@ -29,6 +29,7 @@ import { defaultAuthenticator } from "../auth/authenticator.js";
 import { createCapabilityResolver } from "../auth/rbac.js";
 import { resolveLocales } from "../i18n/locale-registry.js";
 import { resolveLocale } from "../i18n/resolve-locale.js";
+import { ContextError } from "./errors.js";
 
 const EMPTY_BLOCK_REGISTRY: BlockRegistry = createBlockRegistry([]);
 const EMPTY_MARK_LIST: readonly MarkSpec[] = Object.freeze([]);
@@ -412,12 +413,7 @@ export function createAppContext<TSchema extends Record<string, unknown>>(
       // fails fast on the first request rather than silently
       // corrupting `db` / `auth` / etc. for the rest of the process.
       if (key in target) {
-        // eslint-disable-next-line no-restricted-syntax -- TODO migrate to a named factory in a follow-up slice
-        throw new Error(
-          `appContextExtensions entry "${key}" shadows a built-in ` +
-            `AppContext field. Reserve plugin-scoped names; built-in ` +
-            `members like \`db\` and \`auth\` aren't extendable.`,
-        );
+        throw ContextError.appContextExtensionShadowsBuiltin(key);
       }
       target[key] = entry.value;
     }

--- a/packages/core/src/context/errors.ts
+++ b/packages/core/src/context/errors.ts
@@ -1,0 +1,41 @@
+type ContextErrorCode =
+  | "no_request_context"
+  | "app_context_extension_shadows_builtin";
+
+/**
+ * Request/app-context invariant violated. `no_request_context` means an
+ * accessor ran outside `requestStore.run()`; the shadow code means a
+ * malformed extension map reached context assembly. Named-error convention
+ * (#232).
+ */
+export class ContextError extends Error {
+  static {
+    ContextError.prototype.name = "ContextError";
+  }
+
+  readonly code: ContextErrorCode;
+  readonly key: string | undefined;
+
+  private constructor(code: ContextErrorCode, message: string, key?: string) {
+    super(message);
+    this.code = code;
+    this.key = key;
+  }
+
+  static noRequestContext(): ContextError {
+    return new ContextError(
+      "no_request_context",
+      "No request context — getContext() called outside requestStore.run()",
+    );
+  }
+
+  static appContextExtensionShadowsBuiltin(key: string): ContextError {
+    return new ContextError(
+      "app_context_extension_shadows_builtin",
+      `appContextExtensions entry "${key}" shadows a built-in ` +
+        `AppContext field. Reserve plugin-scoped names; built-in ` +
+        `members like \`db\` and \`auth\` aren't extendable.`,
+      key,
+    );
+  }
+}

--- a/packages/core/src/context/stores.ts
+++ b/packages/core/src/context/stores.ts
@@ -4,6 +4,7 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 
 import type { AppContext } from "./app.js";
+import { ContextError } from "./errors.js";
 
 export const requestStore = new AsyncLocalStorage<AppContext>();
 
@@ -27,11 +28,7 @@ export const txStore = new AsyncLocalStorage<unknown>();
 
 export function getContext(): AppContext {
   const ctx = requestStore.getStore();
-  if (!ctx)
-    // eslint-disable-next-line no-restricted-syntax -- TODO migrate to a named factory in a follow-up slice
-    throw new Error(
-      "No request context — getContext() called outside requestStore.run()",
-    );
+  if (!ctx) throw ContextError.noRequestContext();
   return ctx;
 }
 

--- a/packages/core/src/i18n/errors.ts
+++ b/packages/core/src/i18n/errors.ts
@@ -1,0 +1,51 @@
+type I18nConfigErrorCode =
+  | "default_locale_not_listed"
+  | "default_locale_disabled"
+  | "invalid_direction"
+  | "invalid_locale_tag";
+
+/**
+ * i18n config invariant violated while resolving {@link plumix}'s `i18n`
+ * block. The `code` discriminant carries which rule failed; the offending
+ * value is interpolated into the message. Named-error convention (#232).
+ */
+export class I18nConfigError extends Error {
+  static {
+    I18nConfigError.prototype.name = "I18nConfigError";
+  }
+
+  readonly code: I18nConfigErrorCode;
+
+  private constructor(code: I18nConfigErrorCode, message: string) {
+    super(message);
+    this.code = code;
+  }
+
+  static defaultLocaleNotListed(defaultLocale: string): I18nConfigError {
+    return new I18nConfigError(
+      "default_locale_not_listed",
+      `plumix(): i18n.defaultLocale ${JSON.stringify(defaultLocale)} is not present in i18n.locales.`,
+    );
+  }
+
+  static defaultLocaleDisabled(defaultLocale: string): I18nConfigError {
+    return new I18nConfigError(
+      "default_locale_disabled",
+      `plumix(): i18n.defaultLocale ${JSON.stringify(defaultLocale)} cannot be marked enabled:false.`,
+    );
+  }
+
+  static invalidDirection(code: string, raw: unknown): I18nConfigError {
+    return new I18nConfigError(
+      "invalid_direction",
+      `plumix(): i18n locale ${JSON.stringify(code)} direction must be "ltr" or "rtl", got ${JSON.stringify(raw)}.`,
+    );
+  }
+
+  static invalidLocaleTag(raw: string): I18nConfigError {
+    return new I18nConfigError(
+      "invalid_locale_tag",
+      `plumix(): i18n locale code ${JSON.stringify(raw)} is not a valid BCP 47 tag.`,
+    );
+  }
+}

--- a/packages/core/src/i18n/locale-registry.ts
+++ b/packages/core/src/i18n/locale-registry.ts
@@ -1,4 +1,5 @@
 import type { AuthenticatedUser } from "../context/app.js";
+import { I18nConfigError } from "./errors.js";
 
 export type LocaleDirection = "ltr" | "rtl";
 
@@ -48,16 +49,10 @@ export function resolveLocales(input: I18nInput): ResolvedI18n {
   const defaultCode = canonicalizeLocaleCode(input.defaultLocale);
   const defaultLocale = locales.find((l) => l.code === defaultCode);
   if (!defaultLocale) {
-    // eslint-disable-next-line no-restricted-syntax -- TODO migrate to a named factory in a follow-up slice
-    throw new Error(
-      `plumix(): i18n.defaultLocale ${JSON.stringify(input.defaultLocale)} is not present in i18n.locales.`,
-    );
+    throw I18nConfigError.defaultLocaleNotListed(input.defaultLocale);
   }
   if (!defaultLocale.enabled) {
-    // eslint-disable-next-line no-restricted-syntax -- TODO migrate to a named factory in a follow-up slice
-    throw new Error(
-      `plumix(): i18n.defaultLocale ${JSON.stringify(input.defaultLocale)} cannot be marked enabled:false.`,
-    );
+    throw I18nConfigError.defaultLocaleDisabled(input.defaultLocale);
   }
   return { defaultLocale, locales, resolveLocale: input.resolveLocale };
 }
@@ -83,20 +78,14 @@ function normalizeEntry(entry: string | LocaleInput): ResolvedLocale {
 // union via `as any` can't punch out of the attribute.
 function validateDirection(raw: unknown, code: string): LocaleDirection {
   if (raw === "ltr" || raw === "rtl") return raw;
-  // eslint-disable-next-line no-restricted-syntax -- TODO migrate to a named factory in a follow-up slice
-  throw new Error(
-    `plumix(): i18n locale ${JSON.stringify(code)} direction must be "ltr" or "rtl", got ${JSON.stringify(raw)}.`,
-  );
+  throw I18nConfigError.invalidDirection(code, raw);
 }
 
 function canonicalize(raw: string): Intl.Locale {
   try {
     return new Intl.Locale(raw.replace(/_/g, "-"));
   } catch {
-    // eslint-disable-next-line no-restricted-syntax -- TODO migrate to a named factory in a follow-up slice
-    throw new Error(
-      `plumix(): i18n locale code ${JSON.stringify(raw)} is not a valid BCP 47 tag.`,
-    );
+    throw I18nConfigError.invalidLocaleTag(raw);
   }
 }
 

--- a/packages/core/src/rpc/meta/core.ts
+++ b/packages/core/src/rpc/meta/core.ts
@@ -10,6 +10,7 @@ import type {
   ReferenceTarget,
 } from "../../plugin/manifest.js";
 import { eq } from "../../db/index.js";
+import { MetaReferenceError } from "./errors.js";
 
 // Shared meta plumbing for every entity that stores a `meta` JSON
 // column (entries, terms, and — eventually — users). The storage
@@ -453,11 +454,7 @@ function referenceGroupKey(target: ReferenceTarget): string {
   try {
     return `${target.kind}::${JSON.stringify(target.scope ?? null)}`;
   } catch (cause) {
-    // eslint-disable-next-line no-restricted-syntax -- TODO migrate to a named factory in a follow-up slice
-    throw new Error(
-      `lookup adapter scope for kind "${target.kind}" must be JSON-serializable`,
-      { cause },
-    );
+    throw MetaReferenceError.scopeNotSerializable(target.kind, cause);
   }
 }
 
@@ -479,9 +476,10 @@ async function fetchLiveRows(
   callsite: string,
 ): Promise<readonly LookupResult[]> {
   if (ids.size > MAX_REFERENCE_GROUP_BATCH) {
-    // eslint-disable-next-line no-restricted-syntax -- TODO migrate to a named factory in a follow-up slice
-    throw new Error(
-      `${callsite}: aggregated batch size ${ids.size} exceeds MAX_REFERENCE_GROUP_BATCH (${MAX_REFERENCE_GROUP_BATCH})`,
+    throw MetaReferenceError.batchSizeExceeded(
+      callsite,
+      ids.size,
+      MAX_REFERENCE_GROUP_BATCH,
     );
   }
   const idList = [...ids];
@@ -1077,10 +1075,7 @@ function coerceOnRead(type: MetaScalarType, value: unknown): unknown {
 // via a crafted path.
 function metaJsonPath(key: string): string {
   if (/["\\]/.test(key)) {
-    // eslint-disable-next-line no-restricted-syntax -- TODO migrate to a named factory in a follow-up slice
-    throw new Error(
-      `meta key "${key}" contains characters forbidden in a JSON path`,
-    );
+    throw MetaReferenceError.metaKeyForbiddenChars(key);
   }
   return `$."${key}"`;
 }

--- a/packages/core/src/rpc/meta/errors.ts
+++ b/packages/core/src/rpc/meta/errors.ts
@@ -1,0 +1,56 @@
+type MetaReferenceErrorCode =
+  | "scope_not_serializable"
+  | "batch_size_exceeded"
+  | "meta_key_forbidden_chars";
+
+/**
+ * Reference-resolution invariant violated while batching meta lookups: a
+ * scope that won't `JSON.stringify`, an aggregated batch past the hard cap,
+ * or a meta key carrying characters forbidden in a JSON path. Named-error
+ * convention (#232).
+ */
+export class MetaReferenceError extends Error {
+  static {
+    MetaReferenceError.prototype.name = "MetaReferenceError";
+  }
+
+  readonly code: MetaReferenceErrorCode;
+
+  private constructor(
+    code: MetaReferenceErrorCode,
+    message: string,
+    options?: { cause?: unknown },
+  ) {
+    super(message, options);
+    this.code = code;
+  }
+
+  static scopeNotSerializable(
+    kind: string,
+    cause: unknown,
+  ): MetaReferenceError {
+    return new MetaReferenceError(
+      "scope_not_serializable",
+      `lookup adapter scope for kind "${kind}" must be JSON-serializable`,
+      { cause },
+    );
+  }
+
+  static batchSizeExceeded(
+    callsite: string,
+    size: number,
+    limit: number,
+  ): MetaReferenceError {
+    return new MetaReferenceError(
+      "batch_size_exceeded",
+      `${callsite}: aggregated batch size ${size} exceeds MAX_REFERENCE_GROUP_BATCH (${limit})`,
+    );
+  }
+
+  static metaKeyForbiddenChars(key: string): MetaReferenceError {
+    return new MetaReferenceError(
+      "meta_key_forbidden_chars",
+      `meta key "${key}" contains characters forbidden in a JSON path`,
+    );
+  }
+}

--- a/packages/core/src/rpc/procedures/entry/lookup.ts
+++ b/packages/core/src/rpc/procedures/entry/lookup.ts
@@ -6,6 +6,7 @@ import type { LookupAdapter, LookupResult } from "../../../plugin/lookup.js";
 import { and, eq, inArray, like, ne } from "../../../db/index.js";
 import { entries } from "../../../db/schema/entries.js";
 import { buildEntryPermalink } from "../../../route/permalink.js";
+import { LookupScopeError } from "../lookup.errors.js";
 
 const DEFAULT_LIST_LIMIT = 20;
 const MAX_LIST_LIMIT = 100;
@@ -94,10 +95,7 @@ function scopeConditions(scope: EntryFieldScope | undefined): SQL[] {
   // turn the picker into a "list every entry across every type" channel
   // bypassing per-type read scoping.
   if (!scope?.entryTypes || scope.entryTypes.length === 0) {
-    // eslint-disable-next-line no-restricted-syntax -- TODO migrate to a named factory in a follow-up slice
-    throw new Error(
-      "entry adapter: scope.entryTypes is required and must be non-empty",
-    );
+    throw LookupScopeError.entryTypesRequired();
   }
   const conditions: SQL[] = [
     inArray(entries.type, scope.entryTypes as string[]),

--- a/packages/core/src/rpc/procedures/lookup.errors.ts
+++ b/packages/core/src/rpc/procedures/lookup.errors.ts
@@ -1,0 +1,34 @@
+type LookupScopeErrorCode = "entry_types_required" | "term_taxonomies_required";
+
+/**
+ * A lookup adapter was called without the scope filter that enforces
+ * per-type / per-taxonomy read scoping. Thrown at runtime (not just the
+ * builder's TS level) because a wire-side caller could omit it and turn the
+ * picker into an unscoped enumeration channel. Named-error convention (#232).
+ */
+export class LookupScopeError extends Error {
+  static {
+    LookupScopeError.prototype.name = "LookupScopeError";
+  }
+
+  readonly code: LookupScopeErrorCode;
+
+  private constructor(code: LookupScopeErrorCode, message: string) {
+    super(message);
+    this.code = code;
+  }
+
+  static entryTypesRequired(): LookupScopeError {
+    return new LookupScopeError(
+      "entry_types_required",
+      "entry adapter: scope.entryTypes is required and must be non-empty",
+    );
+  }
+
+  static termTaxonomiesRequired(): LookupScopeError {
+    return new LookupScopeError(
+      "term_taxonomies_required",
+      "term adapter: scope.termTaxonomies is required and must be non-empty",
+    );
+  }
+}

--- a/packages/core/src/rpc/procedures/term/lookup.ts
+++ b/packages/core/src/rpc/procedures/term/lookup.ts
@@ -6,6 +6,7 @@ import type { LookupAdapter, LookupResult } from "../../../plugin/lookup.js";
 import { and, eq, inArray, like, or } from "../../../db/index.js";
 import { terms } from "../../../db/schema/terms.js";
 import { buildTermArchiveUrl } from "../../../route/permalink.js";
+import { LookupScopeError } from "../lookup.errors.js";
 
 const DEFAULT_LIST_LIMIT = 20;
 const MAX_LIST_LIMIT = 100;
@@ -93,10 +94,7 @@ function scopeConditions(scope: TermFieldScope | undefined): SQL[] {
   // omit it and would otherwise enumerate every term across every
   // taxonomy.
   if (!scope?.termTaxonomies || scope.termTaxonomies.length === 0) {
-    // eslint-disable-next-line no-restricted-syntax -- TODO migrate to a named factory in a follow-up slice
-    throw new Error(
-      "term adapter: scope.termTaxonomies is required and must be non-empty",
-    );
+    throw LookupScopeError.termTaxonomiesRequired();
   }
   return [inArray(terms.taxonomy, scope.termTaxonomies as string[])];
 }

--- a/packages/plugins/audit-log/src/server/errors.ts
+++ b/packages/plugins/audit-log/src/server/errors.ts
@@ -1,0 +1,26 @@
+type AuditLogConfigErrorCode = "invalid_retention_max_age";
+
+/**
+ * Audit-log config that would corrupt the log if accepted (a non-finite or
+ * negative `maxAgeDays` puts the retention cutoff in the future or no-ops the
+ * SQL). Named-error convention (#232).
+ */
+export class AuditLogConfigError extends Error {
+  static {
+    AuditLogConfigError.prototype.name = "AuditLogConfigError";
+  }
+
+  readonly code: AuditLogConfigErrorCode;
+
+  private constructor(code: AuditLogConfigErrorCode, message: string) {
+    super(message);
+    this.code = code;
+  }
+
+  static invalidRetentionMaxAge(received: unknown): AuditLogConfigError {
+    return new AuditLogConfigError(
+      "invalid_retention_max_age",
+      `[plumix/plugin-audit-log] retention.maxAgeDays must be a non-negative finite number (got ${String(received)})`,
+    );
+  }
+}

--- a/packages/plugins/audit-log/src/server/retention.ts
+++ b/packages/plugins/audit-log/src/server/retention.ts
@@ -1,6 +1,7 @@
 import type { AppContext } from "plumix/plugin";
 
 import type { AuditLogStorage } from "../types.js";
+import { AuditLogConfigError } from "./errors.js";
 
 export interface AuditLogRetentionPolicy {
   readonly maxAgeDays: number;
@@ -35,10 +36,7 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 export function assertValidRetention(retention: AuditLogRetentionConfig): void {
   if (retention === false) return;
   if (!Number.isFinite(retention.maxAgeDays) || retention.maxAgeDays < 0) {
-    // eslint-disable-next-line no-restricted-syntax -- TODO migrate to a named factory in a follow-up slice
-    throw new Error(
-      `[plumix/plugin-audit-log] retention.maxAgeDays must be a non-negative finite number (got ${retention.maxAgeDays})`,
-    );
+    throw AuditLogConfigError.invalidRetentionMaxAge(retention.maxAgeDays);
   }
 }
 

--- a/packages/plumix/src/vite/index.ts
+++ b/packages/plumix/src/vite/index.ts
@@ -170,9 +170,11 @@ export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
       if (userConfig.publicDir === undefined) {
         base.publicDir = ".plumix/public";
       }
-      // TODO: triple loadConfig per cold start (config + buildStart + CLI).
-      // Cache via a closure once moduleCache:false in load-config.ts is
-      // safe to relax.
+      // Loaded fresh (not memoized) on purpose: the dev watcher in
+      // `configureServer` re-runs `regenerate` -> `loadConfig` on every
+      // `plumix.config.ts` edit, so a path-keyed cache here would break
+      // config hot-reload. Deduping the cold-start fan-out needs
+      // watch-aware invalidation — tracked in #1102.
       const { config } = await loadConfig(scanRoot, options.configFile);
       return config.vite
         ? (mergeConfig(


### PR DESCRIPTION
Clears the 14 in-code `TODO`/`FIXME` markers in `src/`. Thirteen were the same thing: a guard clause throwing `new Error(...)` with an `eslint-disable … TODO migrate to a named factory` suppression, because the named-errors convention (umbrella #232) bans raw throws in production `src/`. This adds the missing per-area `errors.ts` factories and routes every site through them, dropping the suppressions.

New factories, mirroring the existing `AppBootError`/`MenuPluginError` shape (code union + `static {}` name + private ctor + static factory methods):

- `core/config.errors.ts` — `ConfigError` (magic-link requires mailer)
- `core/i18n/errors.ts` — `I18nConfigError` (4 locale-config invariants)
- `core/context/errors.ts` — `ContextError` (missing request context, extension shadows builtin)
- `core/rpc/procedures/lookup.errors.ts` — `LookupScopeError` (entry/term scope required)
- `core/rpc/meta/errors.ts` — `MetaReferenceError` (scope serializable, batch cap, JSON-path key)
- `plugins/audit-log/server/errors.ts` — `AuditLogConfigError` (retention bounds)

Every message string is preserved verbatim, so the existing `.toThrow(/…/)` assertions keep passing — pure refactor, no behavior change. Verified: lint + typecheck + knip + format green, core's 2275 tests pass.

The 14th marker was a different beast — a perf TODO in `vite/index.ts` suggesting `loadConfig` be cached. It can't be: the dev watcher re-runs `regenerate → loadConfig` on every `plumix.config.ts` edit to hot-reload config, so a path-keyed cache would serve stale config. That commit replaces the misleading note with the real constraint and tracks the (watch-aware) cold-start dedup in #1102.

Closes the in-code TODO cleanup; refs #1102.