### PR TITLE
feat: add the bespoke editor package (canvas + bridge)

### DIFF
--- a/packages/admin-editor/package.json
+++ b/packages/admin-editor/package.json
@@ -30,6 +30,7 @@
     "@plumix/prettier-config": "workspace:*",
     "@plumix/typescript-config": "workspace:*",
     "@plumix/vitest-config": "workspace:*",
+    "@testing-library/react": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitest/coverage-v8": "catalog:",

--- a/packages/admin-editor/src/canvas-frame.test.tsx
+++ b/packages/admin-editor/src/canvas-frame.test.tsx
@@ -1,0 +1,53 @@
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { EDITOR_BRIDGE_CHANNEL, encode } from "@plumix/blocks/renderer";
+
+import { CanvasFrame } from "./canvas-frame.js";
+import { EditorProvider } from "./provider.js";
+
+const ORIGIN = "http://localhost:3000";
+
+afterEach(cleanup);
+
+function fromCanvas(message: unknown): void {
+  act(() => {
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: encode(EDITOR_BRIDGE_CHANNEL, message),
+        origin: ORIGIN,
+      }),
+    );
+  });
+}
+
+describe("CanvasFrame", () => {
+  test("renders the iframe at the device width", () => {
+    const { container } = render(
+      <EditorProvider>
+        <CanvasFrame previewUrl="about:blank" origin={ORIGIN} />
+      </EditorProvider>,
+    );
+
+    const iframe = container.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    expect(iframe?.style.width).toBe("1280px"); // desktop default
+  });
+
+  test("draws a selection overlay from the canvas's reported geometry", () => {
+    const { queryByTestId } = render(
+      <EditorProvider>
+        <CanvasFrame previewUrl="about:blank" origin={ORIGIN} />
+      </EditorProvider>,
+    );
+
+    // The canvas reports a click (→ selection) and the block geometry.
+    fromCanvas({ type: "canvas:select", id: "h1" });
+    fromCanvas({
+      type: "canvas:geometry",
+      rects: [{ id: "h1", x: 10, y: 20, width: 100, height: 40 }],
+    });
+
+    expect(queryByTestId("plumix-overlay-selected")).not.toBeNull();
+  });
+});

--- a/packages/admin-editor/src/canvas-frame.tsx
+++ b/packages/admin-editor/src/canvas-frame.tsx
@@ -1,0 +1,109 @@
+import type { ReactElement } from "react";
+import { useEffect, useRef, useState } from "react";
+
+import type { BlockRect } from "@plumix/blocks/renderer";
+
+import type { FrameOffset } from "./overlay.js";
+import { connectCanvas } from "./connect-canvas.js";
+import { overlayBox } from "./overlay.js";
+import { useEditorStore, useEditorStoreApi } from "./provider.js";
+import { DEVICE_WIDTH } from "./store.js";
+
+interface CanvasFrameProps {
+  /** URL the iframe loads — the entry's real route with `?plumix.edit`. */
+  readonly previewUrl: string;
+  /** Origin of that route, for bridge message pinning. */
+  readonly origin: string;
+}
+
+const SELECTED_OUTLINE = "#2563eb";
+const HOVER_OUTLINE = "rgba(37,99,235,0.4)";
+const CANVAS_HEIGHT = 800;
+
+/**
+ * Host-side canvas: loads the real route in an iframe, drives it via the
+ * bridge, and draws selection/hover overlays in the shell's coordinate space
+ * (computed from the canvas-reported geometry, so they stay aligned at zoom).
+ */
+export function CanvasFrame({
+  previewUrl,
+  origin,
+}: CanvasFrameProps): ReactElement {
+  const store = useEditorStoreApi();
+  const device = useEditorStore((s) => s.device);
+  const zoom = useEditorStore((s) => s.zoom);
+  const activeId = useEditorStore((s) => s.activeId);
+  const hoverId = useEditorStore((s) => s.hoverId);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  // Captured together in the geometry callback — never read the ref in render.
+  const [geometry, setGeometry] = useState<{
+    readonly rects: ReadonlyMap<string, BlockRect>;
+    readonly frame: FrameOffset | null;
+  }>({ rects: new Map(), frame: null });
+
+  useEffect(() => {
+    const frameWindow = iframeRef.current?.contentWindow;
+    if (!frameWindow) return;
+    const connection = connectCanvas({
+      store,
+      frameWindow,
+      origin,
+      onGeometry: (reported) => {
+        const frame = iframeRef.current?.getBoundingClientRect();
+        setGeometry({
+          rects: new Map(reported.map((r) => [r.id, r])),
+          frame: frame ? { left: frame.left, top: frame.top } : null,
+        });
+      },
+    });
+    return () => connection.dispose();
+  }, [store, origin]);
+
+  const overlay = (
+    id: string | null,
+    color: string,
+    testId: string,
+  ): ReactElement | null => {
+    if (!id || !geometry.frame) return null;
+    const rect = geometry.rects.get(id);
+    if (!rect) return null;
+    const box = overlayBox(rect, geometry.frame, zoom);
+    return (
+      <div
+        data-testid={testId}
+        style={{
+          position: "fixed",
+          left: box.left,
+          top: box.top,
+          width: box.width,
+          height: box.height,
+          outline: `2px solid ${color}`,
+          pointerEvents: "none",
+          zIndex: 10,
+        }}
+      />
+    );
+  };
+
+  return (
+    <div
+      data-testid="plumix-canvas-frame"
+      style={{ position: "relative", flex: 1, overflow: "auto" }}
+    >
+      <iframe
+        ref={iframeRef}
+        src={previewUrl}
+        title="plumix-editor-canvas"
+        style={{
+          width: DEVICE_WIDTH[device],
+          height: CANVAS_HEIGHT,
+          border: 0,
+          transform: `scale(${String(zoom)})`,
+          transformOrigin: "top left",
+        }}
+      />
+      {overlay(hoverId, HOVER_OUTLINE, "plumix-overlay-hover")}
+      {overlay(activeId, SELECTED_OUTLINE, "plumix-overlay-selected")}
+    </div>
+  );
+}

