### PR TITLE
feat: block inserter for the bespoke editor — catalog, drag & empty state

### DIFF
--- a/packages/admin-editor/locales/ar.po
+++ b/packages/admin-editor/locales/ar.po
@@ -6,6 +6,27 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: ar\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. js-lingui-explicit-id
+#: src/canvas-frame.tsx
+msgid "editor.canvas.addBlock"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/block-catalog-tab.tsx
+msgid "editor.catalog.noResults"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/block-catalog-tab.tsx
+msgid "editor.catalog.searchLabel"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/block-inspector.tsx

--- a/packages/admin-editor/locales/de.po
+++ b/packages/admin-editor/locales/de.po
@@ -6,6 +6,27 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: de\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. js-lingui-explicit-id
+#: src/canvas-frame.tsx
+msgid "editor.canvas.addBlock"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/block-catalog-tab.tsx
+msgid "editor.catalog.noResults"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/block-catalog-tab.tsx
+msgid "editor.catalog.searchLabel"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/block-inspector.tsx

--- a/packages/admin-editor/locales/en.po
+++ b/packages/admin-editor/locales/en.po
@@ -6,6 +6,27 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. js-lingui-explicit-id
+#: src/canvas-frame.tsx
+msgid "editor.canvas.addBlock"
+msgstr "Add a block"
+
+#. js-lingui-explicit-id
+#: src/block-catalog-tab.tsx
+msgid "editor.catalog.noResults"
+msgstr "No blocks match your search."
+
+#. js-lingui-explicit-id
+#: src/block-catalog-tab.tsx
+msgid "editor.catalog.searchLabel"
+msgstr "Search blocks"
 
 #. js-lingui-explicit-id
 #: src/block-inspector.tsx

--- a/packages/admin-editor/locales/uk.po
+++ b/packages/admin-editor/locales/uk.po
@@ -6,6 +6,27 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: uk\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. js-lingui-explicit-id
+#: src/canvas-frame.tsx
+msgid "editor.canvas.addBlock"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/block-catalog-tab.tsx
+msgid "editor.catalog.noResults"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/block-catalog-tab.tsx
+msgid "editor.catalog.searchLabel"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/block-inspector.tsx

--- a/packages/admin-editor/locales/zh-CN.po
+++ b/packages/admin-editor/locales/zh-CN.po
@@ -6,6 +6,27 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: zh-CN\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. js-lingui-explicit-id
+#: src/canvas-frame.tsx
+msgid "editor.canvas.addBlock"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/block-catalog-tab.tsx
+msgid "editor.catalog.noResults"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/block-catalog-tab.tsx
+msgid "editor.catalog.searchLabel"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/block-inspector.tsx

--- a/packages/admin-editor/src/block-catalog-tab.test.tsx
+++ b/packages/admin-editor/src/block-catalog-tab.test.tsx
@@ -1,0 +1,84 @@
+import type { ReactElement } from "react";
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, test } from "vitest";
+
+import { createBlockRegistry } from "@plumix/blocks";
+
+import { BlockCatalog } from "./block-catalog-tab.js";
+import { EditorProvider, useEditorStore } from "./provider.js";
+
+beforeAll(() => {
+  i18n.loadAndActivate({ locale: "en", messages: {} });
+});
+
+afterEach(cleanup);
+
+const registry = createBlockRegistry([
+  {
+    name: "core/heading",
+    render: () => null,
+    category: "text",
+    title: "Heading",
+  },
+  { name: "core/quote", render: () => null, category: "text", title: "Quote" },
+  { name: "core/image", render: () => null, category: "media", title: "Image" },
+]);
+
+const NO_CAPS: ReadonlySet<string> = new Set();
+
+function TreeProbe(): ReactElement {
+  const ids = useEditorStore((s) => s.tree.map((n) => n.name).join(","));
+  return <output data-testid="tree-probe">{ids}</output>;
+}
+
+function renderCatalog(): ReturnType<typeof render> {
+  return render(
+    <I18nProvider i18n={i18n}>
+      <EditorProvider initialTree={[]}>
+        <BlockCatalog registry={registry} capabilities={NO_CAPS} />
+        <TreeProbe />
+      </EditorProvider>
+    </I18nProvider>,
+  );
+}
+
+describe("BlockCatalog", () => {
+  test("lists blocks grouped by category", () => {
+    const { getByTestId } = renderCatalog();
+    expect(getByTestId("block-catalog-group-text")).toBeDefined();
+    expect(getByTestId("block-catalog-group-media")).toBeDefined();
+    expect(getByTestId("block-catalog-item-core/heading")).toBeDefined();
+    expect(getByTestId("block-catalog-item-core/image")).toBeDefined();
+  });
+
+  test("search narrows the catalog", () => {
+    const { getByTestId, queryByTestId } = renderCatalog();
+    fireEvent.change(getByTestId("block-catalog-search"), {
+      target: { value: "quote" },
+    });
+    expect(getByTestId("block-catalog-item-core/quote")).toBeDefined();
+    expect(queryByTestId("block-catalog-item-core/heading")).toBeNull();
+    expect(queryByTestId("block-catalog-group-media")).toBeNull();
+  });
+
+  test("a no-match search shows the empty state", () => {
+    const { getByTestId, queryByTestId } = renderCatalog();
+    fireEvent.change(getByTestId("block-catalog-search"), {
+      target: { value: "zzz" },
+    });
+    expect(getByTestId("block-catalog-empty")).toBeDefined();
+    expect(queryByTestId("block-catalog-item-core/heading")).toBeNull();
+  });
+
+  test("clicking a block appends it to the tree", () => {
+    const { getByTestId } = renderCatalog();
+    fireEvent.click(getByTestId("block-catalog-item-core/heading"));
+    fireEvent.click(getByTestId("block-catalog-item-core/image"));
+    // Appended in click order.
+    expect(getByTestId("tree-probe").textContent).toBe(
+      "core/heading,core/image",
+    );
+  });
+});

