### PR TITLE
feat: live edit loop for the bespoke editor — block attributes + autosave

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -195,6 +195,12 @@ const config: KnipConfig = {
     "packages/core": {
       entry: ["lingui.config.ts", "locales/*.mjs"],
     },
+    // The editor's lingui config + compiled catalogs are loaded by the CLI
+    // and merged into admin's i18n at runtime (i18n-boot glob) — knip can't
+    // see either consumer.
+    "packages/admin-editor": {
+      entry: ["lingui.config.ts", "locales/*.mjs"],
+    },
     "packages/plugins/menu": {
       entry: [
         "src/index.ts",

--- a/packages/admin-editor/lingui.config.ts
+++ b/packages/admin-editor/lingui.config.ts
@@ -1,0 +1,3 @@
+import { defineLinguiConfig } from "@plumix/lingui-config";
+
+export default defineLinguiConfig();

--- a/packages/admin-editor/locales/ar.po
+++ b/packages/admin-editor/locales/ar.po
@@ -1,0 +1,13 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-06-20 15:05+0100\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: ar\n"
+
+#. js-lingui-explicit-id
+#: src/block-inspector.tsx
+msgid "editor.inspector.empty"
+msgstr ""

--- a/packages/admin-editor/locales/de.po
+++ b/packages/admin-editor/locales/de.po
@@ -1,0 +1,13 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-06-20 15:05+0100\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: de\n"
+
+#. js-lingui-explicit-id
+#: src/block-inspector.tsx
+msgid "editor.inspector.empty"
+msgstr ""

--- a/packages/admin-editor/locales/en.po
+++ b/packages/admin-editor/locales/en.po
@@ -1,0 +1,13 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-06-20 15:05+0100\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: en\n"
+
+#. js-lingui-explicit-id
+#: src/block-inspector.tsx
+msgid "editor.inspector.empty"
+msgstr "Select a block to edit its attributes."

--- a/packages/admin-editor/locales/uk.po
+++ b/packages/admin-editor/locales/uk.po
@@ -1,0 +1,13 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-06-20 15:05+0100\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: uk\n"
+
+#. js-lingui-explicit-id
+#: src/block-inspector.tsx
+msgid "editor.inspector.empty"
+msgstr ""

--- a/packages/admin-editor/locales/zh-CN.po
+++ b/packages/admin-editor/locales/zh-CN.po
@@ -1,0 +1,13 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-06-20 15:05+0100\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: zh-CN\n"
+
+#. js-lingui-explicit-id
+#: src/block-inspector.tsx
+msgid "editor.inspector.empty"
+msgstr ""

--- a/packages/admin-editor/package.json
+++ b/packages/admin-editor/package.json
@@ -13,20 +13,31 @@
     "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -xdf .cache .turbo dist node_modules",
     "format": "prettier --check . --ignore-path ../../.gitignore",
+    "i18n:check": "node ../plumix/bin/plumix.mjs i18n extract --check",
+    "i18n:compile": "plumix-compile-catalogs",
+    "i18n:extract": "lingui extract",
     "lint": "eslint",
     "test": "vitest run",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
+    "@plumix/admin-ui": "workspace:*",
     "@plumix/blocks": "workspace:*",
+    "@plumix/core": "workspace:*",
     "zustand": "^5.0.14"
   },
   "peerDependencies": {
+    "@lingui/core": "catalog:lingui",
+    "@lingui/react": "catalog:lingui",
     "react": "catalog:",
     "react-dom": "catalog:"
   },
   "devDependencies": {
+    "@lingui/cli": "catalog:lingui",
+    "@lingui/core": "catalog:lingui",
+    "@lingui/react": "catalog:lingui",
     "@plumix/eslint-config": "workspace:*",
+    "@plumix/lingui-config": "workspace:*",
     "@plumix/prettier-config": "workspace:*",
     "@plumix/typescript-config": "workspace:*",
     "@plumix/vitest-config": "workspace:*",

--- a/packages/admin-editor/src/block-input-control.test.tsx
+++ b/packages/admin-editor/src/block-input-control.test.tsx
@@ -1,0 +1,167 @@
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
+
+import type { BlockInput } from "@plumix/blocks";
+
+import { BlockInputControl } from "./block-input-control.js";
+
+beforeAll(() => {
+  i18n.loadAndActivate({ locale: "en", messages: {} });
+});
+
+afterEach(cleanup);
+
+function renderControl(input: BlockInput, value: unknown, onChange = vi.fn()) {
+  const utils = render(
+    <I18nProvider i18n={i18n}>
+      <BlockInputControl input={input} value={value} onChange={onChange} />
+    </I18nProvider>,
+  );
+  return { ...utils, onChange };
+}
+
+describe("BlockInputControl", () => {
+  test("text input renders the value and emits edits", () => {
+    const { getByTestId, onChange } = renderControl(
+      { name: "text", type: "text", label: "Heading" },
+      "Hello",
+    );
+    const control = getByTestId("block-input-text") as HTMLInputElement;
+    expect(control.value).toBe("Hello");
+
+    fireEvent.change(control, { target: { value: "World" } });
+    expect(onChange).toHaveBeenCalledWith("World");
+  });
+
+  test("textarea renders the value and emits edits", () => {
+    const { getByTestId, onChange } = renderControl(
+      { name: "body", type: "textarea" },
+      "one",
+    );
+    fireEvent.change(getByTestId("block-input-body"), {
+      target: { value: "two" },
+    });
+    expect(onChange).toHaveBeenCalledWith("two");
+  });
+
+  test("number input emits a numeric value, null when cleared", () => {
+    const { getByTestId, onChange } = renderControl(
+      { name: "level", type: "number" },
+      2,
+    );
+    const control = getByTestId("block-input-level") as HTMLInputElement;
+    expect(control.value).toBe("2");
+
+    fireEvent.change(control, { target: { value: "3" } });
+    expect(onChange).toHaveBeenCalledWith(3);
+
+    fireEvent.change(control, { target: { value: "" } });
+    expect(onChange).toHaveBeenLastCalledWith(null);
+  });
+
+  test("checkbox reflects a boolean and emits a boolean", () => {
+    const { getByTestId, onChange } = renderControl(
+      { name: "wide", type: "checkbox" },
+      false,
+    );
+    fireEvent.click(getByTestId("block-input-wide"));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  test("select preserves a numeric option value through the round trip", () => {
+    const { getByTestId, onChange } = renderControl(
+      {
+        name: "level",
+        type: "select",
+        options: [
+          { label: "H2", value: 2 },
+          { label: "H3", value: 3 },
+        ],
+      },
+      2,
+    );
+    const control = getByTestId("block-input-level") as HTMLSelectElement;
+    expect(control.value).toBe("2");
+
+    fireEvent.change(control, { target: { value: "3" } });
+    // Emits the number 3, not the string "3".
+    expect(onChange).toHaveBeenCalledWith(3);
+  });
+
+  test("select preserves a boolean option value through the round trip", () => {
+    const { getByTestId, onChange } = renderControl(
+      {
+        name: "wide",
+        type: "select",
+        options: [
+          { label: "Yes", value: true },
+          { label: "No", value: false },
+        ],
+      },
+      false,
+    );
+    fireEvent.change(getByTestId("block-input-wide"), {
+      target: { value: "true" },
+    });
+    // Emits the boolean true, not the string "true".
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  test("number input clears to null on an unparseable value", () => {
+    const { getByTestId, onChange } = renderControl(
+      { name: "level", type: "number" },
+      2,
+    );
+    fireEvent.change(getByTestId("block-input-level"), {
+      target: { value: "" },
+    });
+    // Never emits NaN — empty/unparseable clears to null.
+    expect(onChange).toHaveBeenLastCalledWith(null);
+  });
+
+  test("radio selects an option and emits its typed value", () => {
+    const { getByTestId, onChange } = renderControl(
+      {
+        name: "align",
+        type: "radio",
+        options: [
+          { label: "Left", value: "left" },
+          { label: "Right", value: "right" },
+        ],
+      },
+      "left",
+    );
+    fireEvent.click(getByTestId("block-input-align-right"));
+    expect(onChange).toHaveBeenCalledWith("right");
+  });
+
+  test("combobox is free-text with option suggestions", () => {
+    const { getByTestId, onChange } = renderControl(
+      {
+        name: "tag",
+        type: "combobox",
+        options: [{ label: "News", value: "news" }],
+      },
+      "",
+    );
+    fireEvent.change(getByTestId("block-input-tag"), {
+      target: { value: "custom" },
+    });
+    expect(onChange).toHaveBeenCalledWith("custom");
+  });
+
+  test("falls back to a text input for an unknown kind", () => {
+    const { getByTestId } = renderControl(
+      { name: "mystery", type: "future-kind" },
+      "x",
+    );
+    expect(getByTestId("block-input-mystery")).toBeDefined();
+  });
+
+  test("uses the input name as the label when none is given", () => {
+    const { getByText } = renderControl({ name: "slug", type: "text" }, "");
+    expect(getByText("slug")).toBeDefined();
+  });
+});

--- a/packages/admin-editor/src/block-input-control.tsx
+++ b/packages/admin-editor/src/block-input-control.tsx
@@ -1,0 +1,176 @@
+import type { ReactElement } from "react";
+import { useId } from "react";
+import { useLingui } from "@lingui/react";
+
+import type { BlockInput, BlockInputOption } from "@plumix/blocks";
+import { Checkbox } from "@plumix/admin-ui/checkbox";
+import { Input } from "@plumix/admin-ui/input";
+import { Label } from "@plumix/admin-ui/label";
+import { resolveLabel } from "@plumix/core/i18n";
+
+interface BlockInputControlProps {
+  readonly input: BlockInput;
+  readonly value: unknown;
+  /** Emits the next typed value (string for text, number for number, etc.). */
+  readonly onChange: (value: unknown) => void;
+}
+
+const FIELD_TESTID = (name: string): string => `block-input-${name}`;
+
+/**
+ * Renders one block attribute as an admin-ui form control, dispatching the
+ * typed next value on edit. shadcn primitives where they map cleanly (text,
+ * number, checkbox); native `<select>`/`<textarea>`/radio for the
+ * option-bearing kinds so number/boolean option values survive the round trip
+ * (radix Select is string-only). Mirrors the kinds the Puck field translator
+ * supports so plugin blocks render unchanged.
+ */
+export function BlockInputControl({
+  input,
+  value,
+  onChange,
+}: BlockInputControlProps): ReactElement {
+  const { i18n } = useLingui();
+  const id = useId();
+  const labelId = `${id}-label`;
+  const testId = FIELD_TESTID(input.name);
+  const label =
+    input.label != null ? resolveLabel(input.label, i18n) : input.name;
+  const options = input.options ?? [];
+
+  const control = ((): ReactElement => {
+    switch (input.type) {
+      case "textarea":
+        return (
+          <textarea
+            id={id}
+            data-testid={testId}
+            className="border-input flex min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-sm"
+            value={asString(value)}
+            onChange={(e) => onChange(e.target.value)}
+          />
+        );
+      case "number":
+        return (
+          <Input
+            id={id}
+            data-testid={testId}
+            type="number"
+            value={asString(value)}
+            onChange={(e) => {
+              const next = e.target.valueAsNumber;
+              // Empty or unparseable (a lone "-"/"e" mid-typing) clears to
+              // null rather than poisoning the tree with NaN.
+              onChange(Number.isNaN(next) ? null : next);
+            }}
+          />
+        );
+      case "checkbox":
+        return (
+          <Checkbox
+            id={id}
+            data-testid={testId}
+            checked={value === true}
+            onCheckedChange={(checked) => onChange(checked === true)}
+          />
+        );
+      case "select":
+        return (
+          <select
+            id={id}
+            data-testid={testId}
+            className="border-input flex h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm"
+            value={optionKey(value)}
+            onChange={(e) => onChange(decodeOption(options, e.target.value))}
+          >
+            {options.map((opt) => (
+              <option key={optionKey(opt.value)} value={optionKey(opt.value)}>
+                {resolveLabel(opt.label, i18n)}
+              </option>
+            ))}
+          </select>
+        );
+      case "radio":
+        return (
+          <div role="radiogroup" aria-labelledby={labelId} data-testid={testId}>
+            {options.map((opt) => (
+              <label key={optionKey(opt.value)} className="flex gap-2 text-sm">
+                <input
+                  type="radio"
+                  name={id}
+                  value={optionKey(opt.value)}
+                  checked={optionKey(value) === optionKey(opt.value)}
+                  onChange={() => onChange(opt.value)}
+                  data-testid={`${testId}-${optionKey(opt.value)}`}
+                />
+                {resolveLabel(opt.label, i18n)}
+              </label>
+            ))}
+          </div>
+        );
+      case "combobox": {
+        const listId = `${id}-list`;
+        return (
+          <>
+            <Input
+              id={id}
+              data-testid={testId}
+              list={listId}
+              value={asString(value)}
+              onChange={(e) => onChange(e.target.value)}
+            />
+            <datalist id={listId}>
+              {options.map((opt) => (
+                <option key={optionKey(opt.value)} value={optionKey(opt.value)}>
+                  {resolveLabel(opt.label, i18n)}
+                </option>
+              ))}
+            </datalist>
+          </>
+        );
+      }
+      default:
+        return (
+          <Input
+            id={id}
+            data-testid={testId}
+            value={asString(value)}
+            onChange={(e) => onChange(e.target.value)}
+          />
+        );
+    }
+  })();
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label htmlFor={id} id={labelId}>
+        {label}
+      </Label>
+      {control}
+    </div>
+  );
+}
+
+// Block attr values are primitives in practice; coerce only the primitive
+// kinds so a stray object can't stringify to "[object Object]".
+function asString(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return "";
+}
+
+// DOM control values are strings; key options by their stringified value so
+// number/boolean options round-trip back to their typed form via decodeOption.
+function optionKey(value: unknown): string {
+  return asString(value);
+}
+
+function decodeOption(
+  options: readonly BlockInputOption[],
+  key: string,
+): unknown {
+  const match = options.find((opt) => optionKey(opt.value) === key);
+  return match ? match.value : key;
+}

--- a/packages/admin-editor/src/block-inspector.test.tsx
+++ b/packages/admin-editor/src/block-inspector.test.tsx
@@ -1,0 +1,130 @@
+import type { ReactElement } from "react";
+import { useEffect } from "react";
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, test } from "vitest";
+
+import type { BlockNode, BlockRegistry } from "@plumix/blocks";
+import { createBlockRegistry } from "@plumix/blocks";
+
+import { BlockInspector } from "./block-inspector.js";
+import { EditorProvider, useEditorStoreApi } from "./provider.js";
+
+beforeAll(() => {
+  i18n.loadAndActivate({ locale: "en", messages: {} });
+});
+
+afterEach(cleanup);
+
+const registry: BlockRegistry = createBlockRegistry([
+  {
+    name: "core/heading",
+    render: () => null,
+    inputs: [
+      { name: "text", type: "text", label: "Text" },
+      {
+        name: "level",
+        type: "select",
+        label: "Level",
+        options: [
+          { label: "H2", value: 2 },
+          { label: "H3", value: 3 },
+        ],
+      },
+    ],
+  },
+  { name: "core/spacer", render: () => null },
+  {
+    name: "core/group",
+    render: () => null,
+    inputs: [
+      { name: "content", type: "slot" },
+      { name: "tag", type: "text", label: "Tag" },
+    ],
+  },
+]);
+
+function Selector({ id }: { readonly id?: string }): ReactElement | null {
+  const api = useEditorStoreApi();
+  useEffect(() => {
+    if (id) api.getState().select(id);
+  }, [id, api]);
+  return null;
+}
+
+function renderInspector(
+  tree: readonly BlockNode[],
+  selectId?: string,
+): ReturnType<typeof render> {
+  return render(
+    <I18nProvider i18n={i18n}>
+      <EditorProvider initialTree={tree}>
+        <Selector id={selectId} />
+        <BlockInspector registry={registry} />
+      </EditorProvider>
+    </I18nProvider>,
+  );
+}
+
+describe("BlockInspector", () => {
+  test("shows the empty state when nothing is selected", () => {
+    const { getByTestId, queryByTestId } = renderInspector([
+      { id: "h1", name: "core/heading" },
+    ]);
+    expect(getByTestId("block-inspector-empty")).toBeDefined();
+    expect(queryByTestId("block-input-text")).toBeNull();
+  });
+
+  test("renders the active block's inputs as controls", () => {
+    const { getByTestId } = renderInspector(
+      [{ id: "h1", name: "core/heading", attrs: { text: "Hi", level: 2 } }],
+      "h1",
+    );
+    expect((getByTestId("block-input-text") as HTMLInputElement).value).toBe(
+      "Hi",
+    );
+    expect((getByTestId("block-input-level") as HTMLSelectElement).value).toBe(
+      "2",
+    );
+  });
+
+  test("editing an input patches the store and re-renders live", () => {
+    const { getByTestId } = renderInspector(
+      [{ id: "h1", name: "core/heading", attrs: { text: "Hi" } }],
+      "h1",
+    );
+    const control = getByTestId("block-input-text") as HTMLInputElement;
+    fireEvent.change(control, { target: { value: "Edited" } });
+    // The inspector reads value from the store tree; a live patch round-trips
+    // back into the control with no reload.
+    expect((getByTestId("block-input-text") as HTMLInputElement).value).toBe(
+      "Edited",
+    );
+  });
+
+  test("skips slot inputs — editing one as a control would corrupt children", () => {
+    const { getByTestId, queryByTestId } = renderInspector(
+      [
+        {
+          id: "g1",
+          name: "core/group",
+          attrs: { content: [], tag: "section" },
+        },
+      ],
+      "g1",
+    );
+    // The scalar input renders; the slot is omitted.
+    expect(getByTestId("block-input-tag")).toBeDefined();
+    expect(queryByTestId("block-input-content")).toBeNull();
+  });
+
+  test("renders the bare panel for a block with no inputs", () => {
+    const { getByTestId, queryByTestId } = renderInspector(
+      [{ id: "s1", name: "core/spacer" }],
+      "s1",
+    );
+    expect(getByTestId("block-inspector")).toBeDefined();
+    expect(queryByTestId("block-inspector-empty")).toBeNull();
+  });
+});

--- a/packages/admin-editor/src/block-inspector.tsx
+++ b/packages/admin-editor/src/block-inspector.tsx
@@ -1,0 +1,70 @@
+import type { ReactElement } from "react";
+import { useCallback } from "react";
+import { Trans } from "@lingui/react";
+
+import type { BlockRegistry } from "@plumix/blocks";
+
+import { BlockInputControl } from "./block-input-control.js";
+import { useEditorStore } from "./provider.js";
+import { findBlock } from "./store.js";
+
+interface BlockInspectorProps {
+  /** Core + plugin block registry; supplies each block's input schema. */
+  readonly registry: BlockRegistry;
+}
+
+/**
+ * Right-rail panel for the active block's custom attributes. Reads the
+ * selected block from the canonical tree, renders its registered inputs as
+ * admin-ui controls, and patches the store on edit — which the canvas bridge
+ * pushes to the iframe for a live, reload-free re-render.
+ */
+export function BlockInspector({
+  registry,
+}: BlockInspectorProps): ReactElement {
+  const activeId = useEditorStore((s) => s.activeId);
+  const tree = useEditorStore((s) => s.tree);
+  const updateBlockAttrs = useEditorStore((s) => s.updateBlockAttrs);
+
+  const block = activeId ? findBlock(tree, activeId) : undefined;
+  const handleChange = useCallback(
+    (key: string, value: unknown): void => {
+      if (activeId) updateBlockAttrs(activeId, { [key]: value });
+    },
+    [activeId, updateBlockAttrs],
+  );
+
+  if (!block) {
+    return (
+      <div
+        className="text-muted-foreground p-4 text-sm"
+        data-testid="block-inspector-empty"
+      >
+        <Trans
+          id="editor.inspector.empty"
+          message="Select a block to edit its attributes."
+        />
+      </div>
+    );
+  }
+
+  // Slot inputs hold child block arrays, not scalar attributes — editing
+  // them as a control would overwrite the children with a string. Nested
+  // editing is a separate concern (canvas selection of the child block).
+  const inputs = (registry.get(block.name)?.inputs ?? []).filter(
+    (input) => input.type !== "slot",
+  );
+
+  return (
+    <div className="flex flex-col gap-4 p-4" data-testid="block-inspector">
+      {inputs.map((input) => (
+        <BlockInputControl
+          key={input.name}
+          input={input}
+          value={block.attrs?.[input.name]}
+          onChange={(value) => handleChange(input.name, value)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/admin-editor/src/plumix-editor.test.tsx
+++ b/packages/admin-editor/src/plumix-editor.test.tsx
@@ -1,23 +1,84 @@
-import { cleanup, render } from "@testing-library/react";
-import { afterEach, describe, expect, test } from "vitest";
+import type { ReactElement } from "react";
+import { useEffect } from "react";
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
 
-import { PlumixEditor } from "./plumix-editor.js";
+import type { EntryContent } from "@plumix/blocks";
+import { createBlockRegistry } from "@plumix/blocks";
+
+import { PlumixEditor, TreeChangeEmitter } from "./plumix-editor.js";
+import { EditorProvider, useEditorStoreApi } from "./provider.js";
+
+beforeAll(() => {
+  i18n.loadAndActivate({ locale: "en", messages: {} });
+});
 
 afterEach(cleanup);
 
-describe("PlumixEditor", () => {
-  test("mounts the canvas for the given preview URL", () => {
-    const { getByTestId, container } = render(
+const registry = createBlockRegistry([
+  { name: "core/heading", render: () => null },
+]);
+
+function renderEditor(): ReturnType<typeof render> {
+  return render(
+    <I18nProvider i18n={i18n}>
       <PlumixEditor
         previewUrl="about:blank"
         origin="http://localhost:3000"
         defaultValue={{ version: "plumix.v2", blocks: [] }}
-      />,
-    );
+        registry={registry}
+      />
+    </I18nProvider>,
+  );
+}
 
+describe("PlumixEditor", () => {
+  test("mounts the canvas for the given preview URL", () => {
+    const { getByTestId, container } = renderEditor();
     expect(getByTestId("plumix-canvas-frame")).toBeDefined();
     expect(container.querySelector("iframe")?.getAttribute("src")).toBe(
       "about:blank",
     );
+  });
+
+  test("mounts the right-rail inspector", () => {
+    const { getByTestId } = renderEditor();
+    expect(getByTestId("plumix-editor-right")).toBeDefined();
+    // Nothing selected yet → inspector shows its empty state.
+    expect(getByTestId("block-inspector-empty")).toBeDefined();
+  });
+});
+
+describe("TreeChangeEmitter", () => {
+  test("emits the content envelope when the tree changes", () => {
+    const onChange = vi.fn<(content: EntryContent) => void>();
+    let select: (() => void) | undefined;
+
+    function Mutator(): ReactElement | null {
+      const api = useEditorStoreApi();
+      useEffect(() => {
+        select = () =>
+          api.getState().setTree([{ id: "h1", name: "core/heading" }]);
+      }, [api]);
+      return null;
+    }
+
+    render(
+      <EditorProvider initialTree={[]}>
+        <TreeChangeEmitter onChange={onChange} />
+        <Mutator />
+      </EditorProvider>,
+    );
+
+    expect(onChange).not.toHaveBeenCalled();
+    act(() => select?.());
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith({
+      version: "plumix.v2",
+      blocks: [{ id: "h1", name: "core/heading" }],
+    });
   });
 });

--- a/packages/admin-editor/src/plumix-editor.tsx
+++ b/packages/admin-editor/src/plumix-editor.tsx
@@ -1,9 +1,12 @@
 import type { ReactElement } from "react";
+import { useEffect, useRef } from "react";
 
-import type { EntryContent } from "@plumix/blocks";
+import type { BlockRegistry, EntryContent } from "@plumix/blocks";
+import { defineEntryContent } from "@plumix/blocks";
 
+import { BlockInspector } from "./block-inspector.js";
 import { CanvasFrame } from "./canvas-frame.js";
-import { EditorProvider } from "./provider.js";
+import { EditorProvider, useEditorStoreApi } from "./provider.js";
 
 interface PlumixEditorProps {
   /** Seed content; the editor owns state thereafter (uncontrolled). */
@@ -12,20 +15,65 @@ interface PlumixEditorProps {
   readonly previewUrl: string;
   /** Origin of that route, for bridge message pinning. */
   readonly origin: string;
+  /** Core + plugin block registry, supplying the inspector's input schemas. */
+  readonly registry: BlockRegistry;
+  /** Fires with the full content envelope whenever the tree changes. The host
+   *  debounces + persists (orpc lives in the app, never in this package). */
+  readonly onChange?: (content: EntryContent) => void;
 }
 
 /**
- * The bespoke editor's host shell. Owns the editor store and the canvas;
- * persistence is the host app's job, wired via callbacks in later slices.
+ * The bespoke editor's host shell: the canvas iframe plus the right-rail
+ * attribute inspector. Owns the editor store; persistence is the host app's
+ * job, wired via `onChange`.
  */
 export function PlumixEditor({
   defaultValue,
   previewUrl,
   origin,
+  registry,
+  onChange,
 }: PlumixEditorProps): ReactElement {
   return (
     <EditorProvider initialTree={defaultValue?.blocks}>
-      <CanvasFrame previewUrl={previewUrl} origin={origin} />
+      <div className="flex h-full" data-testid="plumix-editor-layout">
+        <CanvasFrame previewUrl={previewUrl} origin={origin} />
+        <aside
+          className="bg-background w-80 shrink-0 overflow-auto border-s"
+          data-testid="plumix-editor-right"
+        >
+          <BlockInspector registry={registry} />
+        </aside>
+      </div>
+      {onChange ? <TreeChangeEmitter onChange={onChange} /> : null}
     </EditorProvider>
   );
+}
+
+/**
+ * Subscribes to canonical-tree changes and emits the content envelope. Kept a
+ * child of EditorProvider so it can reach the store; the latest `onChange` is
+ * held in a ref so re-subscribing isn't needed when the callback identity
+ * changes between renders.
+ */
+export function TreeChangeEmitter({
+  onChange,
+}: {
+  readonly onChange: (content: EntryContent) => void;
+}): null {
+  const store = useEditorStoreApi();
+  const onChangeRef = useRef(onChange);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  });
+  useEffect(
+    () =>
+      store.subscribe((state, prev) => {
+        if (state.tree !== prev.tree) {
+          onChangeRef.current(defineEntryContent(state.tree));
+        }
+      }),
+    [store],
+  );
+  return null;
 }

--- a/packages/admin-editor/src/store.test.ts
+++ b/packages/admin-editor/src/store.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import type { BlockNode } from "@plumix/blocks";
 
-import { createEditorStore, MAX_ZOOM, MIN_ZOOM } from "./store.js";
+import { createEditorStore, findBlock, MAX_ZOOM, MIN_ZOOM } from "./store.js";
 
 describe("editor store", () => {
   test("select replaces the selection and marks the block active", () => {
@@ -54,5 +54,89 @@ describe("editor store", () => {
     store.getState().setTree(tree);
 
     expect(store.getState().tree).toBe(tree);
+  });
+
+  test("updateBlockAttrs merges a patch into the targeted block's attrs", () => {
+    const store = createEditorStore({
+      tree: [
+        { id: "h1", name: "core/heading", attrs: { level: 2, text: "Hi" } },
+      ],
+    });
+
+    store.getState().updateBlockAttrs("h1", { text: "Hello" });
+
+    const [block] = store.getState().tree;
+    // Patch merges over existing attrs — `level` survives, `text` changes.
+    expect(block?.attrs).toEqual({ level: 2, text: "Hello" });
+  });
+
+  test("updateBlockAttrs reaches a block nested inside a slot", () => {
+    const store = createEditorStore({
+      tree: [
+        {
+          id: "group",
+          name: "core/group",
+          attrs: {
+            content: [
+              { id: "child", name: "core/heading", attrs: { text: "old" } },
+            ],
+          },
+        },
+      ],
+    });
+
+    store.getState().updateBlockAttrs("child", { text: "new" });
+
+    const child = (
+      store.getState().tree[0]?.attrs?.content as readonly BlockNode[]
+    )[0];
+    expect(child?.attrs).toEqual({ text: "new" });
+  });
+
+  test("updateBlockAttrs leaves untouched blocks referentially stable", () => {
+    const sibling: BlockNode = { id: "b", name: "core/spacer" };
+    const store = createEditorStore({
+      tree: [{ id: "a", name: "core/heading", attrs: { text: "x" } }, sibling],
+    });
+
+    store.getState().updateBlockAttrs("a", { text: "y" });
+
+    // The edited block is a new object; the sibling reference is preserved so
+    // React skips re-rendering it.
+    expect(store.getState().tree[1]).toBe(sibling);
+  });
+
+  test("updateBlockAttrs is a no-op when the id is absent", () => {
+    const tree: readonly BlockNode[] = [{ id: "a", name: "core/heading" }];
+    const store = createEditorStore({ tree });
+
+    store.getState().updateBlockAttrs("missing", { text: "y" });
+
+    expect(store.getState().tree).toBe(tree);
+  });
+});
+
+describe("findBlock", () => {
+  test("finds a top-level block by id", () => {
+    const tree: readonly BlockNode[] = [
+      { id: "a", name: "core/heading" },
+      { id: "b", name: "core/spacer" },
+    ];
+    expect(findBlock(tree, "b")?.name).toBe("core/spacer");
+  });
+
+  test("finds a block nested inside a slot", () => {
+    const tree: readonly BlockNode[] = [
+      {
+        id: "g",
+        name: "core/group",
+        attrs: { content: [{ id: "deep", name: "core/heading" }] },
+      },
+    ];
+    expect(findBlock(tree, "deep")?.id).toBe("deep");
+  });
+
+  test("returns undefined when absent", () => {
+    expect(findBlock([{ id: "a", name: "core/heading" }], "z")).toBeUndefined();
   });
 });

--- a/packages/admin-editor/src/store.ts
+++ b/packages/admin-editor/src/store.ts
@@ -1,6 +1,7 @@
 import { createStore } from "zustand/vanilla";
 
 import type { BlockNode } from "@plumix/blocks";
+import { isBlockNodeArray } from "@plumix/blocks";
 
 export type EditorDevice = "desktop" | "tablet" | "mobile";
 
@@ -28,11 +29,67 @@ export interface EditorState {
 
 export interface EditorActions {
   setTree: (tree: readonly BlockNode[]) => void;
+  /** Merge a partial attrs patch into one block, anywhere in the tree. */
+  updateBlockAttrs: (
+    id: string,
+    patch: Readonly<Record<string, unknown>>,
+  ) => void;
   select: (id: string, options?: { readonly additive?: boolean }) => void;
   clearSelection: () => void;
   setHover: (id: string | null) => void;
   setDevice: (device: EditorDevice) => void;
   setZoom: (zoom: number) => void;
+}
+
+/** Find a block by id anywhere in the tree, descending into slot attrs. */
+export function findBlock(
+  nodes: readonly BlockNode[],
+  id: string,
+): BlockNode | undefined {
+  for (const node of nodes) {
+    if (node.id === id) return node;
+    for (const value of Object.values(node.attrs ?? {})) {
+      if (!isBlockNodeArray(value)) continue;
+      const found = findBlock(value, id);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
+// Merge `patch` into one node, returning the same reference when nothing
+// changed. Descends into slot attrs (any attr whose value is a BlockNode[]),
+// so a nested target is reachable and untouched branches stay stable.
+function patchNode(
+  node: BlockNode,
+  id: string,
+  patch: Readonly<Record<string, unknown>>,
+): BlockNode {
+  if (node.id === id) {
+    return { ...node, attrs: { ...node.attrs, ...patch } };
+  }
+  const attrs = node.attrs;
+  if (!attrs) return node;
+  let nextAttrs: Record<string, unknown> | undefined;
+  for (const [key, value] of Object.entries(attrs)) {
+    if (!isBlockNodeArray(value)) continue;
+    const patched = patchAttrs(value, id, patch);
+    if (patched !== value) {
+      (nextAttrs ??= { ...attrs })[key] = patched;
+    }
+  }
+  return nextAttrs ? { ...node, attrs: nextAttrs } : node;
+}
+
+// Rebuild the tree with `patch` applied to the node with `id`. Returns the
+// same array reference when nothing changed so React skips untouched branches.
+function patchAttrs(
+  nodes: readonly BlockNode[],
+  id: string,
+  patch: Readonly<Record<string, unknown>>,
+): readonly BlockNode[] {
+  const next = nodes.map((node) => patchNode(node, id, patch));
+  return next.some((node, i) => node !== nodes[i]) ? next : nodes;
 }
 
 export type EditorStore = EditorState & EditorActions;
@@ -51,6 +108,8 @@ export function createEditorStore(
     zoom: initial?.zoom ?? 1,
 
     setTree: (tree) => set({ tree }),
+    updateBlockAttrs: (id, patch) =>
+      set((state) => ({ tree: patchAttrs(state.tree, id, patch) })),
     select: (id, options) =>
       set((state) => ({
         selectedIds: options?.additive

--- a/packages/admin/e2e/bespoke-editor.spec.ts
+++ b/packages/admin/e2e/bespoke-editor.spec.ts
@@ -47,6 +47,29 @@ test.describe("bespoke editor route", () => {
     expect(src).toMatch(/[?&]plumix\.edit(=|&|$)/);
   });
 
+  test("mounts the right-rail attribute inspector alongside the canvas", async ({
+    page,
+  }) => {
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/entry/get": editorEntry(),
+      "/entry/createPreviewLink": {
+        token: "tok123",
+        url: "/post/hello?preview=tok123",
+      },
+    });
+
+    await page.goto("entries/posts/1/editor");
+
+    // The mock harness can't serve the public route the canvas iframe loads,
+    // so block selection (which arrives from inside the iframe) can't fire
+    // here — the host-side edit→autosave loop is covered by the package unit
+    // tests. This asserts the inspector rail mounts with the registry wired,
+    // showing its empty state until a block is selected.
+    await expect(page.getByTestId("plumix-editor-right")).toBeVisible();
+    await expect(page.getByTestId("block-inspector-empty")).toBeVisible();
+  });
+
   test("a failed preview mint surfaces the error placeholder, not a dead canvas", async ({
     page,
   }) => {

--- a/packages/admin/src/editor/autosave.ts
+++ b/packages/admin/src/editor/autosave.ts
@@ -1,0 +1,16 @@
+import { ORPCError } from "@orpc/client";
+
+// 1 s batches typing bursts; the dedup snapshot in each autosave closure is
+// what actually prevents identical revisions. WordPress's 60 s equivalent is
+// overkill here because we round-trip a workers DB on every save and revisions
+// are cheap.
+export const AUTOSAVE_DEBOUNCE_MS = 1000;
+
+// A stale optimistic-concurrency token: the live row moved since we read it.
+// Both editor routes recover by refetching the row and retrying.
+export function isStaleConflictError(err: unknown): boolean {
+  if (!(err instanceof ORPCError)) return false;
+  if (err.code !== "CONFLICT") return false;
+  const data = err.data as { reason?: unknown };
+  return data.reason === "stale_expected_updated_at";
+}

--- a/packages/admin/src/lib/i18n-boot.ts
+++ b/packages/admin/src/lib/i18n-boot.ts
@@ -20,6 +20,13 @@ const PLUGIN_CATALOGS = import.meta.glob<{ messages: Messages }>(
   "../../../plugins/*/locales/*.mjs",
 );
 
+// The bespoke editor package ships its own chrome catalog (inspector,
+// etc.); it's bundled into admin like a workspace plugin, so merge it
+// the same zero-runtime-cost way.
+const EDITOR_CATALOGS = import.meta.glob<{ messages: Messages }>(
+  "../../../admin-editor/locales/*.mjs",
+);
+
 // Source locale: the language `descriptor.message` strings are authored
 // in. When a user's locale isn't compiled (yet, or at all), we fall
 // back here. Mirrors `lingui.config.ts:sourceLocale`.
@@ -57,13 +64,18 @@ export async function bootI18n(): Promise<void> {
 
   const adminMessages = (await adminLoader()).messages;
   const workspaceMessages = await loadWorkspacePluginCatalogs(locale);
-  // Workspace plugins merged first, admin chrome second so admin
+  const editorMessages = await loadEditorCatalog(locale);
+  // Editor + workspace plugins merged first, admin chrome last so admin
   // wins on collision. Slice 5's note had the opposite order; chrome
   // stability matters more than letting a plugin override
   // `breadcrumb.dashboard`. Workspace-plugin collisions on
   // admin-namespaced keys are a build-time concern (future linter,
   // not enforced here yet).
-  i18n.load(locale, { ...workspaceMessages, ...adminMessages });
+  i18n.load(locale, {
+    ...editorMessages,
+    ...workspaceMessages,
+    ...adminMessages,
+  });
   i18n.activate(locale);
 
   // valibot validator messages registered via `vMessage(descriptor)`
@@ -85,6 +97,17 @@ export async function bootI18n(): Promise<void> {
       pluginCatalogLoaderRef.current(id, locale),
     ),
   );
+}
+
+// The editor catalog falls back to the source locale (unlike plugins) so its
+// chrome is never blank — admin always ships the editor, so an uncompiled
+// locale should still read English rather than the raw descriptor ids.
+async function loadEditorCatalog(locale: string): Promise<Messages> {
+  const loader =
+    EDITOR_CATALOGS[`../../../admin-editor/locales/${locale}.mjs`] ??
+    EDITOR_CATALOGS[`../../../admin-editor/locales/${SOURCE_LOCALE}.mjs`];
+  if (!loader) return {};
+  return (await loader()).messages;
 }
 
 async function loadWorkspacePluginCatalogs(locale: string): Promise<Messages> {

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -16,6 +16,10 @@ import { DocumentSettingsPanel } from "@/components/editor/document-settings.js"
 import { PlainFormLayout } from "@/components/editor/plain-form-layout.js";
 import { ErrorPlaceholder } from "@/components/error-placeholder.js";
 import { buildAdminPatternRegistry } from "@/editor/admin-pattern-registry.js";
+import {
+  AUTOSAVE_DEBOUNCE_MS,
+  isStaleConflictError,
+} from "@/editor/autosave.js";
 import { AutosaveStatusContext } from "@/editor/AutosaveStatus.js";
 import { blockSpecsToPuckComponents } from "@/editor/block-adapter.js";
 import { CoAuthorIndicator } from "@/editor/CoAuthorIndicator.js";
@@ -106,20 +110,6 @@ const EMPTY_COAUTHORS: readonly {
   email: string;
   lastSeenAt: Date;
 }[] = [];
-
-// 1 s batches typing bursts; the dedup snapshot in the autosave closure
-// is what actually prevents identical revisions. WordPress's 60 s
-// equivalent is overkill here because we round-trip a workers DB on
-// every save and revisions are cheap.
-const AUTOSAVE_DEBOUNCE_MS = 1000;
-
-// Keep in sync with the identical helper in _editor/entries/$slug/$id/edit.tsx.
-function isStaleConflictError(err: unknown): boolean {
-  if (!(err instanceof ORPCError)) return false;
-  if (err.code !== "CONFLICT") return false;
-  const data = err.data as { reason?: unknown };
-  return data.reason === "stale_expected_updated_at";
-}
 
 const themeTokens = getThemeTokens();
 

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/editor.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/editor.tsx
@@ -1,14 +1,28 @@
 import type { ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { ErrorPlaceholder } from "@/components/error-placeholder.js";
+import {
+  AUTOSAVE_DEBOUNCE_MS,
+  isStaleConflictError,
+} from "@/editor/autosave.js";
+import { createDebouncer } from "@/editor/debounce.js";
+import { registerCoreBlocks } from "@/editor/register-core-blocks.js";
 import { orpc } from "@/lib/orpc.js";
+import { getRegisteredBlocks } from "@/lib/plugin-registry.js";
 import { Trans } from "@lingui/react";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, notFound } from "@tanstack/react-router";
 import * as v from "valibot";
 
+import type { EntryContent } from "@plumix/blocks";
 import { PlumixEditor } from "@plumix/admin-editor";
-import { isEntryContent } from "@plumix/blocks";
+import { createBlockRegistry, isEntryContent } from "@plumix/blocks";
 import { idPathParam } from "@plumix/core/validation";
+
+// Core + plugin blocks supply the inspector's input schemas. Built once at
+// module load, mirroring the Puck route.
+registerCoreBlocks();
+const registry = createBlockRegistry(getRegisteredBlocks());
 
 // Mint once and cache forever — each call writes a fresh preview token, and
 // the URL it returns is the canvas iframe's target for the editor's lifetime.
@@ -86,6 +100,7 @@ function BespokeEditorRoute(): ReactNode {
     orpc.entry.get.queryOptions({ input: { id, preview: true } }),
   );
   const { data: previewLink } = useSuspenseQuery(previewLinkQuery(id));
+  const handleChange = useContentAutosave(id, entry);
 
   // `createPreviewLink` returns a site-relative url (`/blog/hello?preview=…`);
   // resolve it against the admin's own origin (the public site is same-origin)
@@ -98,6 +113,79 @@ function BespokeEditorRoute(): ReactNode {
       previewUrl={target.toString()}
       origin={target.origin}
       defaultValue={isEntryContent(entry.content) ? entry.content : undefined}
+      registry={registry}
+      onChange={handleChange}
     />
+  );
+}
+
+interface EntryRow {
+  readonly type: string;
+  readonly updatedAt: Date;
+  readonly content: unknown;
+}
+
+// Debounced content autosave. The editor package emits the full content
+// envelope on every tree change; this is the only place orpc lives (the
+// package stays persistence-free). Mirrors the Puck route's content path:
+// dedup against the last save, ride the optimistic-concurrency token, and
+// refresh it on a stale conflict so the next save recovers.
+function useContentAutosave(
+  id: number,
+  entry: EntryRow,
+): (content: EntryContent) => void {
+  const queryClient = useQueryClient();
+  const liveUpdatedAtRef = useRef<Date>(entry.updatedAt);
+  const lastSavedRef = useRef<string>(
+    JSON.stringify(isEntryContent(entry.content) ? entry.content.blocks : []),
+  );
+  const pendingRef = useRef<EntryContent | null>(null);
+  /* eslint-disable react-hooks/refs -- callback fires post-keystroke, not during render */
+  const debouncer = useMemo(
+    () =>
+      createDebouncer(async () => {
+        const content = pendingRef.current;
+        if (!content) return;
+        const serialized = JSON.stringify(content.blocks);
+        if (serialized === lastSavedRef.current) return;
+        try {
+          const updated = await orpc.entry.update.call({
+            id,
+            // Spread to a fresh object literal — the `content` RPC field is a
+            // `Record<string, unknown>`, which the named EntryContent interface
+            // doesn't satisfy without an index signature.
+            content: { ...content },
+            expectedLiveUpdatedAt: liveUpdatedAtRef.current,
+          });
+          // Only stamp the live token when the write landed on the live row;
+          // autosave-supporting types route to a per-user autosave row whose
+          // updatedAt isn't the live anchor (poisoning it would 409 publish).
+          if (updated.type === entry.type) {
+            liveUpdatedAtRef.current = updated.updatedAt;
+          }
+          lastSavedRef.current = serialized;
+        } catch (err) {
+          if (!isStaleConflictError(err)) return;
+          try {
+            const fresh = await queryClient.fetchQuery({
+              ...orpc.entry.get.queryOptions({ input: { id } }),
+              staleTime: 0,
+            });
+            liveUpdatedAtRef.current = fresh.updatedAt;
+          } catch {
+            // Best-effort: the next edit retries with the stale token.
+          }
+        }
+      }, AUTOSAVE_DEBOUNCE_MS),
+    [id, entry.type, queryClient],
+  );
+  /* eslint-enable react-hooks/refs */
+  useEffect(() => () => debouncer.flush(), [debouncer]);
+  return useCallback(
+    (content: EntryContent): void => {
+      pendingRef.current = content;
+      debouncer.call();
+    },
+    [debouncer],
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -461,16 +461,34 @@ importers:
 
   packages/admin-editor:
     dependencies:
+      '@plumix/admin-ui':
+        specifier: workspace:*
+        version: link:../admin-ui
       '@plumix/blocks':
         specifier: workspace:*
         version: link:../blocks
+      '@plumix/core':
+        specifier: workspace:*
+        version: link:../core
       zustand:
         specifier: ^5.0.14
         version: 5.0.14(@types/react@19.2.16)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
     devDependencies:
+      '@lingui/cli':
+        specifier: catalog:lingui
+        version: 6.3.0
+      '@lingui/core':
+        specifier: catalog:lingui
+        version: 6.3.0
+      '@lingui/react':
+        specifier: catalog:lingui
+        version: 6.3.0(react@19.2.7)
       '@plumix/eslint-config':
         specifier: workspace:*
         version: link:../../tooling/eslint
+      '@plumix/lingui-config':
+        specifier: workspace:*
+        version: link:../../tooling/lingui
       '@plumix/prettier-config':
         specifier: workspace:*
         version: link:../../tooling/prettier
@@ -11002,7 +11020,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.9(@types/node@25.9.2)(@vitest/coverage-v8@4.1.9)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.9':
     dependencies:


### PR DESCRIPTION
Wires the bespoke editor's first real editing capability: a right-rail
attribute inspector plus the live edit → persist loop (PRD #1104, slice #1106).

Selecting a block renders its registered inputs as admin-ui controls (text,
textarea, number, select, radio, checkbox, combobox). Editing patches the
canonical tree in the store, which the canvas bridge already pushes to the
iframe — so the block updates live with no reload. Slot inputs are deliberately
skipped: their value is a child-block array, edited via canvas selection of the
child, not a scalar control (editing one as text would overwrite the children).

The editor package stays persistence-free. `PlumixEditor` gained `registry` and
`onChange` props; it emits the full content envelope on every tree change, and
the admin route wires that to a debounced `entry.update` autosave with dedup,
the optimistic-concurrency token, and stale-conflict recovery. The shared
`isStaleConflictError` + `AUTOSAVE_DEBOUNCE_MS` were extracted to
`@/editor/autosave.ts` so the Puck route and this route can't drift apart on the
concurrency contract. Plugin block inputs render through the same renderer with
no plugin changes — the host passes the full core + plugin registry.

The package gains its own Lingui catalog (inspector chrome + block-author label
resolution via `resolveLabel`), merged into the admin runtime i18n alongside the
workspace plugins.

Note on test coverage: the canvas is an iframe loading the real public route,
which the admin e2e mock harness can't serve, so block selection (which arrives
from inside the iframe) can't fire in e2e. The host-side edit→store→onChange
loop is covered by the package unit tests; the e2e asserts the inspector rail
mounts with the registry wired. A follow-up will evaluate extracting a shared
`useContentAutosave` hook once both routes stabilize.

Closes #1106