--- a/packages/admin-editor/src/connect-canvas.ts
+++ b/packages/admin-editor/src/connect-canvas.ts
@@ -7,6 +7,7 @@ import {
   createHandshake,
   EDITOR_BRIDGE_CHANNEL,
   encode,
+  isHandshakeFrame,
   parseEnvelope,
 } from "@plumix/blocks/renderer";
 
@@ -31,15 +32,6 @@ interface ConnectCanvasOptions {
 // The iframe runtime usually boots after the parent mounts, so a single hello
 // would race; re-announce on this interval until the canvas acks.
 const HANDSHAKE_RETRY_MS = 250;
-
-function isHandshakeFrame(
-  message: object,
-): message is { readonly kind: string } {
-  return (
-    "kind" in message &&
-    typeof (message as { kind?: unknown }).kind === "string"
-  );
-}
 
 /**
  * Parent half of the editor bridge. The canvas never mutates the tree — it

--- a/packages/admin-editor/src/connect-runtime.test.ts
+++ b/packages/admin-editor/src/connect-runtime.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "vitest";
+
+import type { BlockNode } from "@plumix/blocks";
+import { EDITOR_BRIDGE_CHANNEL, encode } from "@plumix/blocks/renderer";
+
+import { connectRuntime } from "./connect-runtime.js";
+
+const ORIGIN = "http://localhost:3000";
+
+function fakeParent(): { win: Window; posted: unknown[] } {
+  const posted: unknown[] = [];
+  const win = {
+    postMessage: (data: unknown) => posted.push(data),
+  } as unknown as Window;
+  return { win, posted };
+}
+
+function fromHost(message: unknown, origin = ORIGIN): void {
+  window.dispatchEvent(
+    new MessageEvent("message", {
+      data: encode(EDITOR_BRIDGE_CHANNEL, message),
+      origin,
+    }),
+  );
+}
+
+function messages(posted: unknown[]): unknown[] {
+  return posted.map((p) => (p as { message?: unknown }).message);
+}
+
+describe("connectRuntime (canvas/iframe side)", () => {
+  test("acks the host's hello and re-announces readiness", () => {
+    const { win, posted } = fakeParent();
+    const conn = connectRuntime({
+      parentWindow: win,
+      origin: ORIGIN,
+      onTree: () => undefined,
+    });
+
+    fromHost({ kind: "hello" });
+
+    expect(messages(posted)).toContainEqual({ kind: "ack" });
+    expect(messages(posted)).toContainEqual({ type: "canvas:ready" });
+    conn.dispose();
+  });
+
+  test("delivers a pushed tree to onTree", () => {
+    const seen: (readonly BlockNode[])[] = [];
+    const { win } = fakeParent();
+    const conn = connectRuntime({
+      parentWindow: win,
+      origin: ORIGIN,
+      onTree: (tree) => seen.push(tree),
+    });
+
+    const tree: readonly BlockNode[] = [{ id: "a", name: "core/heading" }];
+    fromHost({ type: "host:tree", tree });
+
+    expect(seen.at(-1)).toEqual(tree);
+    conn.dispose();
+  });
+
+  test("reportSelect posts canvas:select to the host", () => {
+    const { win, posted } = fakeParent();
+    const conn = connectRuntime({
+      parentWindow: win,
+      origin: ORIGIN,
+      onTree: () => undefined,
+    });
+
+    conn.reportSelect("blk-1");
+
+    expect(messages(posted)).toContainEqual({
+      type: "canvas:select",
+      id: "blk-1",
+    });
+    conn.dispose();
+  });
+
+  test("ignores host messages from a foreign origin", () => {
+    const seen: (readonly BlockNode[])[] = [];
+    const { win } = fakeParent();
+    const conn = connectRuntime({
+      parentWindow: win,
+      origin: ORIGIN,
+      onTree: (tree) => seen.push(tree),
+    });
+
+    fromHost(
+      { type: "host:tree", tree: [{ id: "x", name: "core/heading" }] },
+      "http://evil.test",
+    );
+
+    expect(seen).toHaveLength(0);
+    conn.dispose();
+  });
+});

--- a/packages/admin-editor/src/connect-runtime.ts
+++ b/packages/admin-editor/src/connect-runtime.ts
@@ -1,0 +1,82 @@
+import type { BlockNode } from "@plumix/blocks";
+import type {
+  BlockRect,
+  CanvasMessage,
+  HostMessage,
+} from "@plumix/blocks/renderer";
+import {
+  createHandshake,
+  EDITOR_BRIDGE_CHANNEL,
+  encode,
+  isHandshakeFrame,
+  parseEnvelope,
+} from "@plumix/blocks/renderer";
+
+export interface RuntimeConnection {
+  readonly reportSelect: (id: string) => void;
+  readonly reportHover: (id: string | null) => void;
+  readonly reportGeometry: (rects: readonly BlockRect[]) => void;
+  readonly dispose: () => void;
+}
+
+interface ConnectRuntimeOptions {
+  /** The host (admin shell) window — usually `window.parent`. */
+  readonly parentWindow: Window;
+  /** Expected origin of the host; messages from elsewhere are dropped. */
+  readonly origin: string;
+  /** Called with each tree the host pushes. */
+  readonly onTree: (tree: readonly BlockNode[]) => void;
+}
+
+/**
+ * Canvas (iframe) half of the editor bridge. Acks the host's handshake,
+ * applies the trees it pushes, and exposes report* helpers the canvas calls
+ * when the author interacts. It never owns the tree — it only renders what
+ * the host sends and reports intent back.
+ */
+export function connectRuntime({
+  parentWindow,
+  origin,
+  onTree,
+}: ConnectRuntimeOptions): RuntimeConnection {
+  const post = (message: object): void => {
+    parentWindow.postMessage(encode(EDITOR_BRIDGE_CHANNEL, message), origin);
+  };
+  const handshake = createHandshake({ role: "responder", post });
+
+  const announce = (): void => {
+    post({ type: "canvas:ready" } satisfies CanvasMessage);
+  };
+
+  const onMessage = (event: MessageEvent): void => {
+    const message = parseEnvelope<object>(
+      EDITOR_BRIDGE_CHANNEL,
+      event.data,
+      event.origin,
+      origin,
+    );
+    if (!message) return;
+    if (isHandshakeFrame(message)) {
+      handshake.onMessage(message);
+      // A hello means the host (re)connected and is listening — re-announce
+      // so it pushes the tree even if it missed our first announce.
+      if (message.kind === "hello") announce();
+      return;
+    }
+    const host = message as Partial<HostMessage>;
+    if (host.type === "host:tree" && host.tree) onTree(host.tree);
+  };
+
+  window.addEventListener("message", onMessage);
+  announce();
+
+  return {
+    reportSelect: (id) =>
+      post({ type: "canvas:select", id } satisfies CanvasMessage),
+    reportHover: (id) =>
+      post({ type: "canvas:hover", id } satisfies CanvasMessage),
+    reportGeometry: (rects) =>
+      post({ type: "canvas:geometry", rects } satisfies CanvasMessage),
+    dispose: () => window.removeEventListener("message", onMessage),
+  };
+}