--- a/packages/admin-editor/src/block-catalog-tab.tsx
+++ b/packages/admin-editor/src/block-catalog-tab.tsx
@@ -1,0 +1,91 @@
+import type { ReactElement } from "react";
+import { useId, useMemo, useState } from "react";
+import { Trans, useLingui } from "@lingui/react";
+
+import type { BlockRegistry } from "@plumix/blocks";
+import { Input } from "@plumix/admin-ui/input";
+import { resolveLabel } from "@plumix/core/i18n";
+
+import { createBlockFromSpec, groupBlocksByCategory } from "./block-catalog.js";
+import { useEditorStore } from "./provider.js";
+
+interface BlockCatalogProps {
+  readonly registry: BlockRegistry;
+  readonly capabilities: ReadonlySet<string>;
+}
+
+/**
+ * Left-rail block inserter: a searchable catalog grouped by category. Clicking
+ * a block appends it; pressing on one starts a drag the canvas resolves to a
+ * positional drop. Both paths go through the store's insert/drag actions, so
+ * the live patch loop renders and persists the result.
+ */
+export function BlockCatalog({
+  registry,
+  capabilities,
+}: BlockCatalogProps): ReactElement {
+  const { i18n } = useLingui();
+  const searchId = useId();
+  const [query, setQuery] = useState("");
+  const insertBlock = useEditorStore((s) => s.insertBlock);
+  const startBlockDrag = useEditorStore((s) => s.startBlockDrag);
+  const treeLength = useEditorStore((s) => s.tree.length);
+
+  const groups = useMemo(
+    () => groupBlocksByCategory(registry, { capabilities, query }),
+    [registry, capabilities, query],
+  );
+
+  return (
+    <div className="flex flex-col gap-3 p-3" data-testid="block-catalog">
+      <label htmlFor={searchId} className="sr-only">
+        <Trans id="editor.catalog.searchLabel" message="Search blocks" />
+      </label>
+      <Input
+        id={searchId}
+        type="search"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        data-testid="block-catalog-search"
+      />
+      {groups.length === 0 ? (
+        <p
+          className="text-muted-foreground text-sm"
+          data-testid="block-catalog-empty"
+        >
+          <Trans
+            id="editor.catalog.noResults"
+            message="No blocks match your search."
+          />
+        </p>
+      ) : (
+        groups.map((group) => (
+          <section
+            key={group.category}
+            data-testid={`block-catalog-group-${group.category}`}
+          >
+            <h3 className="text-muted-foreground mb-1 text-xs font-medium tracking-wide uppercase">
+              {group.category}
+            </h3>
+            <div className="grid grid-cols-2 gap-2">
+              {group.blocks.map((spec) => (
+                <button
+                  key={spec.name}
+                  type="button"
+                  data-testid={`block-catalog-item-${spec.name}`}
+                  className="border-input hover:bg-accent rounded-md border p-2 text-start text-sm"
+                  onPointerDown={() => startBlockDrag(spec)}
+                  onClick={() =>
+                    insertBlock(createBlockFromSpec(spec), treeLength)
+                  }
+                >
+                  {resolveLabel(spec.title ?? spec.name, i18n)}
+                </button>
+              ))}
+            </div>
+          </section>
+        ))
+      )}
+    </div>
+  );
+}

