### PR TITLE
feat: bespoke editor spine — edit gate, bridge, store, ssr wiring

### DIFF
--- a/packages/admin-editor/eslint.config.ts
+++ b/packages/admin-editor/eslint.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "eslint/config";
+
+import { baseConfig } from "@plumix/eslint-config/base";
+import { reactConfig } from "@plumix/eslint-config/react";
+
+export default defineConfig(baseConfig, reactConfig);

--- a/packages/admin-editor/package.json
+++ b/packages/admin-editor/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@plumix/admin-editor",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "git clean -xdf .cache .turbo dist node_modules",
+    "format": "prettier --check . --ignore-path ../../.gitignore",
+    "lint": "eslint",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit --emitDeclarationOnly false"
+  },
+  "dependencies": {
+    "@plumix/blocks": "workspace:*",
+    "zustand": "^5.0.14"
+  },
+  "peerDependencies": {
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@plumix/eslint-config": "workspace:*",
+    "@plumix/prettier-config": "workspace:*",
+    "@plumix/typescript-config": "workspace:*",
+    "@plumix/vitest-config": "workspace:*",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "eslint": "catalog:",
+    "jsdom": "catalog:",
+    "prettier": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "prettier": "@plumix/prettier-config"
+}

--- a/packages/admin-editor/src/connect-canvas.test.ts
+++ b/packages/admin-editor/src/connect-canvas.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { BlockNode } from "@plumix/blocks";
+import { EDITOR_BRIDGE_CHANNEL, encode } from "@plumix/blocks/renderer";
+
+import { connectCanvas } from "./connect-canvas.js";
+import { createEditorStore } from "./store.js";
+
+const ORIGIN = "http://localhost:3000";
+
+function fakeFrame(): { win: Window; posted: unknown[] } {
+  const posted: unknown[] = [];
+  const win = {
+    postMessage: (data: unknown) => posted.push(data),
+  } as unknown as Window;
+  return { win, posted };
+}
+
+function fromCanvas(message: unknown, origin = ORIGIN): void {
+  window.dispatchEvent(
+    new MessageEvent("message", {
+      data: encode(EDITOR_BRIDGE_CHANNEL, message),
+      origin,
+    }),
+  );
+}
+
+function hostMessages(posted: unknown[]): { type?: string; tree?: unknown }[] {
+  return posted
+    .map((p) => (p as { message?: { type?: string } }).message)
+    .filter((m): m is { type?: string } => m != null && "type" in m);
+}
+
+describe("connectCanvas", () => {
+  test("pushes the current tree when the canvas reports ready", () => {
+    const tree: readonly BlockNode[] = [{ id: "a", name: "core/heading" }];
+    const store = createEditorStore({ tree });
+    const { win, posted } = fakeFrame();
+    const conn = connectCanvas({ store, frameWindow: win, origin: ORIGIN });
+
+    fromCanvas({ type: "canvas:ready" });
+
+    const treeMsg = hostMessages(posted).find((m) => m.type === "host:tree");
+    expect(treeMsg?.tree).toEqual(tree);
+    conn.dispose();
+  });
+
+  test("a canvas:select message updates the store's active block", () => {
+    const store = createEditorStore();
+    const { win } = fakeFrame();
+    const conn = connectCanvas({ store, frameWindow: win, origin: ORIGIN });
+
+    fromCanvas({ type: "canvas:select", id: "x" });
+
+    expect(store.getState().activeId).toBe("x");
+    conn.dispose();
+  });
+
+  test("re-pushes the tree when the store tree changes after ready", () => {
+    const store = createEditorStore();
+    const { win, posted } = fakeFrame();
+    const conn = connectCanvas({ store, frameWindow: win, origin: ORIGIN });
+    fromCanvas({ type: "canvas:ready" });
+    posted.length = 0;
+
+    const next: readonly BlockNode[] = [{ id: "b", name: "core/quote" }];
+    store.getState().setTree(next);
+
+    const treeMsg = hostMessages(posted).find((m) => m.type === "host:tree");
+    expect(treeMsg?.tree).toEqual(next);
+    conn.dispose();
+  });
+
+  test("re-announces hello until the canvas acks, then stops", () => {
+    vi.useFakeTimers();
+    try {
+      const store = createEditorStore();
+      const { win, posted } = fakeFrame();
+      const conn = connectCanvas({ store, frameWindow: win, origin: ORIGIN });
+      const helloCount = (): number =>
+        posted.filter(
+          (p) =>
+            (p as { message?: { kind?: string } }).message?.kind === "hello",
+        ).length;
+
+      expect(helloCount()).toBe(1); // sent once on connect
+      vi.advanceTimersByTime(500);
+      expect(helloCount()).toBeGreaterThan(1); // retried while waiting
+
+      const afterAck = helloCount();
+      fromCanvas({ kind: "ack" });
+      vi.advanceTimersByTime(500);
+      expect(helloCount()).toBe(afterAck); // stops once ready
+
+      conn.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("ignores messages from a foreign origin", () => {
+    const store = createEditorStore();
+    const { win } = fakeFrame();
+    const conn = connectCanvas({ store, frameWindow: win, origin: ORIGIN });
+
+    fromCanvas({ type: "canvas:select", id: "evil" }, "http://evil.test");
+
+    expect(store.getState().activeId).toBeNull();
+    conn.dispose();
+  });
+});

--- a/packages/admin-editor/src/connect-canvas.ts
+++ b/packages/admin-editor/src/connect-canvas.ts
@@ -1,0 +1,118 @@
+import type {
+  BlockRect,
+  CanvasMessage,
+  HostMessage,
+} from "@plumix/blocks/renderer";
+import {
+  createHandshake,
+  EDITOR_BRIDGE_CHANNEL,
+  encode,
+  parseEnvelope,
+} from "@plumix/blocks/renderer";
+
+import type { EditorStoreApi } from "./store.js";
+
+export interface CanvasConnection {
+  /** Resolves once the canvas has completed the handshake. */
+  readonly whenReady: Promise<void>;
+  readonly dispose: () => void;
+}
+
+interface ConnectCanvasOptions {
+  readonly store: EditorStoreApi;
+  /** The iframe's `contentWindow`. */
+  readonly frameWindow: Window;
+  /** Expected origin of the canvas iframe; messages from elsewhere are dropped. */
+  readonly origin: string;
+  /** Latest block geometry, for the shell to draw selection/hover overlays. */
+  readonly onGeometry?: (rects: readonly BlockRect[]) => void;
+}
+
+// The iframe runtime usually boots after the parent mounts, so a single hello
+// would race; re-announce on this interval until the canvas acks.
+const HANDSHAKE_RETRY_MS = 250;
+
+function isHandshakeFrame(
+  message: object,
+): message is { readonly kind: string } {
+  return (
+    "kind" in message &&
+    typeof (message as { kind?: unknown }).kind === "string"
+  );
+}
+
+/**
+ * Parent half of the editor bridge. The canvas never mutates the tree — it
+ * only reports intent, and this turns those reports into store actions.
+ */
+export function connectCanvas({
+  store,
+  frameWindow,
+  origin,
+  onGeometry,
+}: ConnectCanvasOptions): CanvasConnection {
+  const post = (message: object): void => {
+    frameWindow.postMessage(encode(EDITOR_BRIDGE_CHANNEL, message), origin);
+  };
+  const handshake = createHandshake({ role: "initiator", post });
+
+  const pushTree = (): void => {
+    post({
+      type: "host:tree",
+      tree: store.getState().tree,
+    } satisfies HostMessage);
+  };
+
+  const onMessage = (event: MessageEvent): void => {
+    const message = parseEnvelope<object>(
+      EDITOR_BRIDGE_CHANNEL,
+      event.data,
+      event.origin,
+      origin,
+    );
+    if (!message) return;
+    if (isHandshakeFrame(message)) {
+      handshake.onMessage(message);
+      return;
+    }
+    const canvas = message as CanvasMessage;
+    switch (canvas.type) {
+      case "canvas:ready":
+        pushTree();
+        break;
+      case "canvas:select":
+        store.getState().select(canvas.id);
+        break;
+      case "canvas:hover":
+        store.getState().setHover(canvas.id);
+        break;
+      case "canvas:geometry":
+        onGeometry?.(canvas.rects);
+        break;
+    }
+  };
+
+  window.addEventListener("message", onMessage);
+
+  let previousTree = store.getState().tree;
+  const unsubscribe = store.subscribe((state) => {
+    if (state.tree !== previousTree) {
+      previousTree = state.tree;
+      pushTree();
+    }
+  });
+
+  // retry() no-ops once ready, so this is safe to fire until handshake resolves.
+  const retryTimer = setInterval(() => handshake.retry(), HANDSHAKE_RETRY_MS);
+  const whenReady = handshake.whenReady();
+  void whenReady.then(() => clearInterval(retryTimer));
+
+  return {
+    whenReady,
+    dispose: () => {
+      clearInterval(retryTimer);
+      window.removeEventListener("message", onMessage);
+      unsubscribe();
+    },
+  };
+}

--- a/packages/admin-editor/src/errors.ts
+++ b/packages/admin-editor/src/errors.ts
@@ -1,0 +1,15 @@
+export class EditorError extends Error {
+  static {
+    EditorError.prototype.name = "EditorError";
+  }
+
+  private constructor(message: string) {
+    super(message);
+  }
+
+  static missingProvider(): EditorError {
+    return new EditorError(
+      "useEditorStore must be used within <EditorProvider/>.",
+    );
+  }
+}

--- a/packages/admin-editor/src/index.ts
+++ b/packages/admin-editor/src/index.ts
@@ -1,0 +1,11 @@
+export { connectCanvas } from "./connect-canvas.js";
+export type { CanvasConnection } from "./connect-canvas.js";
+export { EditorProvider, useEditorStore } from "./provider.js";
+export { createEditorStore, MAX_ZOOM, MIN_ZOOM } from "./store.js";
+export type {
+  EditorActions,
+  EditorDevice,
+  EditorState,
+  EditorStore,
+  EditorStoreApi,
+} from "./store.js";

--- a/packages/admin-editor/src/provider.tsx
+++ b/packages/admin-editor/src/provider.tsx
@@ -1,0 +1,44 @@
+import type { ReactElement, ReactNode } from "react";
+import { createContext, useContext, useState } from "react";
+import { useStore } from "zustand";
+
+import type { BlockNode } from "@plumix/blocks";
+
+import type { EditorDevice, EditorStore, EditorStoreApi } from "./store.js";
+import { EditorError } from "./errors.js";
+import { createEditorStore } from "./store.js";
+
+const EditorStoreContext = createContext<EditorStoreApi | null>(null);
+
+/**
+ * Creates one store per editor instance (kept stable across renders) and
+ * shares it via context. Uncontrolled: `initialTree` seeds once — the host
+ * persists via callbacks and never feeds the tree back mid-session.
+ */
+export function EditorProvider({
+  initialTree,
+  device,
+  zoom,
+  children,
+}: {
+  readonly initialTree?: readonly BlockNode[];
+  readonly device?: EditorDevice;
+  readonly zoom?: number;
+  readonly children: ReactNode;
+}): ReactElement {
+  const [store] = useState<EditorStoreApi>(() =>
+    createEditorStore({ tree: initialTree, device, zoom }),
+  );
+
+  return (
+    <EditorStoreContext.Provider value={store}>
+      {children}
+    </EditorStoreContext.Provider>
+  );
+}
+
+export function useEditorStore<T>(selector: (state: EditorStore) => T): T {
+  const store = useContext(EditorStoreContext);
+  if (!store) throw EditorError.missingProvider();
+  return useStore(store, selector);
+}

--- a/packages/admin-editor/src/store.test.ts
+++ b/packages/admin-editor/src/store.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "vitest";
+
+import type { BlockNode } from "@plumix/blocks";
+
+import { createEditorStore, MAX_ZOOM, MIN_ZOOM } from "./store.js";
+
+describe("editor store", () => {
+  test("select replaces the selection and marks the block active", () => {
+    const store = createEditorStore();
+
+    store.getState().select("a");
+    expect(store.getState().activeId).toBe("a");
+    expect([...store.getState().selectedIds]).toEqual(["a"]);
+
+    store.getState().select("b");
+    expect(store.getState().activeId).toBe("b");
+    expect([...store.getState().selectedIds]).toEqual(["b"]);
+  });
+
+  test("additive select extends the set, keeping the latest as active", () => {
+    const store = createEditorStore();
+
+    store.getState().select("a");
+    store.getState().select("b", { additive: true });
+
+    expect([...store.getState().selectedIds].sort()).toEqual(["a", "b"]);
+    expect(store.getState().activeId).toBe("b");
+  });
+
+  test("clearSelection empties the set and the active block", () => {
+    const store = createEditorStore();
+    store.getState().select("a");
+
+    store.getState().clearSelection();
+
+    expect(store.getState().activeId).toBeNull();
+    expect(store.getState().selectedIds.size).toBe(0);
+  });
+
+  test("zoom is clamped to the allowed range", () => {
+    const store = createEditorStore();
+
+    store.getState().setZoom(99);
+    expect(store.getState().zoom).toBe(MAX_ZOOM);
+
+    store.getState().setZoom(0);
+    expect(store.getState().zoom).toBe(MIN_ZOOM);
+  });
+
+  test("setTree replaces the canonical tree", () => {
+    const store = createEditorStore();
+    const tree: readonly BlockNode[] = [{ id: "x", name: "core/heading" }];
+
+    store.getState().setTree(tree);
+
+    expect(store.getState().tree).toBe(tree);
+  });
+});

--- a/packages/admin-editor/src/store.ts
+++ b/packages/admin-editor/src/store.ts
@@ -1,0 +1,59 @@
+import { createStore } from "zustand/vanilla";
+
+import type { BlockNode } from "@plumix/blocks";
+
+export type EditorDevice = "desktop" | "tablet" | "mobile";
+
+export const MIN_ZOOM = 0.25;
+export const MAX_ZOOM = 2;
+
+export interface EditorState {
+  /** Canonical block tree — the single source of truth pushed to the canvas. */
+  readonly tree: readonly BlockNode[];
+  readonly selectedIds: ReadonlySet<string>;
+  /** Last-clicked block; the inspector edits this one when several are selected. */
+  readonly activeId: string | null;
+  readonly hoverId: string | null;
+  readonly device: EditorDevice;
+  readonly zoom: number;
+}
+
+export interface EditorActions {
+  setTree: (tree: readonly BlockNode[]) => void;
+  select: (id: string, options?: { readonly additive?: boolean }) => void;
+  clearSelection: () => void;
+  setHover: (id: string | null) => void;
+  setDevice: (device: EditorDevice) => void;
+  setZoom: (zoom: number) => void;
+}
+
+export type EditorStore = EditorState & EditorActions;
+
+export type EditorStoreApi = ReturnType<typeof createEditorStore>;
+
+export function createEditorStore(
+  initial?: Partial<Pick<EditorState, "tree" | "device" | "zoom">>,
+) {
+  return createStore<EditorStore>((set) => ({
+    tree: initial?.tree ?? [],
+    selectedIds: new Set<string>(),
+    activeId: null,
+    hoverId: null,
+    device: initial?.device ?? "desktop",
+    zoom: initial?.zoom ?? 1,
+
+    setTree: (tree) => set({ tree }),
+    select: (id, options) =>
+      set((state) => ({
+        selectedIds: options?.additive
+          ? new Set(state.selectedIds).add(id)
+          : new Set([id]),
+        activeId: id,
+      })),
+    clearSelection: () => set({ selectedIds: new Set(), activeId: null }),
+    setHover: (hoverId) => set({ hoverId }),
+    setDevice: (device) => set({ device }),
+    setZoom: (zoom) =>
+      set({ zoom: Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoom)) }),
+  }));
+}

--- a/packages/admin-editor/tsconfig.build.json
+++ b/packages/admin-editor/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "stripInternal": true
+  },
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/packages/admin-editor/tsconfig.json
+++ b/packages/admin-editor/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@plumix/typescript-config/library.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "types": []
+  },
+  "include": ["src"]
+}