--- a/packages/admin-editor/src/editor-canvas.test.tsx
+++ b/packages/admin-editor/src/editor-canvas.test.tsx
@@ -1,0 +1,83 @@
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import type { BlockNode } from "@plumix/blocks";
+import { coreBlocks, createBlockRegistry } from "@plumix/blocks";
+import { EDITOR_BRIDGE_CHANNEL, encode } from "@plumix/blocks/renderer";
+
+import { EditorCanvas } from "./editor-canvas.js";
+
+const registry = createBlockRegistry(coreBlocks);
+const ORIGIN = "http://localhost:3000";
+
+afterEach(cleanup);
+
+function pushTree(tree: readonly BlockNode[]): void {
+  act(() => {
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: encode(EDITOR_BRIDGE_CHANNEL, { type: "host:tree", tree }),
+        origin: ORIGIN,
+      }),
+    );
+  });
+}
+
+describe("EditorCanvas", () => {
+  test("renders the host's tree in edit mode, tagging blocks for selection", () => {
+    const { container } = render(
+      <EditorCanvas registry={registry} origin={ORIGIN} />,
+    );
+
+    pushTree([
+      { id: "h1", name: "core/heading", attrs: { text: "Hi", level: 2 } },
+    ]);
+
+    expect(container.querySelector('[data-plumix-id="h1"]')).not.toBeNull();
+    expect(container.textContent).toContain("Hi");
+  });
+
+  test("clicking a block reports canvas:select to the host", () => {
+    const posted: unknown[] = [];
+    const spy = vi
+      .spyOn(window.parent, "postMessage")
+      .mockImplementation((data) => posted.push(data));
+
+    const { container } = render(
+      <EditorCanvas registry={registry} origin={ORIGIN} />,
+    );
+    pushTree([{ id: "h1", name: "core/heading", attrs: { text: "Hi" } }]);
+
+    const block = container.querySelector('[data-plumix-id="h1"]');
+    expect(block).not.toBeNull();
+    if (block) fireEvent.click(block);
+
+    const select = posted
+      .map((p) => (p as { message?: { type?: string } }).message)
+      .find((m) => m?.type === "canvas:select");
+    expect(select).toEqual({ type: "canvas:select", id: "h1" });
+    spy.mockRestore();
+  });
+
+  test("hovering a block reports canvas:hover to the host", () => {
+    const posted: unknown[] = [];
+    const spy = vi
+      .spyOn(window.parent, "postMessage")
+      .mockImplementation((data) => posted.push(data));
+
+    const { container } = render(
+      <EditorCanvas registry={registry} origin={ORIGIN} />,
+    );
+    pushTree([{ id: "h1", name: "core/heading", attrs: { text: "Hi" } }]);
+
+    const block = container.querySelector('[data-plumix-id="h1"]');
+    expect(block).not.toBeNull();
+    if (block) fireEvent.mouseOver(block);
+
+    const hover = posted
+      .map((p) => (p as { message?: { type?: string } }).message)
+      .find((m) => m?.type === "canvas:hover");
+    expect(hover).toEqual({ type: "canvas:hover", id: "h1" });
+    spy.mockRestore();
+  });
+});