--- a/packages/admin-editor/src/block-catalog.test.ts
+++ b/packages/admin-editor/src/block-catalog.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "vitest";
+
+import type { BlockSpec } from "@plumix/blocks";
+import { createBlockRegistry } from "@plumix/blocks";
+
+import { createBlockFromSpec, groupBlocksByCategory } from "./block-catalog.js";
+
+const spec = (over: Partial<BlockSpec> & { name: string }): BlockSpec => ({
+  render: () => null,
+  ...over,
+});
+
+const NO_CAPS: ReadonlySet<string> = new Set();
+
+describe("groupBlocksByCategory", () => {
+  test("groups eligible blocks by category in first-seen order", () => {
+    const registry = createBlockRegistry([
+      spec({ name: "core/heading", category: "text", title: "Heading" }),
+      spec({ name: "core/image", category: "media", title: "Image" }),
+      spec({ name: "core/quote", category: "text", title: "Quote" }),
+    ]);
+
+    const groups = groupBlocksByCategory(registry, { capabilities: NO_CAPS });
+
+    expect(groups.map((g) => g.category)).toEqual(["text", "media"]);
+    expect(groups[0]?.blocks.map((b) => b.name)).toEqual([
+      "core/heading",
+      "core/quote",
+    ]);
+  });
+
+  test("falls back to 'uncategorized' for specs without a category", () => {
+    const registry = createBlockRegistry([spec({ name: "core/x" })]);
+
+    const groups = groupBlocksByCategory(registry, { capabilities: NO_CAPS });
+
+    expect(groups[0]?.category).toBe("uncategorized");
+  });
+
+  test("excludes blocks with inserter:false", () => {
+    const registry = createBlockRegistry([
+      spec({ name: "core/heading", category: "text" }),
+      spec({ name: "core/internal", category: "text", inserter: false }),
+    ]);
+
+    const groups = groupBlocksByCategory(registry, { capabilities: NO_CAPS });
+
+    expect(groups[0]?.blocks.map((b) => b.name)).toEqual(["core/heading"]);
+  });
+
+  test("excludes capability-gated blocks the viewer lacks", () => {
+    const registry = createBlockRegistry([
+      spec({ name: "core/public", category: "text" }),
+      spec({
+        name: "core/secret",
+        category: "text",
+        capability: "blocks:secret",
+      }),
+    ]);
+
+    const lacking = groupBlocksByCategory(registry, { capabilities: NO_CAPS });
+    expect(lacking[0]?.blocks.map((b) => b.name)).toEqual(["core/public"]);
+
+    const granted = groupBlocksByCategory(registry, {
+      capabilities: new Set(["blocks:secret"]),
+    });
+    expect(granted[0]?.blocks.map((b) => b.name)).toEqual([
+      "core/public",
+      "core/secret",
+    ]);
+  });
+
+  test("filters by query against title, name and keywords; drops empty groups", () => {
+    const registry = createBlockRegistry([
+      spec({ name: "core/heading", category: "text", title: "Heading" }),
+      spec({
+        name: "core/quote",
+        category: "text",
+        title: "Quote",
+        keywords: ["citation"],
+      }),
+      spec({ name: "core/image", category: "media", title: "Image" }),
+    ]);
+
+    // Title match.
+    expect(
+      groupBlocksByCategory(registry, {
+        capabilities: NO_CAPS,
+        query: "head",
+      }).flatMap((g) => g.blocks.map((b) => b.name)),
+    ).toEqual(["core/heading"]);
+
+    // Keyword match — the media group is dropped (no matches).
+    const byKeyword = groupBlocksByCategory(registry, {
+      capabilities: NO_CAPS,
+      query: "citation",
+    });
+    expect(byKeyword.map((g) => g.category)).toEqual(["text"]);
+    expect(byKeyword[0]?.blocks.map((b) => b.name)).toEqual(["core/quote"]);
+  });
+});
+
+describe("createBlockFromSpec", () => {
+  test("mints a fresh node with the spec's name and defaults", () => {
+    const node = createBlockFromSpec(
+      spec({ name: "core/heading", defaults: { level: 2 } }),
+    );
+    expect(node.name).toBe("core/heading");
+    expect(node.attrs).toEqual({ level: 2 });
+    // A real, non-seed id so two inserts never collide.
+    expect(node.id).not.toBe("seed");
+    expect(node.id.length).toBeGreaterThan(0);
+    expect(createBlockFromSpec(spec({ name: "core/heading" })).id).not.toBe(
+      node.id,
+    );
+  });
+});

--- a/packages/admin-editor/src/block-catalog.ts
+++ b/packages/admin-editor/src/block-catalog.ts
@@ -1,0 +1,73 @@
+import type { BlockNode, BlockRegistry, BlockSpec } from "@plumix/blocks";
+import { rewriteBlockNodeIds } from "@plumix/blocks";
+import { labelSourceText } from "@plumix/core/i18n";
+
+interface CatalogGroup {
+  readonly category: string;
+  readonly blocks: readonly BlockSpec[];
+}
+
+const UNCATEGORIZED = "uncategorized";
+
+interface GroupOptions {
+  readonly capabilities: ReadonlySet<string>;
+  /** Case-insensitive filter over name, title and keywords. */
+  readonly query?: string;
+}
+
+/**
+ * Build the inserter catalog: eligible blocks (shown in the inserter and
+ * within the viewer's capabilities), optionally filtered by query, grouped by
+ * category. Category and within-category order follow registry iteration
+ * order; empty groups are dropped.
+ */
+export function groupBlocksByCategory(
+  registry: BlockRegistry,
+  { capabilities, query }: GroupOptions,
+): readonly CatalogGroup[] {
+  const needle = query?.trim().toLowerCase() ?? "";
+  const order: string[] = [];
+  const buckets = new Map<string, BlockSpec[]>();
+  for (const spec of registry) {
+    if (spec.inserter === false) continue;
+    if (spec.capability && !capabilities.has(spec.capability)) continue;
+    if (needle && !matchesQuery(spec, needle)) continue;
+    const category = spec.category ?? UNCATEGORIZED;
+    let bucket = buckets.get(category);
+    if (!bucket) {
+      bucket = [];
+      buckets.set(category, bucket);
+      order.push(category);
+    }
+    bucket.push(spec);
+  }
+  return order.map((category) => ({
+    category,
+    blocks: buckets.get(category) ?? [],
+  }));
+}
+
+/** A fresh, insertable block node from a catalog spec: its defaults plus a
+ *  freshly minted id (reusing the same crypto id path as pattern insertion). */
+export function createBlockFromSpec(spec: BlockSpec): BlockNode {
+  const seed: BlockNode = {
+    id: "seed",
+    name: spec.name,
+    attrs: { ...spec.defaults },
+  };
+  const [node = seed] = rewriteBlockNodeIds([seed]);
+  return node;
+}
+
+function matchesQuery(spec: BlockSpec, needle: string): boolean {
+  if (spec.name.toLowerCase().includes(needle)) return true;
+  if (
+    spec.title !== undefined &&
+    labelSourceText(spec.title).toLowerCase().includes(needle)
+  ) {
+    return true;
+  }
+  return (spec.keywords ?? []).some((keyword) =>
+    labelSourceText(keyword).toLowerCase().includes(needle),
+  );
+}