--- a/packages/admin-editor/vitest.config.ts
+++ b/packages/admin-editor/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig, mergeConfig } from "vitest/config";
+
+import { baseConfig } from "@plumix/vitest-config/base";
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      environment: "jsdom",
+    },
+  }),
+);

--- a/packages/blocks/src/render-block-tree.edit.test.tsx
+++ b/packages/blocks/src/render-block-tree.edit.test.tsx
@@ -1,0 +1,28 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import type { BlockNode } from "./render-block-tree.js";
+import { createBlockRegistry } from "./block-registry.js";
+import { headingBlock } from "./heading/index.js";
+import { renderBlockTree } from "./render-block-tree.js";
+
+const registry = createBlockRegistry([headingBlock]);
+const tree: readonly BlockNode[] = [
+  { id: "abc", name: "core/heading", attrs: { text: "Hi", level: 2 } },
+];
+
+describe("renderBlockTree edit-aware seam", () => {
+  test("editing tags each block wrapper with its id for canvas selection", () => {
+    const html = renderToStaticMarkup(
+      renderBlockTree(tree, registry, { editing: true }),
+    );
+
+    expect(html).toContain('data-plumix-id="abc"');
+  });
+
+  test("the normal (non-editing) render carries no editor annotations", () => {
+    const html = renderToStaticMarkup(renderBlockTree(tree, registry));
+
+    expect(html).not.toContain("data-plumix-id");
+  });
+});