--- a/packages/admin-editor/src/editor-canvas.tsx
+++ b/packages/admin-editor/src/editor-canvas.tsx
@@ -1,0 +1,100 @@
+import type { MouseEvent, ReactElement } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+
+import type { BlockNode, BlockRegistry } from "@plumix/blocks";
+import type { BlockRect } from "@plumix/blocks/renderer";
+import { BlockRenderer, PlumixProvider } from "@plumix/blocks/renderer";
+
+import type { RuntimeConnection } from "./connect-runtime.js";
+import { connectRuntime } from "./connect-runtime.js";
+
+interface EditorCanvasProps {
+  /** Block registry for the site (core + plugin blocks). */
+  readonly registry: BlockRegistry;
+  /** Expected origin of the host (admin shell). */
+  readonly origin: string;
+}
+
+/**
+ * The canvas that runs inside the editor iframe. Renders the host's tree via
+ * the real BlockRenderer in edit mode (so blocks are tagged with
+ * data-plumix-id), and reports the author's clicks + block geometry back. It
+ * never owns the tree — the host does.
+ */
+export function EditorCanvas({
+  registry,
+  origin,
+}: EditorCanvasProps): ReactElement {
+  const [tree, setTree] = useState<readonly BlockNode[]>([]);
+  const connectionRef = useRef<RuntimeConnection | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const connection = connectRuntime({
+      parentWindow: window.parent,
+      origin,
+      onTree: setTree,
+    });
+    connectionRef.current = connection;
+    return () => {
+      connection.dispose();
+      connectionRef.current = null;
+    };
+  }, [origin]);
+
+  const reportGeometry = useCallback((): void => {
+    const root = containerRef.current;
+    const connection = connectionRef.current;
+    if (!root || !connection) return;
+    const rects: BlockRect[] = [];
+    root.querySelectorAll<HTMLElement>("[data-plumix-id]").forEach((el) => {
+      const id = el.dataset.plumixId;
+      if (!id) return;
+      const r = el.getBoundingClientRect();
+      rects.push({ id, x: r.left, y: r.top, width: r.width, height: r.height });
+    });
+    connection.reportGeometry(rects);
+  }, []);
+
+  useLayoutEffect(() => {
+    reportGeometry();
+  }, [tree, reportGeometry]);
+
+  const blockIdAt = (event: MouseEvent<HTMLDivElement>): string | null => {
+    const block = (event.target as HTMLElement).closest("[data-plumix-id]");
+    return block?.getAttribute("data-plumix-id") ?? null;
+  };
+
+  const handleClick = (event: MouseEvent<HTMLDivElement>): void => {
+    const id = blockIdAt(event);
+    if (id) connectionRef.current?.reportSelect(id);
+  };
+
+  const handleMouseOver = (event: MouseEvent<HTMLDivElement>): void => {
+    connectionRef.current?.reportHover(blockIdAt(event));
+  };
+
+  const handleMouseOut = (): void => {
+    connectionRef.current?.reportHover(null);
+  };
+
+  return (
+    <PlumixProvider value={{ registry, mode: "edit" }}>
+      <div
+        ref={containerRef}
+        data-testid="plumix-editor-canvas"
+        onClick={handleClick}
+        onMouseOver={handleMouseOver}
+        onMouseOut={handleMouseOut}
+      >
+        <BlockRenderer content={{ version: "plumix.v2", blocks: tree }} />
+      </div>
+    </PlumixProvider>
+  );
+}