--- a/packages/admin-editor/src/canvas-frame.test.tsx
+++ b/packages/admin-editor/src/canvas-frame.test.tsx
@@ -1,12 +1,30 @@
-import { act, cleanup, render } from "@testing-library/react";
-import { afterEach, describe, expect, test } from "vitest";
+import type { ReactElement, ReactNode } from "react";
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, test } from "vitest";
 
+import { createBlockRegistry } from "@plumix/blocks";
 import { EDITOR_BRIDGE_CHANNEL, encode } from "@plumix/blocks/renderer";
 
 import { CanvasFrame } from "./canvas-frame.js";
-import { EditorProvider } from "./provider.js";
+import { EditorProvider, useEditorStore } from "./provider.js";
 
 const ORIGIN = "http://localhost:3000";
+
+const registry = createBlockRegistry([
+  {
+    name: "core/heading",
+    render: () => null,
+    category: "text",
+    title: "Heading",
+  },
+]);
+const NO_CAPS: ReadonlySet<string> = new Set();
+
+beforeAll(() => {
+  i18n.loadAndActivate({ locale: "en", messages: {} });
+});
 
 afterEach(cleanup);
 
@@ -21,12 +39,30 @@ function fromCanvas(message: unknown): void {
   });
 }
 
+function Wrapper({ children }: { readonly children: ReactNode }): ReactElement {
+  return (
+    <I18nProvider i18n={i18n}>
+      <EditorProvider>{children}</EditorProvider>
+    </I18nProvider>
+  );
+}
+
+function TreeProbe(): ReactElement {
+  const names = useEditorStore((s) => s.tree.map((n) => n.name).join(","));
+  return <output data-testid="tree-probe">{names}</output>;
+}
+
 describe("CanvasFrame", () => {
   test("renders the iframe at the device width", () => {
     const { container } = render(
-      <EditorProvider>
-        <CanvasFrame previewUrl="about:blank" origin={ORIGIN} />
-      </EditorProvider>,
+      <Wrapper>
+        <CanvasFrame
+          previewUrl="about:blank"
+          origin={ORIGIN}
+          registry={registry}
+          capabilities={NO_CAPS}
+        />
+      </Wrapper>,
     );
 
     const iframe = container.querySelector("iframe");
@@ -36,12 +72,16 @@ describe("CanvasFrame", () => {
 
   test("draws a selection overlay from the canvas's reported geometry", () => {
     const { queryByTestId } = render(
-      <EditorProvider>
-        <CanvasFrame previewUrl="about:blank" origin={ORIGIN} />
-      </EditorProvider>,
+      <Wrapper>
+        <CanvasFrame
+          previewUrl="about:blank"
+          origin={ORIGIN}
+          registry={registry}
+          capabilities={NO_CAPS}
+        />
+      </Wrapper>,
     );
 
-    // The canvas reports a click (→ selection) and the block geometry.
     fromCanvas({ type: "canvas:select", id: "h1" });
     fromCanvas({
       type: "canvas:geometry",
@@ -49,5 +89,25 @@ describe("CanvasFrame", () => {
     });
 
     expect(queryByTestId("plumix-overlay-selected")).not.toBeNull();
+  });
+
+  test("empty-state affordance inserts the first catalog block", () => {
+    const { getByTestId, queryByTestId } = render(
+      <Wrapper>
+        <CanvasFrame
+          previewUrl="about:blank"
+          origin={ORIGIN}
+          registry={registry}
+          capabilities={NO_CAPS}
+        />
+        <TreeProbe />
+      </Wrapper>,
+    );
+
+    expect(getByTestId("tree-probe").textContent).toBe("");
+    fireEvent.click(getByTestId("plumix-empty-add"));
+    expect(getByTestId("tree-probe").textContent).toBe("core/heading");
+    // Affordance disappears once the canvas is no longer empty.
+    expect(queryByTestId("plumix-empty-add")).toBeNull();
   });
 });

--- a/packages/admin-editor/src/canvas-frame.tsx
+++ b/packages/admin-editor/src/canvas-frame.tsx
@@ -1,10 +1,14 @@
 import type { ReactElement } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Trans } from "@lingui/react";
 
+import type { BlockRegistry } from "@plumix/blocks";
 import type { BlockRect } from "@plumix/blocks/renderer";
 
 import type { FrameOffset } from "./overlay.js";
+import { createBlockFromSpec, groupBlocksByCategory } from "./block-catalog.js";
 import { connectCanvas } from "./connect-canvas.js";
+import { dropPlacement } from "./drop-index.js";
 import { overlayBox } from "./overlay.js";
 import { useEditorStore, useEditorStoreApi } from "./provider.js";
 import { DEVICE_WIDTH } from "./store.js";
@@ -14,32 +18,49 @@ interface CanvasFrameProps {
   readonly previewUrl: string;
   /** Origin of that route, for bridge message pinning. */
   readonly origin: string;
+  /** Catalog for the empty-state affordance's default block. */
+  readonly registry: BlockRegistry;
+  /** Viewer capabilities, gating which block the empty state inserts. */
+  readonly capabilities: ReadonlySet<string>;
 }
 
 const SELECTED_OUTLINE = "#2563eb";
 const HOVER_OUTLINE = "rgba(37,99,235,0.4)";
 const CANVAS_HEIGHT = 800;
 
+interface Geometry {
+  readonly rects: ReadonlyMap<string, BlockRect>;
+  readonly frame: FrameOffset | null;
+}
+
 /**
  * Host-side canvas: loads the real route in an iframe, drives it via the
- * bridge, and draws selection/hover overlays in the shell's coordinate space
- * (computed from the canvas-reported geometry, so they stay aligned at zoom).
+ * bridge, draws selection/hover overlays in the shell's coordinate space, and
+ * resolves catalog drags into top-level inserts (a drop indicator follows the
+ * pointer; releasing over the canvas inserts at that position).
  */
 export function CanvasFrame({
   previewUrl,
   origin,
+  registry,
+  capabilities,
 }: CanvasFrameProps): ReactElement {
   const store = useEditorStoreApi();
   const device = useEditorStore((s) => s.device);
   const zoom = useEditorStore((s) => s.zoom);
   const activeId = useEditorStore((s) => s.activeId);
   const hoverId = useEditorStore((s) => s.hoverId);
+  const dragSpec = useEditorStore((s) => s.dragSpec);
+  const isEmpty = useEditorStore((s) => s.tree.length === 0);
   const iframeRef = useRef<HTMLIFrameElement>(null);
-  // Captured together in the geometry callback — never read the ref in render.
-  const [geometry, setGeometry] = useState<{
-    readonly rects: ReadonlyMap<string, BlockRect>;
-    readonly frame: FrameOffset | null;
-  }>({ rects: new Map(), frame: null });
+  const [geometry, setGeometry] = useState<Geometry>({
+    rects: new Map(),
+    frame: null,
+  });
+  // Mirror geometry for the drag handler so it reads fresh rects without
+  // re-subscribing the window listeners on every geometry report.
+  const geometryRef = useRef<Geometry>(geometry);
+  const [dropY, setDropY] = useState<number | null>(null);
 
   useEffect(() => {
     const frameWindow = iframeRef.current?.contentWindow;
@@ -49,15 +70,83 @@ export function CanvasFrame({
       frameWindow,
       origin,
       onGeometry: (reported) => {
-        const frame = iframeRef.current?.getBoundingClientRect();
-        setGeometry({
+        const rect = iframeRef.current?.getBoundingClientRect();
+        const next: Geometry = {
           rects: new Map(reported.map((r) => [r.id, r])),
-          frame: frame ? { left: frame.left, top: frame.top } : null,
-        });
+          frame: rect ? { left: rect.left, top: rect.top } : null,
+        };
+        geometryRef.current = next;
+        setGeometry(next);
       },
     });
     return () => connection.dispose();
   }, [store, origin]);
+
+  // Catalog drag → top-level insert. While dragging, the iframe ignores pointer
+  // events so the host keeps receiving them over the canvas; the placement is
+  // computed from the reported block geometry mapped into screen space.
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!dragSpec || !iframe) return;
+    iframe.style.pointerEvents = "none";
+
+    const placementAt = (clientX: number, clientY: number) => {
+      const rect = iframe.getBoundingClientRect();
+      const over =
+        clientX >= rect.left &&
+        clientX <= rect.right &&
+        clientY >= rect.top &&
+        clientY <= rect.bottom;
+      if (!over) return null;
+      const frame: FrameOffset = { left: rect.left, top: rect.top };
+      const { tree, zoom: z } = store.getState();
+      const spans = tree.flatMap((node) => {
+        const r = geometryRef.current.rects.get(node.id);
+        if (!r) return [];
+        const box = overlayBox(r, frame, z);
+        return [{ y: box.top, height: box.height }];
+      });
+      return dropPlacement(spans, clientY);
+    };
+
+    const onMove = (e: PointerEvent): void => {
+      setDropY(placementAt(e.clientX, e.clientY)?.indicatorY ?? null);
+    };
+    const onUp = (e: PointerEvent): void => {
+      const placement = placementAt(e.clientX, e.clientY);
+      if (placement) {
+        store
+          .getState()
+          .insertBlock(createBlockFromSpec(dragSpec), placement.index);
+      }
+      store.getState().endBlockDrag();
+    };
+    // Without this, a pointercancel (touch interruption, context menu, drag
+    // into a native element) or Escape would skip onUp, stranding dragSpec set
+    // and the iframe permanently non-interactive (pointerEvents: none).
+    const onCancel = (): void => store.getState().endBlockDrag();
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === "Escape") store.getState().endBlockDrag();
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+    window.addEventListener("pointercancel", onCancel);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onCancel);
+      window.removeEventListener("keydown", onKey);
+      iframe.style.pointerEvents = "";
+      setDropY(null);
+    };
+  }, [dragSpec, store]);
+
+  const addFirstBlock = useCallback((): void => {
+    const [group] = groupBlocksByCategory(registry, { capabilities });
+    const spec = group?.blocks[0];
+    if (spec) store.getState().insertBlock(createBlockFromSpec(spec), 0);
+  }, [registry, capabilities, store]);
 
   const overlay = (
     id: string | null,
@@ -104,6 +193,33 @@ export function CanvasFrame({
       />
       {overlay(hoverId, HOVER_OUTLINE, "plumix-overlay-hover")}
       {overlay(activeId, SELECTED_OUTLINE, "plumix-overlay-selected")}
+      {dropY !== null && geometry.frame && (
+        <div
+          data-testid="plumix-drop-indicator"
+          style={{
+            position: "fixed",
+            left: geometry.frame.left,
+            top: dropY,
+            width: DEVICE_WIDTH[device] * zoom,
+            height: 2,
+            background: SELECTED_OUTLINE,
+            pointerEvents: "none",
+            zIndex: 20,
+          }}
+        />
+      )}
+      {/* Stays visible during a drag so an empty canvas still shows a drop
+          target (no block geometry exists to draw an indicator against). */}
+      {isEmpty && (
+        <button
+          type="button"
+          data-testid="plumix-empty-add"
+          onClick={addFirstBlock}
+          className="border-muted-foreground/40 text-muted-foreground hover:bg-accent absolute inset-x-8 top-8 rounded-md border border-dashed p-6 text-sm"
+        >
+          <Trans id="editor.canvas.addBlock" message="Add a block" />
+        </button>
+      )}
     </div>
   );
 }

--- a/packages/admin-editor/src/drop-index.test.ts
+++ b/packages/admin-editor/src/drop-index.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vitest";
+
+import { dropIndexFromPointer, dropPlacement } from "./drop-index.js";
+
+// Three stacked blocks, 100px tall each: midpoints at 50, 150, 250.
+const SPANS = [
+  { y: 0, height: 100 },
+  { y: 100, height: 100 },
+  { y: 200, height: 100 },
+];
+
+describe("dropIndexFromPointer", () => {
+  test("returns 0 above the first block's midpoint", () => {
+    expect(dropIndexFromPointer(SPANS, 10)).toBe(0);
+    expect(dropIndexFromPointer(SPANS, 49)).toBe(0);
+  });
+
+  test("returns the index of the block whose midpoint the pointer passed", () => {
+    expect(dropIndexFromPointer(SPANS, 51)).toBe(1);
+    expect(dropIndexFromPointer(SPANS, 149)).toBe(1);
+    expect(dropIndexFromPointer(SPANS, 151)).toBe(2);
+  });
+
+  test("returns the end index below the last midpoint", () => {
+    expect(dropIndexFromPointer(SPANS, 260)).toBe(3);
+  });
+
+  test("returns 0 for an empty canvas", () => {
+    expect(dropIndexFromPointer([], 42)).toBe(0);
+  });
+});
+
+describe("dropPlacement", () => {
+  test("indicator sits at the top edge of the block dropped before", () => {
+    expect(dropPlacement(SPANS, 51)).toEqual({ index: 1, indicatorY: 100 });
+  });
+
+  test("indicator sits at the bottom edge when dropping at the end", () => {
+    expect(dropPlacement(SPANS, 999)).toEqual({ index: 3, indicatorY: 300 });
+  });
+
+  test("no indicator for an empty canvas", () => {
+    expect(dropPlacement([], 10)).toEqual({ index: 0, indicatorY: null });
+  });
+});

--- a/packages/admin-editor/src/drop-index.ts
+++ b/packages/admin-editor/src/drop-index.ts
@@ -1,0 +1,42 @@
+/** A block's vertical extent in the coordinate space the pointer is measured in. */
+interface VerticalSpan {
+  readonly y: number;
+  readonly height: number;
+}
+
+/**
+ * The top-level insertion index for a pointer at `pointerY`: drop before the
+ * first block whose vertical midpoint the pointer hasn't passed, or at the end
+ * if it's below them all. `spans` must be in tree order and the same
+ * coordinate space as `pointerY`.
+ */
+export function dropIndexFromPointer(
+  spans: readonly VerticalSpan[],
+  pointerY: number,
+): number {
+  for (let i = 0; i < spans.length; i++) {
+    const span = spans[i];
+    if (span && pointerY < span.y + span.height / 2) return i;
+  }
+  return spans.length;
+}
+
+interface DropPlacement {
+  /** Top-level insertion index. */
+  readonly index: number;
+  /** Y of the drop-indicator line, or null when the canvas has no blocks. */
+  readonly indicatorY: number | null;
+}
+
+/** Insertion index plus where to draw the drop indicator: at the top edge of
+ *  the block we'd insert before, or the bottom edge of the last block. */
+export function dropPlacement(
+  spans: readonly VerticalSpan[],
+  pointerY: number,
+): DropPlacement {
+  const index = dropIndexFromPointer(spans, pointerY);
+  const last = spans[spans.length - 1];
+  if (!last) return { index: 0, indicatorY: null };
+  const target = spans[index];
+  return { index, indicatorY: target ? target.y : last.y + last.height };
+}

--- a/packages/admin-editor/src/plumix-editor.tsx
+++ b/packages/admin-editor/src/plumix-editor.tsx
@@ -4,9 +4,12 @@ import { useEffect, useRef } from "react";
 import type { BlockRegistry, EntryContent } from "@plumix/blocks";
 import { defineEntryContent } from "@plumix/blocks";
 
+import { BlockCatalog } from "./block-catalog-tab.js";
 import { BlockInspector } from "./block-inspector.js";
 import { CanvasFrame } from "./canvas-frame.js";
 import { EditorProvider, useEditorStoreApi } from "./provider.js";
+
+const NO_CAPABILITIES: ReadonlySet<string> = new Set();
 
 interface PlumixEditorProps {
   /** Seed content; the editor owns state thereafter (uncontrolled). */
@@ -15,8 +18,10 @@ interface PlumixEditorProps {
   readonly previewUrl: string;
   /** Origin of that route, for bridge message pinning. */
   readonly origin: string;
-  /** Core + plugin block registry, supplying the inspector's input schemas. */
+  /** Core + plugin block registry, supplying the inspector + catalog schemas. */
   readonly registry: BlockRegistry;
+  /** Viewer capabilities, gating which blocks the catalog offers. */
+  readonly capabilities?: ReadonlySet<string>;
   /** Fires with the full content envelope whenever the tree changes. The host
    *  debounces + persists (orpc lives in the app, never in this package). */
   readonly onChange?: (content: EntryContent) => void;
@@ -32,12 +37,24 @@ export function PlumixEditor({
   previewUrl,
   origin,
   registry,
+  capabilities = NO_CAPABILITIES,
   onChange,
 }: PlumixEditorProps): ReactElement {
   return (
     <EditorProvider initialTree={defaultValue?.blocks}>
       <div className="flex h-full" data-testid="plumix-editor-layout">
-        <CanvasFrame previewUrl={previewUrl} origin={origin} />
+        <aside
+          className="bg-background w-72 shrink-0 overflow-auto border-e"
+          data-testid="plumix-editor-left"
+        >
+          <BlockCatalog registry={registry} capabilities={capabilities} />
+        </aside>
+        <CanvasFrame
+          previewUrl={previewUrl}
+          origin={origin}
+          registry={registry}
+          capabilities={capabilities}
+        />
         <aside
           className="bg-background w-80 shrink-0 overflow-auto border-s"
           data-testid="plumix-editor-right"

--- a/packages/admin-editor/src/store.test.ts
+++ b/packages/admin-editor/src/store.test.ts
@@ -116,6 +116,45 @@ describe("editor store", () => {
   });
 });
 
+describe("insertBlock", () => {
+  test("inserts a block at the given top-level index and selects it", () => {
+    const store = createEditorStore({
+      tree: [
+        { id: "a", name: "core/heading" },
+        { id: "b", name: "core/spacer" },
+      ],
+    });
+
+    store.getState().insertBlock({ id: "new", name: "core/rich-text" }, 1);
+
+    expect(store.getState().tree.map((n) => n.id)).toEqual(["a", "new", "b"]);
+    // The freshly inserted block becomes the active selection.
+    expect(store.getState().activeId).toBe("new");
+    expect([...store.getState().selectedIds]).toEqual(["new"]);
+  });
+
+  test("clamps an out-of-range index to the ends", () => {
+    const store = createEditorStore({ tree: [{ id: "a", name: "core/x" }] });
+
+    store.getState().insertBlock({ id: "head", name: "core/y" }, -5);
+    store.getState().insertBlock({ id: "tail", name: "core/z" }, 99);
+
+    expect(store.getState().tree.map((n) => n.id)).toEqual([
+      "head",
+      "a",
+      "tail",
+    ]);
+  });
+
+  test("inserts into an empty tree", () => {
+    const store = createEditorStore();
+
+    store.getState().insertBlock({ id: "first", name: "core/heading" }, 0);
+
+    expect(store.getState().tree.map((n) => n.id)).toEqual(["first"]);
+  });
+});
+
 describe("findBlock", () => {
   test("finds a top-level block by id", () => {
     const tree: readonly BlockNode[] = [

--- a/packages/admin-editor/src/store.ts
+++ b/packages/admin-editor/src/store.ts
@@ -1,6 +1,6 @@
 import { createStore } from "zustand/vanilla";
 
-import type { BlockNode } from "@plumix/blocks";
+import type { BlockNode, BlockSpec } from "@plumix/blocks";
 import { isBlockNodeArray } from "@plumix/blocks";
 
 export type EditorDevice = "desktop" | "tablet" | "mobile";
@@ -25,10 +25,14 @@ export interface EditorState {
   readonly hoverId: string | null;
   readonly device: EditorDevice;
   readonly zoom: number;
+  /** The catalog block currently being dragged toward the canvas, if any. */
+  readonly dragSpec: BlockSpec | null;
 }
 
 export interface EditorActions {
   setTree: (tree: readonly BlockNode[]) => void;
+  /** Insert a block at a top-level index (clamped) and select it. */
+  insertBlock: (node: BlockNode, index: number) => void;
   /** Merge a partial attrs patch into one block, anywhere in the tree. */
   updateBlockAttrs: (
     id: string,
@@ -39,6 +43,8 @@ export interface EditorActions {
   setHover: (id: string | null) => void;
   setDevice: (device: EditorDevice) => void;
   setZoom: (zoom: number) => void;
+  startBlockDrag: (spec: BlockSpec) => void;
+  endBlockDrag: () => void;
 }
 
 /** Find a block by id anywhere in the tree, descending into slot attrs. */
@@ -106,8 +112,19 @@ export function createEditorStore(
     hoverId: null,
     device: initial?.device ?? "desktop",
     zoom: initial?.zoom ?? 1,
+    dragSpec: null,
 
     setTree: (tree) => set({ tree }),
+    insertBlock: (node, index) =>
+      set((state) => {
+        const at = Math.max(0, Math.min(index, state.tree.length));
+        const tree = [
+          ...state.tree.slice(0, at),
+          node,
+          ...state.tree.slice(at),
+        ];
+        return { tree, activeId: node.id, selectedIds: new Set([node.id]) };
+      }),
     updateBlockAttrs: (id, patch) =>
       set((state) => ({ tree: patchAttrs(state.tree, id, patch) })),
     select: (id, options) =>
@@ -122,5 +139,7 @@ export function createEditorStore(
     setDevice: (device) => set({ device }),
     setZoom: (zoom) =>
       set({ zoom: Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoom)) }),
+    startBlockDrag: (dragSpec) => set({ dragSpec }),
+    endBlockDrag: () => set({ dragSpec: null }),
   }));
 }

--- a/packages/admin/e2e/bespoke-editor.spec.ts
+++ b/packages/admin/e2e/bespoke-editor.spec.ts
@@ -70,6 +70,30 @@ test.describe("bespoke editor route", () => {
     await expect(page.getByTestId("block-inspector-empty")).toBeVisible();
   });
 
+  test("mounts the left-rail block catalog and the empty-state affordance", async ({
+    page,
+  }) => {
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/entry/get": editorEntry(),
+      "/entry/createPreviewLink": {
+        token: "tok123",
+        url: "/post/hello?preview=tok123",
+      },
+    });
+
+    await page.goto("entries/posts/1/editor");
+
+    // The catalog lists the core blocks the registry ships, searchable.
+    await expect(page.getByTestId("plumix-editor-left")).toBeVisible();
+    await expect(page.getByTestId("block-catalog-search")).toBeVisible();
+    await expect(
+      page.getByTestId("block-catalog-item-core/heading"),
+    ).toBeVisible();
+    // A fresh (content-less) entry offers the "Add a block" affordance.
+    await expect(page.getByTestId("plumix-empty-add")).toBeVisible();
+  });
+
   test("a failed preview mint surfaces the error placeholder, not a dead canvas", async ({
     page,
   }) => {

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/editor.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/editor.tsx
@@ -100,6 +100,11 @@ function BespokeEditorRoute(): ReactNode {
     orpc.entry.get.queryOptions({ input: { id, preview: true } }),
   );
   const { data: previewLink } = useSuspenseQuery(previewLinkQuery(id));
+  const { user } = Route.useRouteContext();
+  const capabilities = useMemo(
+    () => new Set(user.capabilities),
+    [user.capabilities],
+  );
   const handleChange = useContentAutosave(id, entry);
 
   // `createPreviewLink` returns a site-relative url (`/blog/hello?preview=…`);
@@ -114,6 +119,7 @@ function BespokeEditorRoute(): ReactNode {
       origin={target.origin}
       defaultValue={isEntryContent(entry.content) ? entry.content : undefined}
       registry={registry}
+      capabilities={capabilities}
       onChange={handleChange}
     />
   );


### PR DESCRIPTION
Adds the bespoke editor's block inserter (PRD #1104, slice #1107): a left-rail
catalog plus the ways to get blocks onto the canvas.

The catalog lists every registered block the inserter and the viewer's
capabilities allow, grouped by category and filtered by a search box. Two insert
paths share the store's insert action:

- **Click** a catalog block → appended at the end.
- **Drag** a block onto the canvas → inserted at a chosen top-level position.
  Because HTML drag-and-drop doesn't cross the iframe boundary, this is a pointer
  bridge: while dragging, the iframe drops `pointer-events` so the host keeps
  receiving pointer moves over the canvas, maps the canvas-reported block
  geometry into screen space, and renders a drop indicator at the computed index.
- An **empty entry** shows an "Add a block" affordance, which also stays as the
  drop target during a drag (an empty canvas has no geometry to indicate against).

Inserts render live through the existing patch loop and persist via autosave.

The pure logic — catalog grouping/search, fresh-node minting, and the
pointer→index/indicator math — is split into standalone tested modules
(`block-catalog.ts`, `drop-index.ts`). A drag always tears down on pointerup,
**pointercancel, or Escape**, so an interrupted drag can't strand the canvas
non-interactive.

Test coverage note: the canvas iframe loads the real public route, which the
admin e2e mock harness can't serve, so the pointer-drag choreography itself
isn't e2e-driveable. The host-side logic is covered by unit tests (store insert,
catalog grouping/search, drop-index/placement, empty-state insert, click-append);
the e2e asserts the catalog rail + empty-state mount in the real build.

Known limitation: drop geometry uses the last-reported layout, so scrolling the
canvas mid-drag can desync the indicator — the shared geometry observer
(deferred from the spine slice) will close this for selection overlays and drops
alike.

Closes #1107