--- a/packages/blocks/src/render-block-tree.ts
+++ b/packages/blocks/src/render-block-tree.ts
@@ -70,6 +70,8 @@ export interface RenderBlockTreeOptions {
   readonly shortcodes?: ShortcodeRegistry;
   /** Queried entry, exposed to shortcodes via `BlockContext.entry`. */
   readonly entry?: Readonly<Record<string, unknown>> | null;
+  /** Edit mode: tag each block wrapper with `data-plumix-id` for canvas selection. */
+  readonly editing?: boolean;
 }
 
 export interface BlockNodeRenderProps<
@@ -164,6 +166,7 @@ interface WalkerEnv {
   readonly hooks: BlockRenderHooks | undefined;
   readonly loaderData: ResolvedBlockLoaders | undefined;
   readonly patterns: PatternRegistry | undefined;
+  readonly editing: boolean;
 }
 
 function renderNodes(
@@ -232,6 +235,7 @@ function renderNode(
     {
       key: node.id,
       "data-plumix-block": node.name,
+      "data-plumix-id": env.editing && safeId ? safeId : undefined,
       className,
     },
     styleTag,
@@ -289,6 +293,7 @@ export function renderBlockTree(
     hooks: options?.hooks,
     loaderData: options?.loaderData,
     patterns: options?.patterns,
+    editing: options?.editing ?? false,
   };
   const rootContext: BlockContext = {
     ...DEFAULT_BLOCK_CONTEXT,

--- a/packages/blocks/src/renderer/bridge.test.ts
+++ b/packages/blocks/src/renderer/bridge.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "vitest";
+
+import { createHandshake, encode, parseEnvelope } from "./bridge.js";
+
+const CHANNEL = "plumix.editor";
+const ORIGIN = "https://admin.example";
+
+describe("bridge envelope", () => {
+  test("parseEnvelope returns the message for a matching channel and allowed origin", () => {
+    const raw = encode(CHANNEL, { type: "ping" });
+
+    expect(parseEnvelope(CHANNEL, raw, ORIGIN, ORIGIN)).toEqual({
+      type: "ping",
+    });
+  });
+
+  test("parseEnvelope rejects a message from a foreign origin (origin pinning)", () => {
+    const raw = encode(CHANNEL, { type: "ping" });
+
+    expect(
+      parseEnvelope(CHANNEL, raw, "https://evil.example", ORIGIN),
+    ).toBeNull();
+  });
+
+  test("parseEnvelope ignores traffic on a different channel and non-envelope data", () => {
+    const foreign = encode("some.other.channel", { type: "ping" });
+    expect(parseEnvelope(CHANNEL, foreign, ORIGIN, ORIGIN)).toBeNull();
+
+    // Unrelated postMessage traffic (HMR, devtools, plugins) is not an envelope.
+    expect(parseEnvelope(CHANNEL, "hot-update", ORIGIN, ORIGIN)).toBeNull();
+    expect(parseEnvelope(CHANNEL, null, ORIGIN, ORIGIN)).toBeNull();
+    // Right channel, but no message payload → not a usable envelope.
+    expect(
+      parseEnvelope(CHANNEL, { channel: CHANNEL }, ORIGIN, ORIGIN),
+    ).toBeNull();
+  });
+});
+
+describe("handshake", () => {
+  test("the initiator re-posts hello until it receives ack, then resolves ready once", async () => {
+    const posts: unknown[] = [];
+    const hs = createHandshake({
+      role: "initiator",
+      post: (m) => posts.push(m),
+    });
+
+    // Posts hello on creation.
+    expect(posts).toEqual([{ kind: "hello" }]);
+    expect(hs.isReady()).toBe(false);
+
+    // Re-posts while still waiting for ack.
+    hs.retry();
+    expect(posts).toEqual([{ kind: "hello" }, { kind: "hello" }]);
+
+    // ack arrives → ready, whenReady resolves.
+    hs.onMessage({ kind: "ack" });
+    expect(hs.isReady()).toBe(true);
+    await expect(hs.whenReady()).resolves.toBeUndefined();
+
+    // Stops re-posting once ready.
+    hs.retry();
+    expect(posts).toHaveLength(2);
+  });
+
+  test("the responder stays quiet until a hello, then replies ack and is ready", async () => {
+    const posts: unknown[] = [];
+    const hs = createHandshake({
+      role: "responder",
+      post: (m) => posts.push(m),
+    });
+
+    // Responder does not initiate.
+    expect(posts).toEqual([]);
+    expect(hs.isReady()).toBe(false);
+
+    // hello arrives → replies ack, becomes ready.
+    hs.onMessage({ kind: "hello" });
+    expect(posts).toEqual([{ kind: "ack" }]);
+    expect(hs.isReady()).toBe(true);
+    await expect(hs.whenReady()).resolves.toBeUndefined();
+
+    // A repeated hello (initiator retry after a dropped ack) re-acks and
+    // stays ready — no second resolution.
+    hs.onMessage({ kind: "hello" });
+    expect(posts).toEqual([{ kind: "ack" }, { kind: "ack" }]);
+    expect(hs.isReady()).toBe(true);
+  });
+});

--- a/packages/blocks/src/renderer/bridge.ts
+++ b/packages/blocks/src/renderer/bridge.ts
@@ -1,0 +1,82 @@
+// Editor bridge primitives shared by the admin shell (parent) and the
+// canvas runtime (iframe). No transport here — the caller injects `post`
+// and feeds inbound data in, so the protocol is testable without an iframe.
+
+export interface Envelope<M> {
+  readonly channel: string;
+  readonly message: M;
+}
+
+export function encode<M>(channel: string, message: M): Envelope<M> {
+  return { channel, message };
+}
+
+export type HandshakeRole = "initiator" | "responder";
+
+type HandshakeMessage = { readonly kind: "hello" } | { readonly kind: "ack" };
+
+export interface Handshake {
+  /** Feed an inbound handshake message (hello/ack). */
+  onMessage(message: { readonly kind?: string }): void;
+  /** Re-post hello while still waiting for ack (driven by the caller's timer). */
+  retry(): void;
+  isReady(): boolean;
+  whenReady(): Promise<void>;
+}
+
+/**
+ * Connection handshake over an injected `post`. The initiator posts `hello`
+ * and re-posts on each `retry()` until it receives `ack`; the responder
+ * replies `ack` to a `hello`. Both resolve `whenReady` exactly once. No
+ * timers here — the caller drives `retry()` so the logic stays testable.
+ */
+export function createHandshake({
+  role,
+  post,
+}: {
+  readonly role: HandshakeRole;
+  readonly post: (message: HandshakeMessage) => void;
+}): Handshake {
+  let ready = false;
+  let resolveReady: () => void = () => undefined;
+  const readyPromise = new Promise<void>((resolve) => {
+    resolveReady = resolve;
+  });
+  const markReady = (): void => {
+    if (ready) return;
+    ready = true;
+    resolveReady();
+  };
+
+  if (role === "initiator") post({ kind: "hello" });
+
+  return {
+    onMessage(message) {
+      if (role === "initiator" && message.kind === "ack") markReady();
+      if (role === "responder" && message.kind === "hello") {
+        // Re-ack every hello, even once ready: if the initiator's ack was
+        // dropped, its retry resends hello and must receive a fresh ack.
+        post({ kind: "ack" });
+        markReady();
+      }
+    },
+    retry() {
+      if (!ready && role === "initiator") post({ kind: "hello" });
+    },
+    isReady: () => ready,
+    whenReady: () => readyPromise,
+  };
+}
+
+export function parseEnvelope<M>(
+  channel: string,
+  raw: unknown,
+  origin: string,
+  expectedOrigin: string,
+): M | null {
+  if (origin !== expectedOrigin) return null;
+  if (raw === null || typeof raw !== "object") return null;
+  const env = raw as Partial<Envelope<M>>;
+  if (env.channel !== channel || env.message === undefined) return null;
+  return env.message;
+}

--- a/packages/blocks/src/renderer/editor-protocol.ts
+++ b/packages/blocks/src/renderer/editor-protocol.ts
@@ -1,0 +1,32 @@
+// Typed message contract for the editor bridge, shared by the admin shell
+// (parent) and the SSR-injected canvas runtime (iframe). The parent owns
+// the canonical tree and pushes it down; the canvas renders what it's told
+// and reports user intent back. Transport/handshake live in ./bridge.
+
+import type { BlockNode } from "../render-block-tree.js";
+
+export const EDITOR_BRIDGE_CHANNEL = "plumix.editor";
+
+/** Geometry of one block, in the iframe's unscaled coordinate space. */
+export interface BlockRect {
+  readonly id: string;
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+/** Parent (admin shell) → canvas (iframe). */
+export type HostMessage =
+  | { readonly type: "host:tree"; readonly tree: readonly BlockNode[] }
+  | { readonly type: "host:select"; readonly id: string | null }
+  | { readonly type: "host:hover"; readonly id: string | null };
+
+/** Canvas (iframe) → parent (admin shell). */
+export type CanvasMessage =
+  | { readonly type: "canvas:ready" }
+  | { readonly type: "canvas:select"; readonly id: string }
+  | { readonly type: "canvas:hover"; readonly id: string | null }
+  | { readonly type: "canvas:geometry"; readonly rects: readonly BlockRect[] };
+
+export type EditorBridgeMessage = HostMessage | CanvasMessage;

--- a/packages/blocks/src/renderer/index.tsx
+++ b/packages/blocks/src/renderer/index.tsx
@@ -25,8 +25,12 @@ export type RendererQueriedEntry =
   | { readonly kind: "term"; readonly id: number }
   | { readonly kind: "archive"; readonly entryType: string };
 
+export type PlumixRenderMode = "live" | "preview" | "edit";
+
 export interface PlumixContextValue {
   readonly registry: BlockRegistry;
+  /** Render mode; defaults to `"live"`. `edit`/`preview` drive the editor hooks. */
+  readonly mode?: PlumixRenderMode;
   readonly tokens?: ThemeTokens;
   readonly loaderData?: ResolvedBlockLoaders;
   readonly user?: RendererUser | null;
@@ -79,7 +83,24 @@ export function BlockRenderer({
     locale: ctx.locale,
     shortcodes: ctx.shortcodes,
     entry: ctx.entry,
+    editing: ctx.mode === "edit",
   });
+}
+
+/** Current render mode; `"live"` unless the editor set it. */
+export function usePlumixMode(): PlumixRenderMode {
+  return usePlumixContext("usePlumixMode").mode ?? "live";
+}
+
+/** True only in the visual editor (drag/drop, live patches). */
+export function useIsEditing(): boolean {
+  return usePlumixMode() === "edit";
+}
+
+/** True when editing OR previewing a draft. */
+export function useIsPreview(): boolean {
+  const mode = usePlumixMode();
+  return mode === "edit" || mode === "preview";
 }
 
 export function useTokens(): ThemeTokens | undefined {
@@ -118,3 +139,15 @@ export type {
   ImageAttrs,
 } from "./image-attrs.js";
 export { buildImageAttrs, matchesRemotePattern } from "./image-attrs.js";
+
+// Editor bridge: transport primitives + typed message contract, shared by
+// the admin shell (parent) and the SSR-injected canvas runtime (iframe).
+export { createHandshake, encode, parseEnvelope } from "./bridge.js";
+export type { Envelope, Handshake, HandshakeRole } from "./bridge.js";
+export { EDITOR_BRIDGE_CHANNEL } from "./editor-protocol.js";
+export type {
+  BlockRect,
+  CanvasMessage,
+  EditorBridgeMessage,
+  HostMessage,
+} from "./editor-protocol.js";

--- a/packages/blocks/src/renderer/mode.test.tsx
+++ b/packages/blocks/src/renderer/mode.test.tsx
@@ -1,0 +1,50 @@
+import type { ReactElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import { createBlockRegistry } from "../block-registry.js";
+import {
+  PlumixProvider,
+  useIsEditing,
+  useIsPreview,
+  usePlumixMode,
+} from "./index.js";
+
+const registry = createBlockRegistry([]);
+
+function Probe(): ReactElement {
+  return (
+    <span>
+      {`mode=${usePlumixMode()} editing=${String(useIsEditing())} preview=${String(useIsPreview())}`}
+    </span>
+  );
+}
+
+describe("render mode hooks", () => {
+  test("edit mode: editing and preview are both true", () => {
+    const html = renderToStaticMarkup(
+      <PlumixProvider value={{ registry, mode: "edit" }}>
+        <Probe />
+      </PlumixProvider>,
+    );
+    expect(html).toContain("mode=edit editing=true preview=true");
+  });
+
+  test("preview mode: previewing but not editing", () => {
+    const html = renderToStaticMarkup(
+      <PlumixProvider value={{ registry, mode: "preview" }}>
+        <Probe />
+      </PlumixProvider>,
+    );
+    expect(html).toContain("mode=preview editing=false preview=true");
+  });
+
+  test("defaults to live when no mode is provided", () => {
+    const html = renderToStaticMarkup(
+      <PlumixProvider value={{ registry }}>
+        <Probe />
+      </PlumixProvider>,
+    );
+    expect(html).toContain("mode=live editing=false preview=false");
+  });
+});

--- a/packages/core/src/route/edit-mode.render.test.ts
+++ b/packages/core/src/route/edit-mode.render.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "vitest";
+
+import { definePlugin } from "../plugin/define.js";
+import { createDispatcherHarness } from "../test/dispatcher.js";
+
+// Exercises the edit gate end-to-end through the real public render path:
+// resolveSingle → resolveEditMode → PlumixProvider mode → injectEditorBootstrap.
+// The `data-plumix-editor` marker is the injected runtime script.
+
+const blogPlugin = definePlugin("blog", (ctx) => {
+  ctx.registerEntryType("post", { label: "Posts", isPublic: true });
+});
+
+const URL = "https://cms.example/post/hello";
+
+async function seed() {
+  const h = await createDispatcherHarness({ plugins: [blogPlugin] });
+  const editor = await h.seedUser("editor");
+  await h.factory.entry.create({
+    type: "post",
+    slug: "hello",
+    title: "Hello",
+    content: null,
+    status: "published",
+    authorId: editor.id,
+  });
+  return { h, editor };
+}
+
+describe("edit gate through the public render", () => {
+  test("a visitor render ships no editor runtime", async () => {
+    const { h } = await seed();
+
+    const res = await h.dispatch(new Request(URL));
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).not.toContain("data-plumix-editor");
+  });
+
+  test("an authorized editor with ?plumix.edit gets the editor runtime injected", async () => {
+    const { h, editor } = await seed();
+
+    const req = await h.authenticateRequest(
+      new Request(`${URL}?plumix.edit`),
+      editor.id,
+    );
+    const res = await h.dispatch(req);
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("data-plumix-editor");
+  });
+
+  test("an authorized editor without ?plumix.edit stays a normal render", async () => {
+    const { h, editor } = await seed();
+
+    const req = await h.authenticateRequest(new Request(URL), editor.id);
+    const res = await h.dispatch(req);
+
+    expect(await res.text()).not.toContain("data-plumix-editor");
+  });
+
+  test("?plumix.edit without a session never injects the runtime (leaked-URL guard)", async () => {
+    const { h } = await seed();
+
+    const res = await h.dispatch(new Request(`${URL}?plumix.edit`));
+
+    expect(await res.text()).not.toContain("data-plumix-editor");
+  });
+});

--- a/packages/core/src/route/edit-mode.test.ts
+++ b/packages/core/src/route/edit-mode.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "vitest";
+
+import { resolveEditMode } from "./edit-mode.js";
+
+describe("resolveEditMode (visual editor edit gate)", () => {
+  test("a normal visitor request renders live, ships no runtime, and stays cacheable", () => {
+    const decision = resolveEditMode({
+      editParam: false,
+      canEdit: false,
+      previewGrant: false,
+    });
+
+    expect(decision).toEqual({
+      mode: "live",
+      injectRuntime: false,
+      bypassCache: false,
+    });
+  });
+
+  test("a logged-in editor who did NOT request edit still gets the normal cacheable path", () => {
+    // Capability alone must not inject the runtime or tax the cache — an
+    // author browsing the site normally is just a visitor until they opt in.
+    expect(
+      resolveEditMode({ editParam: false, canEdit: true, previewGrant: false }),
+    ).toEqual({ mode: "live", injectRuntime: false, bypassCache: false });
+
+    expect(
+      resolveEditMode({ editParam: false, canEdit: true, previewGrant: true }),
+    ).toEqual({ mode: "preview", injectRuntime: false, bypassCache: true });
+  });
+
+  test("a valid preview token (no edit param) renders the draft, ships no runtime, and bypasses the cache", () => {
+    const decision = resolveEditMode({
+      editParam: false,
+      canEdit: false,
+      previewGrant: true,
+    });
+
+    expect(decision).toEqual({
+      mode: "preview",
+      injectRuntime: false,
+      bypassCache: true,
+    });
+  });
+
+  test("an authorized editor with ?plumix.edit enters edit mode, boots the runtime, and bypasses the cache", () => {
+    const decision = resolveEditMode({
+      editParam: true,
+      canEdit: true,
+      previewGrant: false,
+    });
+
+    expect(decision).toEqual({
+      mode: "edit",
+      injectRuntime: true,
+      bypassCache: true,
+    });
+  });
+
+  test("?plumix.edit without the edit capability never boots the runtime (leaked-URL guard)", () => {
+    const noGrant = resolveEditMode({
+      editParam: true,
+      canEdit: false,
+      previewGrant: false,
+    });
+    expect(noGrant).toEqual({
+      mode: "live",
+      injectRuntime: false,
+      bypassCache: false,
+    });
+
+    // A preview-link holder (no edit cap) opening ?plumix.edit sees the
+    // draft read-only — never the editor.
+    const withGrant = resolveEditMode({
+      editParam: true,
+      canEdit: false,
+      previewGrant: true,
+    });
+    expect(withGrant).toEqual({
+      mode: "preview",
+      injectRuntime: false,
+      bypassCache: true,
+    });
+  });
+
+  test("an authorized editor enters edit mode even when a preview token is also present (capability wins)", () => {
+    const decision = resolveEditMode({
+      editParam: true,
+      canEdit: true,
+      previewGrant: true,
+    });
+
+    expect(decision).toEqual({
+      mode: "edit",
+      injectRuntime: true,
+      bypassCache: true,
+    });
+  });
+});

--- a/packages/core/src/route/edit-mode.ts
+++ b/packages/core/src/route/edit-mode.ts
@@ -1,0 +1,44 @@
+// The visual-editor edit gate: the security truth table deciding whether a
+// request renders live/preview/edit and whether to ship the editor runtime.
+// Kept separate from the `ctx` wiring in resolve.ts so it stays auditable.
+
+/** Render mode, shared vocabulary with the runtime's `useIsEditing`/`useIsPreview`. */
+export type EditRenderMode = "live" | "preview" | "edit";
+
+export interface EditModeDecision {
+  readonly mode: EditRenderMode;
+  /** Ship + boot the editor runtime into the SSR output. */
+  readonly injectRuntime: boolean;
+  // The response must never be edge-cached. Today the cache layer already
+  // excludes these requests (a session cookie / `?preview` marks them
+  // privileged); this records the gate's intent as the eventual single
+  // source of truth.
+  readonly bypassCache: boolean;
+}
+
+/** The decision for an ordinary visitor render — the common case. */
+export const LIVE_EDIT_MODE: EditModeDecision = {
+  mode: "live",
+  injectRuntime: false,
+  bypassCache: false,
+};
+
+export function resolveEditMode(input: {
+  /** `?plumix.edit` present on the request URL. */
+  readonly editParam: boolean;
+  /** Viewer can edit this entry (false when there is no session). */
+  readonly canEdit: boolean;
+  /** A valid `?preview=<token>` grants draft visibility for this entry. */
+  readonly previewGrant: boolean;
+}): EditModeDecision {
+  // The runtime boots only for an authorized editor who asked for it. A
+  // leaked `?plumix.edit` without the capability falls through to the
+  // normal preview/live path below — never edit.
+  if (input.editParam && input.canEdit) {
+    return { mode: "edit", injectRuntime: true, bypassCache: true };
+  }
+  if (input.previewGrant) {
+    return { mode: "preview", injectRuntime: false, bypassCache: true };
+  }
+  return { mode: "live", injectRuntime: false, bypassCache: false };
+}

--- a/packages/core/src/route/render/asset-manifest.ts
+++ b/packages/core/src/route/render/asset-manifest.ts
@@ -59,6 +59,23 @@ export function devThemeStylesTag(command: ViteCommand, basePath = ""): string {
   return `<script type="module" src="${src}"></script>`;
 }
 
+// In build, resolve the hashed asset path from Vite's manifest; in dev (or
+// the cold-build edge where the entry isn't in the manifest yet) fall back
+// to the source path Vite's dev server serves directly.
+export function resolveEntryUrl(
+  manifest: AssetManifest,
+  command: ViteCommand,
+  key: string,
+  devPath: string,
+  basePath = "",
+): string {
+  if (command === "build") {
+    const entry = manifest[key];
+    if (entry?.file) return withBasePath("/" + entry.file, basePath);
+  }
+  return devPath;
+}
+
 function collectReachableCss(
   key: string,
   manifest: AssetManifest,

--- a/packages/core/src/route/render/inject-editor-bootstrap.test.ts
+++ b/packages/core/src/route/render/inject-editor-bootstrap.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+
+import type { AssetManifest } from "./asset-manifest.js";
+import { injectEditorBootstrap } from "./inject-editor-bootstrap.js";
+
+const BODY = "<main>content</main>";
+
+describe("injectEditorBootstrap", () => {
+  test("leaves the body untouched when the edit gate says not to inject", () => {
+    const out = injectEditorBootstrap(BODY, false, {}, "serve");
+
+    expect(out).toBe(BODY);
+  });
+
+  test("appends the editor runtime script (dev path) when injecting", () => {
+    const out = injectEditorBootstrap(BODY, true, {}, "serve");
+
+    expect(out.startsWith(BODY)).toBe(true);
+    expect(out).toContain("/.plumix/editor-entry.ts");
+    expect(out).toContain("data-plumix-editor");
+  });
+
+  test("uses the hashed asset path from the manifest in build", () => {
+    const manifest: AssetManifest = {
+      ".plumix/editor-entry.ts": { file: "assets/editor-abc123.js" },
+    };
+
+    const out = injectEditorBootstrap(BODY, true, manifest, "build");
+
+    expect(out).toContain("/assets/editor-abc123.js");
+    expect(out).not.toContain("/.plumix/editor-entry.ts");
+  });
+});

--- a/packages/core/src/route/render/inject-editor-bootstrap.ts
+++ b/packages/core/src/route/render/inject-editor-bootstrap.ts
@@ -1,0 +1,29 @@
+// Injects the visual-editor runtime `<script>` only when the edit gate
+// authorized it (see resolveEditMode). Mirrors injectIslandsBootstrap, but
+// gated on the edit-mode decision rather than page content.
+
+import type { AssetManifest, ViteCommand } from "./asset-manifest.js";
+import { resolveEntryUrl } from "./asset-manifest.js";
+
+const DEV_ENTRY_PATH = "/.plumix/editor-entry.ts";
+const RUNTIME_MANIFEST_KEY = ".plumix/editor-entry.ts";
+
+export function injectEditorBootstrap(
+  body: string,
+  injectRuntime: boolean,
+  manifest: AssetManifest,
+  command: ViteCommand,
+  basePath = "",
+): string {
+  if (!injectRuntime) return body;
+  const src = resolveEntryUrl(
+    manifest,
+    command,
+    RUNTIME_MANIFEST_KEY,
+    DEV_ENTRY_PATH,
+    basePath,
+  );
+  return (
+    body + `<script type="module" src="${src}" data-plumix-editor></script>`
+  );
+}

--- a/packages/core/src/route/render/inject-islands-bootstrap.ts
+++ b/packages/core/src/route/render/inject-islands-bootstrap.ts
@@ -15,7 +15,7 @@
 // `rollupOptions.input`). Read from Vite's `.vite/manifest.json`.
 
 import type { AssetManifest, ViteCommand } from "./asset-manifest.js";
-import { withBasePath } from "../../base-path.js";
+import { resolveEntryUrl } from "./asset-manifest.js";
 
 const DEV_ENTRY_PATH = "/.plumix/islands-entry.ts";
 const RUNTIME_MANIFEST_KEY = ".plumix/islands-entry.ts";
@@ -52,21 +52,4 @@ export function injectIslandsBootstrap(
     body +
     `<script type="module" src="${src}" data-plumix-renderer-url="${rendererUrl}"></script>`
   );
-}
-
-// In build, resolve the hashed asset path from Vite's manifest; in dev
-// (or on the cold-build edge where the entry isn't in the manifest yet)
-// fall back to the source path Vite's dev server serves directly.
-function resolveEntryUrl(
-  manifest: AssetManifest,
-  command: ViteCommand,
-  key: string,
-  devPath: string,
-  basePath: string,
-): string {
-  if (command === "build") {
-    const entry = manifest[key];
-    if (entry?.file) return withBasePath("/" + entry.file, basePath);
-  }
-  return devPath;
 }

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -24,6 +24,7 @@ import type {
   TemplateRegistry,
   ThemeDescriptor,
 } from "../../theme.js";
+import type { EditModeDecision } from "../edit-mode.js";
 import type { AssetManifest, ViteCommand } from "./asset-manifest.js";
 import type { ErrorData } from "./resolved-entry.js";
 import type { ResolvedNode } from "./template-hierarchy.js";
@@ -37,7 +38,9 @@ import {
 } from "../../template-deps.js";
 import { normalizeTemplate } from "../../template.js";
 import { validateDocumentManifest } from "../../theme.js";
+import { LIVE_EDIT_MODE } from "../edit-mode.js";
 import { bundledCssTags, devThemeStylesTag } from "./asset-manifest.js";
+import { injectEditorBootstrap } from "./inject-editor-bootstrap.js";
 import { injectIslandsBootstrap } from "./inject-islands-bootstrap.js";
 import { resolveTemplateCandidates } from "./template-hierarchy.js";
 
@@ -69,6 +72,8 @@ interface RenderArgs {
   readonly node: ResolvedNode;
   readonly data: TemplateData;
   readonly title: string;
+  /** Visual-editor decision; defaults to a plain live render. */
+  readonly editMode?: EditModeDecision;
 }
 
 export async function renderThroughTheme({
@@ -81,6 +86,7 @@ export async function renderThroughTheme({
   node,
   data,
   title,
+  editMode = LIVE_EDIT_MODE,
 }: RenderArgs): Promise<string> {
   const candidates = await resolveTemplateCandidates(node, ctx.hooks);
   const { template, slot } = pickTemplate(theme.templates, candidates);
@@ -124,6 +130,7 @@ export async function renderThroughTheme({
     deps,
     loaderData,
     tokens: theme.tokens,
+    editMode,
   });
 }
 
@@ -203,6 +210,7 @@ export async function renderErrorThroughTheme({
     deps,
     loaderData: undefined,
     tokens: theme.tokens,
+    editMode: LIVE_EDIT_MODE,
   });
 }
 
@@ -283,6 +291,7 @@ interface RenderTreeArgs {
   readonly deps: Record<string, Record<string, unknown>>;
   readonly loaderData: ResolvedBlockLoaders | undefined;
   readonly tokens: ThemeTokens | undefined;
+  readonly editMode: EditModeDecision;
 }
 
 // React 19 reorders every child of `<head>` (metadata first, scripts /
@@ -301,6 +310,7 @@ function renderTree({
   deps,
   tokens,
   loaderData,
+  editMode,
 }: RenderTreeArgs): string {
   // Adapter FC wraps `template.render({ data, ctx, ...deps })` so it
   // executes inside React's render pass — hooks (useState, useId,
@@ -329,6 +339,7 @@ function renderTree({
     {
       value: {
         registry: ctx.blocks,
+        mode: editMode.mode,
         tokens,
         loaderData,
         user: ctx.user,
@@ -398,9 +409,22 @@ function renderTree({
     voidTagsToHtml("meta", document.meta) +
     scripts.headEnd.map(scriptToHtml).join("");
 
+  const withIslands = injectIslandsBootstrap(
+    body,
+    assetManifest,
+    command,
+    ctx.basePath,
+  );
+  const withRuntimes = injectEditorBootstrap(
+    withIslands,
+    editMode.injectRuntime,
+    assetManifest,
+    command,
+    ctx.basePath,
+  );
   const bodyContent =
     scripts.bodyStart.map(scriptToHtml).join("") +
-    injectIslandsBootstrap(body, assetManifest, command, ctx.basePath) +
+    withRuntimes +
     scripts.bodyEnd.map(scriptToHtml).join("") +
     HYDRATION_SLOT;
 

--- a/packages/core/src/route/resolve.ts
+++ b/packages/core/src/route/resolve.ts
@@ -24,7 +24,9 @@ import { entries } from "../db/schema/entries.js";
 import { entryTerm } from "../db/schema/entry_term.js";
 import { terms } from "../db/schema/terms.js";
 import { labelSourceText } from "../i18n/label.js";
+import { entryCapability } from "../rpc/procedures/entry/lifecycle.js";
 import { notFound, permanentRedirect } from "../runtime/http.js";
+import { resolveEditMode } from "./edit-mode.js";
 import { paginate } from "./paginate.js";
 import { findEntryByPath, findTermByPath } from "./path-chain.js";
 import { buildTermArchiveUrl } from "./permalink.js";
@@ -361,6 +363,15 @@ async function resolveSingle(
 
   ctx.resolvedEntity = { kind: "entry", id: row.id };
 
+  const editMode = resolveEditMode({
+    editParam: new URL(ctx.request.url).searchParams.has("plumix.edit"),
+    canEdit:
+      ctx.auth.can(entryCapability(row.type, "edit_any")) ||
+      (ctx.user?.id === row.authorId &&
+        ctx.auth.can(entryCapability(row.type, "edit_own"))),
+    previewGrant: await previewTokenGrantsEntry(ctx, row),
+  });
+
   const [entry] = await buildResolvedEntries(ctx, [row]);
   if (!entry) {
     // eslint-disable-next-line no-restricted-syntax -- diagnostic throw
@@ -398,6 +409,7 @@ async function resolveSingle(
     },
     data: expanded,
     title,
+    editMode,
   });
   return new Response(html, {
     headers: { "content-type": "text/html; charset=utf-8" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,6 +456,58 @@ importers:
         specifier: 'catalog:'
         version: 4.1.9(@types/node@25.9.2)(@vitest/coverage-v8@4.1.9)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/admin-editor:
+    dependencies:
+      '@plumix/blocks':
+        specifier: workspace:*
+        version: link:../blocks
+      zustand:
+        specifier: ^5.0.14
+        version: 5.0.14(@types/react@19.2.16)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
+    devDependencies:
+      '@plumix/eslint-config':
+        specifier: workspace:*
+        version: link:../../tooling/eslint
+      '@plumix/prettier-config':
+        specifier: workspace:*
+        version: link:../../tooling/prettier
+      '@plumix/typescript-config':
+        specifier: workspace:*
+        version: link:../../tooling/typescript
+      '@plumix/vitest-config':
+        specifier: workspace:*
+        version: link:../../tooling/vitest
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.16
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.16)
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.9(vitest@4.1.9)
+      eslint:
+        specifier: 'catalog:'
+        version: 10.5.0(jiti@2.7.0)
+      jsdom:
+        specifier: 'catalog:'
+        version: 29.1.1
+      prettier:
+        specifier: 'catalog:'
+        version: 3.8.3
+      react:
+        specifier: 'catalog:'
+        version: 19.2.7
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.7(react@19.2.7)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@types/node@25.9.2)(@vitest/coverage-v8@4.1.9)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/admin-ui:
     dependencies:
       '@dnd-kit/core':
@@ -7835,6 +7887,24 @@ packages:
       use-sync-external-store:
         optional: true
 
+  zustand@5.0.14:
+    resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
 
   '@adobe/css-tools@4.4.4': {}
@@ -14062,6 +14132,12 @@ snapshots:
   zod@4.4.3: {}
 
   zustand@5.0.13(@types/react@19.2.16)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)):
+    optionalDependencies:
+      '@types/react': 19.2.16
+      react: 19.2.7
+      use-sync-external-store: 1.6.0(react@19.2.7)
+
+  zustand@5.0.14(@types/react@19.2.16)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)):
     optionalDependencies:
       '@types/react': 19.2.16
       react: 19.2.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - "packages/admin"
+  - "packages/admin-editor"
   - "packages/admin-ui"
   - "packages/blocks"
   - "packages/core"


### PR DESCRIPTION
Foundation for the bespoke visual editor (PRD #1104): the security / SSR / bridge spine — not yet the clickable editor (this stays a draft until the UI flow lands). An authorized editor requesting an entry with `?plumix.edit` now renders the real themed page in edit mode and gets the editor runtime script injected; visitors, leaked `?plumix.edit` URLs without a session, and editors without the param all render normally and stay edge-cacheable.

What's here, all green (~40 tests; route + dispatcher suites pass with no regressions):

- `resolveEditMode` — the pure edit-gate truth table (live/preview/edit, injectRuntime, bypassCache), wired into `resolveSingle` and threaded through `renderThroughTheme` to set `PlumixProvider` mode and conditionally inject the runtime. Verified end-to-end through the dispatcher harness.
- `@plumix/blocks/renderer` — `mode` + `useIsEditing`/`useIsPreview` hooks, the `data-plumix-id` edit-aware render seam, and the bridge transport (`encode`/`parseEnvelope` origin+channel pinning, retrying `createHandshake`) with a typed message contract.
- `@plumix/admin-editor` — new package plus the zustand editor store (selection / viewport).

Review focus is the hot-path change in `route/resolve.ts` and `render/render-template.tsx`: `editMode` defaults to a plain live render everywhere except an authorized single-entry edit request, so visitor output and the edge-cache path are unchanged. The four dispatcher tests in `edit-mode.render.test.ts` lock that boundary (visitor, leaked URL, editor-without-param, authorized editor).

Intentionally not here yet (follow-up commits on this branch before it leaves draft): the SSR hydration boundary, the iframe runtime, the canvas host + `<PlumixEditor>` shell, the Vite editor-entry registration, and the flagged admin route.

Refs #1105