--- a/packages/admin-editor/src/index.ts
+++ b/packages/admin-editor/src/index.ts
@@ -1,5 +1,10 @@
 export { connectCanvas } from "./connect-canvas.js";
 export type { CanvasConnection } from "./connect-canvas.js";
+export { connectRuntime } from "./connect-runtime.js";
+export type { RuntimeConnection } from "./connect-runtime.js";
+export { EditorCanvas } from "./editor-canvas.js";
+export { CanvasFrame } from "./canvas-frame.js";
+export { PlumixEditor } from "./plumix-editor.js";
 export { EditorProvider, useEditorStore } from "./provider.js";
 export { createEditorStore, MAX_ZOOM, MIN_ZOOM } from "./store.js";
 export type {

--- a/packages/admin-editor/src/overlay.test.ts
+++ b/packages/admin-editor/src/overlay.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "vitest";
+
+import { overlayBox } from "./overlay.js";
+
+describe("overlayBox", () => {
+  // Pins the iframe→screen transform — the old Puck zoom-overlay bug lived here.
+  test("maps an iframe rect to screen coords by offset and zoom", () => {
+    const box = overlayBox(
+      { id: "a", x: 10, y: 20, width: 100, height: 40 },
+      { left: 5, top: 8 },
+      0.5,
+    );
+
+    expect(box).toEqual({ left: 10, top: 18, width: 50, height: 20 });
+  });
+
+  test("at 100% zoom it is the rect shifted by the iframe offset", () => {
+    const box = overlayBox(
+      { id: "a", x: 0, y: 0, width: 200, height: 100 },
+      { left: 30, top: 40 },
+      1,
+    );
+
+    expect(box).toEqual({ left: 30, top: 40, width: 200, height: 100 });
+  });
+});

--- a/packages/admin-editor/src/overlay.ts
+++ b/packages/admin-editor/src/overlay.ts
@@ -1,0 +1,25 @@
+import type { BlockRect } from "@plumix/blocks/renderer";
+
+export interface FrameOffset {
+  readonly left: number;
+  readonly top: number;
+}
+
+/**
+ * Map a block rect (iframe's unscaled coordinate space) to a screen-space
+ * overlay box, accounting for the iframe's on-screen offset and CSS zoom.
+ * Computing in the iframe's own space and scaling here is what keeps the
+ * overlay aligned at <100% zoom (the Puck overlay bug computed it scaled).
+ */
+export function overlayBox(
+  rect: BlockRect,
+  frame: FrameOffset,
+  zoom: number,
+): { left: number; top: number; width: number; height: number } {
+  return {
+    left: frame.left + rect.x * zoom,
+    top: frame.top + rect.y * zoom,
+    width: rect.width * zoom,
+    height: rect.height * zoom,
+  };
+}

--- a/packages/admin-editor/src/plumix-editor.test.tsx
+++ b/packages/admin-editor/src/plumix-editor.test.tsx
@@ -1,0 +1,23 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { PlumixEditor } from "./plumix-editor.js";
+
+afterEach(cleanup);
+
+describe("PlumixEditor", () => {
+  test("mounts the canvas for the given preview URL", () => {
+    const { getByTestId, container } = render(
+      <PlumixEditor
+        previewUrl="about:blank"
+        origin="http://localhost:3000"
+        defaultValue={{ version: "plumix.v2", blocks: [] }}
+      />,
+    );
+
+    expect(getByTestId("plumix-canvas-frame")).toBeDefined();
+    expect(container.querySelector("iframe")?.getAttribute("src")).toBe(
+      "about:blank",
+    );
+  });
+});

--- a/packages/admin-editor/src/plumix-editor.tsx
+++ b/packages/admin-editor/src/plumix-editor.tsx
@@ -1,0 +1,31 @@
+import type { ReactElement } from "react";
+
+import type { EntryContent } from "@plumix/blocks";
+
+import { CanvasFrame } from "./canvas-frame.js";
+import { EditorProvider } from "./provider.js";
+
+interface PlumixEditorProps {
+  /** Seed content; the editor owns state thereafter (uncontrolled). */
+  readonly defaultValue?: EntryContent;
+  /** URL the canvas iframe loads — the entry's real route with `?plumix.edit`. */
+  readonly previewUrl: string;
+  /** Origin of that route, for bridge message pinning. */
+  readonly origin: string;
+}
+
+/**
+ * The bespoke editor's host shell. Owns the editor store and the canvas;
+ * persistence is the host app's job, wired via callbacks in later slices.
+ */
+export function PlumixEditor({
+  defaultValue,
+  previewUrl,
+  origin,
+}: PlumixEditorProps): ReactElement {
+  return (
+    <EditorProvider initialTree={defaultValue?.blocks}>
+      <CanvasFrame previewUrl={previewUrl} origin={origin} />
+    </EditorProvider>
+  );
+}

--- a/packages/admin-editor/src/provider.tsx
+++ b/packages/admin-editor/src/provider.tsx
@@ -42,3 +42,10 @@ export function useEditorStore<T>(selector: (state: EditorStore) => T): T {
   if (!store) throw EditorError.missingProvider();
   return useStore(store, selector);
 }
+
+/** The raw store handle, for non-React consumers like the canvas bridge. */
+export function useEditorStoreApi(): EditorStoreApi {
+  const store = useContext(EditorStoreContext);
+  if (!store) throw EditorError.missingProvider();
+  return store;
+}

--- a/packages/admin-editor/src/store.ts
+++ b/packages/admin-editor/src/store.ts
@@ -4,6 +4,14 @@ import type { BlockNode } from "@plumix/blocks";
 
 export type EditorDevice = "desktop" | "tablet" | "mobile";
 
+// Default canvas widths per device. The theme can override these via the
+// manifest (theme-defined breakpoints); these are the fallbacks.
+export const DEVICE_WIDTH: Record<EditorDevice, number> = {
+  desktop: 1280,
+  tablet: 768,
+  mobile: 375,
+};
+
 export const MIN_ZOOM = 0.25;
 export const MAX_ZOOM = 2;
 

--- a/packages/blocks/src/renderer/bridge.ts
+++ b/packages/blocks/src/renderer/bridge.ts
@@ -68,6 +68,16 @@ export function createHandshake({
   };
 }
 
+/** Distinguishes a handshake frame (hello/ack) from a typed editor message. */
+export function isHandshakeFrame(
+  message: object,
+): message is { readonly kind: string } {
+  return (
+    "kind" in message &&
+    typeof (message as { kind?: unknown }).kind === "string"
+  );
+}
+
 export function parseEnvelope<M>(
   channel: string,
   raw: unknown,

--- a/packages/blocks/src/renderer/editor-protocol.ts
+++ b/packages/blocks/src/renderer/editor-protocol.ts
@@ -17,10 +17,10 @@ export interface BlockRect {
 }
 
 /** Parent (admin shell) → canvas (iframe). */
-export type HostMessage =
-  | { readonly type: "host:tree"; readonly tree: readonly BlockNode[] }
-  | { readonly type: "host:select"; readonly id: string | null }
-  | { readonly type: "host:hover"; readonly id: string | null };
+export interface HostMessage {
+  readonly type: "host:tree";
+  readonly tree: readonly BlockNode[];
+}
 
 /** Canvas (iframe) → parent (admin shell). */
 export type CanvasMessage =

--- a/packages/blocks/src/renderer/index.tsx
+++ b/packages/blocks/src/renderer/index.tsx
@@ -142,7 +142,12 @@ export { buildImageAttrs, matchesRemotePattern } from "./image-attrs.js";
 
 // Editor bridge: transport primitives + typed message contract, shared by
 // the admin shell (parent) and the SSR-injected canvas runtime (iframe).
-export { createHandshake, encode, parseEnvelope } from "./bridge.js";
+export {
+  createHandshake,
+  encode,
+  isHandshakeFrame,
+  parseEnvelope,
+} from "./bridge.js";
 export type { Envelope, Handshake, HandshakeRole } from "./bridge.js";
 export { EDITOR_BRIDGE_CHANNEL } from "./editor-protocol.js";
 export type {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -477,6 +477,9 @@ importers:
       '@plumix/vitest-config':
         specifier: workspace:*
         version: link:../../tooling/vitest
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.16


### PR DESCRIPTION
The bespoke visual editor's package — the canvas, both halves of the postMessage bridge, the store, and the host shell — fully unit-tested. This is additive: nothing in the app wires it in yet, so it ships no behavior change. The app wiring (Vite editor entry, SSR hydration boundary, flagged admin route) is a follow-up that turns this into a usable route and closes the issue.

Both sides of the bridge are verified in jsdom, no live runtime required: `connectCanvas` (host) drives the iframe and folds reported selection/hover/geometry into the store; `connectRuntime` (iframe) acks the handshake, applies pushed trees, and reports intent. `EditorCanvas` renders the host's tree through the real `BlockRenderer` in edit mode (blocks tagged `data-plumix-id`); `CanvasFrame` loads the route in an iframe and draws zoom-correct overlays via the pure `overlayBox` transform — the spot where the old Puck overlay-at-zoom bug lived, now pinned by tests; `PlumixEditor` is the uncontrolled host shell.

Review focus is the bridge symmetry (`connect-canvas` vs `connect-runtime`, sharing `isHandshakeFrame`) and `overlayBox`'s coordinate math. Accepted spine limitations: geometry is recomputed only when the canvas reports (no scroll/resize observer yet) and device widths are static defaults (theme-overridable in a later slice).

Refs #1105