### PR TITLE
feat: layers tree for the bespoke editor — outline, select & dnd reorder

### DIFF
--- a/packages/admin-editor/locales/ar.po
+++ b/packages/admin-editor/locales/ar.po
@@ -19,8 +19,23 @@ msgid "editor.canvas.addBlock"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.blocks"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.layers"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/block-catalog-tab.tsx
 msgid "editor.catalog.noResults"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/layers-tab.tsx
+msgid "editor.layers.empty"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/de.po
+++ b/packages/admin-editor/locales/de.po
@@ -19,8 +19,23 @@ msgid "editor.canvas.addBlock"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.blocks"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.layers"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/block-catalog-tab.tsx
 msgid "editor.catalog.noResults"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/layers-tab.tsx
+msgid "editor.layers.empty"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/en.po
+++ b/packages/admin-editor/locales/en.po
@@ -19,9 +19,24 @@ msgid "editor.canvas.addBlock"
 msgstr "Add a block"
 
 #. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.blocks"
+msgstr "Blocks"
+
+#. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.layers"
+msgstr "Layers"
+
+#. js-lingui-explicit-id
 #: src/block-catalog-tab.tsx
 msgid "editor.catalog.noResults"
 msgstr "No blocks match your search."
+
+#. js-lingui-explicit-id
+#: src/layers-tab.tsx
+msgid "editor.layers.empty"
+msgstr "No blocks yet."
 
 #. js-lingui-explicit-id
 #: src/block-catalog-tab.tsx

--- a/packages/admin-editor/locales/uk.po
+++ b/packages/admin-editor/locales/uk.po
@@ -19,8 +19,23 @@ msgid "editor.canvas.addBlock"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.blocks"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.layers"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/block-catalog-tab.tsx
 msgid "editor.catalog.noResults"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/layers-tab.tsx
+msgid "editor.layers.empty"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/zh-CN.po
+++ b/packages/admin-editor/locales/zh-CN.po
@@ -19,8 +19,23 @@ msgid "editor.canvas.addBlock"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.blocks"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.layers"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/block-catalog-tab.tsx
 msgid "editor.catalog.noResults"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/layers-tab.tsx
+msgid "editor.layers.empty"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/package.json
+++ b/packages/admin-editor/package.json
@@ -21,6 +21,9 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
+    "@dnd-kit/core": "catalog:",
+    "@dnd-kit/sortable": "catalog:",
+    "@dnd-kit/utilities": "catalog:",
     "@plumix/admin-ui": "workspace:*",
     "@plumix/blocks": "workspace:*",
     "@plumix/core": "workspace:*",

--- a/packages/admin-editor/src/block-inspector.tsx
+++ b/packages/admin-editor/src/block-inspector.tsx
@@ -5,8 +5,8 @@ import { Trans } from "@lingui/react";
 import type { BlockRegistry } from "@plumix/blocks";
 
 import { BlockInputControl } from "./block-input-control.js";
+import { findBlock } from "./block-tree-ops.js";
 import { useEditorStore } from "./provider.js";
-import { findBlock } from "./store.js";
 
 interface BlockInspectorProps {
   /** Core + plugin block registry; supplies each block's input schema. */

--- a/packages/admin-editor/src/block-tree-ops.test.ts
+++ b/packages/admin-editor/src/block-tree-ops.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, test } from "vitest";
+
+import type { BlockNode } from "@plumix/blocks";
+
+import {
+  findBlock,
+  flattenTree,
+  moveBlock,
+  projectMove,
+} from "./block-tree-ops.js";
+
+const ids = (tree: readonly BlockNode[]): string[] =>
+  flattenTree(tree).map((n) => `${n.parentId ?? "-"}/${n.id}`);
+
+const group = (id: string, children: readonly BlockNode[]): BlockNode => ({
+  id,
+  name: "core/group",
+  attrs: { content: children },
+});
+
+const TREE: readonly BlockNode[] = [
+  { id: "a", name: "core/heading" },
+  {
+    id: "g",
+    name: "core/group",
+    attrs: {
+      content: [
+        { id: "c1", name: "core/text" },
+        {
+          id: "c2",
+          name: "core/group",
+          attrs: { content: [{ id: "deep", name: "core/spacer" }] },
+        },
+      ],
+    },
+  },
+];
+
+describe("flattenTree", () => {
+  test("walks the tree depth-first with depth, parent and slot capacity", () => {
+    expect(flattenTree(TREE)).toEqual([
+      {
+        id: "a",
+        name: "core/heading",
+        depth: 0,
+        parentId: null,
+        hasSlot: false,
+      },
+      { id: "g", name: "core/group", depth: 0, parentId: null, hasSlot: true },
+      { id: "c1", name: "core/text", depth: 1, parentId: "g", hasSlot: false },
+      { id: "c2", name: "core/group", depth: 1, parentId: "g", hasSlot: true },
+      {
+        id: "deep",
+        name: "core/spacer",
+        depth: 2,
+        parentId: "c2",
+        hasSlot: false,
+      },
+    ]);
+  });
+
+  test("descends only the first slot (multi-slot blocks show one slot)", () => {
+    const tree: readonly BlockNode[] = [
+      {
+        id: "cols",
+        name: "core/columns",
+        attrs: {
+          left: [{ id: "l", name: "x" }],
+          right: [{ id: "r", name: "x" }],
+        },
+      },
+    ];
+    // Only the first slot's child surfaces, keeping the outline consistent
+    // with what moveBlock can address.
+    expect(flattenTree(tree).map((n) => n.id)).toEqual(["cols", "l"]);
+  });
+
+  test("returns an empty list for an empty tree", () => {
+    expect(flattenTree([])).toEqual([]);
+  });
+});
+
+describe("moveBlock", () => {
+  test("reorders top-level siblings", () => {
+    const tree: readonly BlockNode[] = [
+      { id: "a", name: "x" },
+      { id: "b", name: "x" },
+      { id: "c", name: "x" },
+    ];
+    const moved = moveBlock(tree, "a", { parentId: null, index: 2 });
+    expect(ids(moved)).toEqual(["-/b", "-/c", "-/a"]);
+  });
+
+  test("nests a top-level block into a group's slot", () => {
+    const tree: readonly BlockNode[] = [
+      { id: "a", name: "x" },
+      group("g", [{ id: "c1", name: "x" }]),
+    ];
+    const moved = moveBlock(tree, "a", { parentId: "g", index: 0 });
+    expect(ids(moved)).toEqual(["-/g", "g/a", "g/c1"]);
+  });
+
+  test("un-nests a child back to the top level", () => {
+    const tree: readonly BlockNode[] = [group("g", [{ id: "c1", name: "x" }])];
+    const moved = moveBlock(tree, "c1", { parentId: null, index: 0 });
+    expect(ids(moved)).toEqual(["-/c1", "-/g"]);
+  });
+
+  test("refuses to move a block into itself", () => {
+    const tree: readonly BlockNode[] = [group("g", [{ id: "c1", name: "x" }])];
+    expect(moveBlock(tree, "g", { parentId: "g", index: 0 })).toBe(tree);
+  });
+
+  test("refuses to move a block into its own descendant", () => {
+    const tree: readonly BlockNode[] = [
+      group("g", [group("inner", [{ id: "c", name: "x" }])]),
+    ];
+    expect(moveBlock(tree, "g", { parentId: "inner", index: 0 })).toBe(tree);
+  });
+
+  test("is a no-op when the target parent has no slot to nest into", () => {
+    const tree: readonly BlockNode[] = [
+      { id: "a", name: "x" },
+      { id: "leaf", name: "core/spacer" },
+    ];
+    expect(moveBlock(tree, "a", { parentId: "leaf", index: 0 })).toBe(tree);
+  });
+
+  test("is a no-op when the source is absent", () => {
+    const tree: readonly BlockNode[] = [{ id: "a", name: "x" }];
+    expect(moveBlock(tree, "missing", { parentId: null, index: 0 })).toBe(tree);
+  });
+});
+
+describe("projectMove", () => {
+  // a, b, then group g containing c — a typical mixed-depth outline.
+  const FLAT = flattenTree([
+    { id: "a", name: "x" },
+    { id: "b", name: "x" },
+    group("g", [{ id: "c", name: "x" }]),
+  ]);
+  const INDENT = 16;
+
+  test("reorders to a new top-level position (no horizontal drag)", () => {
+    expect(projectMove(FLAT, "a", "b", 0, INDENT)).toEqual({
+      parentId: null,
+      index: 1,
+    });
+  });
+
+  test("nests under the preceding block when dragged right", () => {
+    // Drag b down past g/c with one indent step → nests into g.
+    expect(projectMove(FLAT, "b", "c", INDENT, INDENT)).toEqual({
+      parentId: "g",
+      index: 1,
+    });
+  });
+
+  test("un-nests to the top level when dragged left", () => {
+    // Drag c up to b's row with a left pull → leaves the group.
+    expect(projectMove(FLAT, "c", "b", -INDENT, INDENT)).toEqual({
+      parentId: null,
+      index: 1,
+    });
+  });
+
+  test("never nests under a slotless leaf (would silently no-op)", () => {
+    // a (heading, no slot), leaf (no slot), x — drag x up onto leaf pulling
+    // right. The projection must stay at the top level, not name leaf a parent.
+    const flat = flattenTree([
+      { id: "h", name: "core/heading" },
+      { id: "leaf", name: "core/spacer" },
+      { id: "x", name: "x" },
+    ]);
+    const target = projectMove(flat, "x", "leaf", INDENT, INDENT);
+    expect(target).toEqual({ parentId: null, index: 1 });
+  });
+
+  test("returns null when the active block is unknown", () => {
+    expect(projectMove(FLAT, "zzz", "b", 0, INDENT)).toBeNull();
+  });
+});
+
+describe("findBlock", () => {
+  test("finds a top-level block", () => {
+    expect(findBlock(TREE, "g")?.name).toBe("core/group");
+  });
+
+  test("finds a deeply nested block", () => {
+    expect(findBlock(TREE, "deep")?.id).toBe("deep");
+  });
+
+  test("returns undefined when absent", () => {
+    expect(findBlock(TREE, "zzz")).toBeUndefined();
+  });
+});

--- a/packages/admin-editor/src/block-tree-ops.ts
+++ b/packages/admin-editor/src/block-tree-ops.ts
@@ -1,0 +1,238 @@
+import type { BlockNode } from "@plumix/blocks";
+import { isBlockNodeArray } from "@plumix/blocks";
+
+/** Find a block by id anywhere in the tree, descending into slot attrs. */
+export function findBlock(
+  nodes: readonly BlockNode[],
+  id: string,
+): BlockNode | undefined {
+  for (const node of nodes) {
+    if (node.id === id) return node;
+    for (const value of Object.values(node.attrs ?? {})) {
+      if (!isBlockNodeArray(value)) continue;
+      const found = findBlock(value, id);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
+export interface FlatNode {
+  readonly id: string;
+  readonly name: string;
+  /** Nesting depth; 0 for top-level blocks. */
+  readonly depth: number;
+  /** The slot-owning block's id, or null at the top level. */
+  readonly parentId: string | null;
+  /** Whether this block can hold children (has a slot) — gates nesting onto it. */
+  readonly hasSlot: boolean;
+}
+
+/**
+ * Flatten the nested tree to a depth-first outline (a node immediately
+ * followed by its children), the shape the Layers list renders. Descends only
+ * the block's first slot — the same one `moveBlock` writes — so the outline and
+ * drag targets address the same children. Multi-slot blocks (e.g. columns)
+ * surface only their first slot in the tree for now; see [[#1108 follow-up]].
+ */
+export function flattenTree(tree: readonly BlockNode[]): readonly FlatNode[] {
+  const out: FlatNode[] = [];
+  const walk = (
+    nodes: readonly BlockNode[],
+    depth: number,
+    parentId: string | null,
+  ): void => {
+    for (const node of nodes) {
+      const key = slotKey(node);
+      out.push({
+        id: node.id,
+        name: node.name,
+        depth,
+        parentId,
+        hasSlot: key !== null,
+      });
+      const children = key !== null ? node.attrs?.[key] : undefined;
+      if (isBlockNodeArray(children)) walk(children, depth + 1, node.id);
+    }
+  };
+  walk(tree, 0, null);
+  return out;
+}
+
+function arrayMove(
+  items: readonly FlatNode[],
+  from: number,
+  to: number,
+): FlatNode[] {
+  const copy = items.slice();
+  const [moved] = copy.splice(from, 1);
+  if (moved) copy.splice(to, 0, moved);
+  return copy;
+}
+
+/**
+ * Resolve a tree drag (active dropped over `overId`, dragged `offsetX` pixels
+ * horizontally) to a move target. The horizontal offset picks a depth — the
+ * standard flattened-tree projection — clamped between the row below (its
+ * depth) and one past the row above. Returns null when the active row is gone.
+ */
+export function projectMove(
+  items: readonly FlatNode[],
+  activeId: string,
+  overId: string,
+  offsetX: number,
+  indentWidth: number,
+): MoveTarget | null {
+  const activeIndex = items.findIndex((i) => i.id === activeId);
+  const overIndex = items.findIndex((i) => i.id === overId);
+  if (activeIndex === -1 || overIndex === -1) return null;
+  const active = items[activeIndex];
+  if (!active) return null;
+
+  const moved = arrayMove(items, activeIndex, overIndex);
+  const prev = moved[overIndex - 1];
+  const next = moved[overIndex + 1];
+  const projected = active.depth + Math.round(offsetX / indentWidth);
+  // Only nest one level deeper than the row above when that row can actually
+  // hold children — otherwise the projection would name a slotless leaf as
+  // parent and the move would silently no-op.
+  const maxDepth = prev ? (prev.hasSlot ? prev.depth + 1 : prev.depth) : 0;
+  const minDepth = next ? next.depth : 0;
+  const depth = Math.max(minDepth, Math.min(projected, maxDepth));
+
+  const parentId = projectedParentId(moved, overIndex, depth, prev);
+  const index = moved
+    .slice(0, overIndex)
+    .filter((i) => i.id !== activeId && i.parentId === parentId).length;
+  return { parentId, index };
+}
+
+function projectedParentId(
+  moved: readonly FlatNode[],
+  overIndex: number,
+  depth: number,
+  prev: FlatNode | undefined,
+): string | null {
+  if (depth === 0 || !prev) return null;
+  if (depth === prev.depth) return prev.parentId;
+  if (depth > prev.depth) return prev.id;
+  // Shallower than the row above: adopt the nearest earlier row at this depth.
+  const ancestor = moved
+    .slice(0, overIndex)
+    .reverse()
+    .find((i) => i.depth === depth);
+  return ancestor?.parentId ?? null;
+}
+
+export interface MoveTarget {
+  /** The new parent's id, or null to move to the top level. */
+  readonly parentId: string | null;
+  /** Insertion index among the target parent's children. */
+  readonly index: number;
+}
+
+/**
+ * Move a block to a new parent + index, immutably. Handles reorder (same
+ * parent), nest (into a parent's slot) and un-nest (to the top level). Returns
+ * the same tree reference when the move is invalid — source missing, dropping
+ * into itself or its own descendant, or a target parent with no slot to hold
+ * children — so a bad drag is a safe no-op rather than a lost subtree.
+ */
+export function moveBlock(
+  tree: readonly BlockNode[],
+  sourceId: string,
+  target: MoveTarget,
+): readonly BlockNode[] {
+  if (target.parentId === sourceId) return tree;
+  const source = findBlock(tree, sourceId);
+  if (!source) return tree;
+  if (target.parentId !== null) {
+    const parent = findBlock(tree, target.parentId);
+    if (!parent || slotKey(parent) === null) return tree;
+    if (containsBlock(source, target.parentId)) return tree;
+  }
+  return insertNode(removeNode(tree, sourceId), source, target);
+}
+
+// The first attr key holding a child-block array, or null if the block has no
+// slot. The layers tree addresses only this first slot — multi-slot blocks
+// aren't fully reachable from the outline yet (tracked as a #1108 follow-up).
+function slotKey(node: BlockNode): string | null {
+  for (const [key, value] of Object.entries(node.attrs ?? {})) {
+    if (isBlockNodeArray(value)) return key;
+  }
+  return null;
+}
+
+/** Whether `id` is `node` itself or anywhere in its subtree. */
+function containsBlock(node: BlockNode, id: string): boolean {
+  if (node.id === id) return true;
+  for (const value of Object.values(node.attrs ?? {})) {
+    if (isBlockNodeArray(value) && value.some((c) => containsBlock(c, id))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function removeNode(
+  nodes: readonly BlockNode[],
+  id: string,
+): readonly BlockNode[] {
+  const next = nodes.filter((node) => node.id !== id);
+  let changed = next.length !== nodes.length;
+  const mapped = next.map((node) => {
+    const attrs = node.attrs;
+    if (!attrs) return node;
+    let nextAttrs: Record<string, unknown> | undefined;
+    for (const [key, value] of Object.entries(attrs)) {
+      if (!isBlockNodeArray(value)) continue;
+      const pruned = removeNode(value, id);
+      if (pruned !== value) (nextAttrs ??= { ...attrs })[key] = pruned;
+    }
+    if (!nextAttrs) return node;
+    changed = true;
+    return { ...node, attrs: nextAttrs };
+  });
+  return changed ? mapped : nodes;
+}
+
+function clampIndex(index: number, length: number): number {
+  return Math.max(0, Math.min(index, length));
+}
+
+function insertNode(
+  nodes: readonly BlockNode[],
+  node: BlockNode,
+  target: MoveTarget,
+): readonly BlockNode[] {
+  if (target.parentId === null) {
+    const at = clampIndex(target.index, nodes.length);
+    return [...nodes.slice(0, at), node, ...nodes.slice(at)];
+  }
+  return nodes.map((current) => {
+    if (current.id === target.parentId) {
+      const key = slotKey(current);
+      if (key === null) return current;
+      const slot = current.attrs?.[key];
+      const children = isBlockNodeArray(slot) ? slot : [];
+      const at = clampIndex(target.index, children.length);
+      return {
+        ...current,
+        attrs: {
+          ...current.attrs,
+          [key]: [...children.slice(0, at), node, ...children.slice(at)],
+        },
+      };
+    }
+    const attrs = current.attrs;
+    if (!attrs) return current;
+    let nextAttrs: Record<string, unknown> | undefined;
+    for (const [key, value] of Object.entries(attrs)) {
+      if (!isBlockNodeArray(value)) continue;
+      const inserted = insertNode(value, node, target);
+      if (inserted !== value) (nextAttrs ??= { ...attrs })[key] = inserted;
+    }
+    return nextAttrs ? { ...current, attrs: nextAttrs } : current;
+  });
+}

--- a/packages/admin-editor/src/layers-tab.test.tsx
+++ b/packages/admin-editor/src/layers-tab.test.tsx
@@ -1,0 +1,75 @@
+import type { ReactElement } from "react";
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, test } from "vitest";
+
+import type { BlockNode } from "@plumix/blocks";
+import { createBlockRegistry } from "@plumix/blocks";
+
+import { LayersTab } from "./layers-tab.js";
+import { EditorProvider, useEditorStore } from "./provider.js";
+
+beforeAll(() => {
+  i18n.loadAndActivate({ locale: "en", messages: {} });
+});
+
+afterEach(cleanup);
+
+const registry = createBlockRegistry([
+  { name: "core/heading", render: () => null, title: "Heading" },
+  { name: "core/group", render: () => null, title: "Group" },
+]);
+
+const TREE: readonly BlockNode[] = [
+  { id: "a", name: "core/heading" },
+  {
+    id: "g",
+    name: "core/group",
+    attrs: { content: [{ id: "c", name: "core/heading" }] },
+  },
+];
+
+function ActiveProbe(): ReactElement {
+  const activeId = useEditorStore((s) => s.activeId);
+  return <output data-testid="active-probe">{activeId ?? ""}</output>;
+}
+
+function renderLayers(tree: readonly BlockNode[]): ReturnType<typeof render> {
+  return render(
+    <I18nProvider i18n={i18n}>
+      <EditorProvider initialTree={tree}>
+        <LayersTab registry={registry} />
+        <ActiveProbe />
+      </EditorProvider>
+    </I18nProvider>,
+  );
+}
+
+describe("LayersTab", () => {
+  test("renders the nested structure as indented rows", () => {
+    const { getByTestId } = renderLayers(TREE);
+    expect(getByTestId("layer-a")).toBeDefined();
+    expect(getByTestId("layer-g")).toBeDefined();
+    // The nested child is rendered and indented one level.
+    const child = getByTestId("layer-c").parentElement;
+    expect(child?.style.paddingInlineStart).toBe("16px");
+  });
+
+  test("uses the registry title as the layer label", () => {
+    const { getByTestId } = renderLayers(TREE);
+    expect(getByTestId("layer-g").textContent).toBe("Group");
+  });
+
+  test("clicking a layer selects the block", () => {
+    const { getByTestId } = renderLayers(TREE);
+    expect(getByTestId("active-probe").textContent).toBe("");
+    fireEvent.click(getByTestId("layer-c"));
+    expect(getByTestId("active-probe").textContent).toBe("c");
+  });
+
+  test("shows an empty state when there are no blocks", () => {
+    const { getByTestId } = renderLayers([]);
+    expect(getByTestId("layers-empty")).toBeDefined();
+  });
+});

--- a/packages/admin-editor/src/layers-tab.tsx
+++ b/packages/admin-editor/src/layers-tab.tsx
@@ -1,0 +1,145 @@
+import type { DragEndEvent } from "@dnd-kit/core";
+import type { ReactElement } from "react";
+import { useMemo } from "react";
+import {
+  closestCenter,
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { Trans, useLingui } from "@lingui/react";
+
+import type { BlockRegistry } from "@plumix/blocks";
+import { resolveLabel } from "@plumix/core/i18n";
+
+import type { FlatNode } from "./block-tree-ops.js";
+import { flattenTree, projectMove } from "./block-tree-ops.js";
+import { useEditorStore } from "./provider.js";
+
+const INDENT_WIDTH = 16;
+
+interface LayersTabProps {
+  /** Resolves a block's display label from its name. */
+  readonly registry: BlockRegistry;
+}
+
+/**
+ * Layers outline: the nested tree as a flat, indented list. Clicking a row
+ * selects the block (the canvas overlay follows); dragging reorders and nests
+ * via the projection, writing through the store's move action so the canvas
+ * reflects it live and it persists.
+ */
+export function LayersTab({ registry }: LayersTabProps): ReactElement {
+  const { i18n } = useLingui();
+  const tree = useEditorStore((s) => s.tree);
+  const activeId = useEditorStore((s) => s.activeId);
+  const select = useEditorStore((s) => s.select);
+  const moveBlock = useEditorStore((s) => s.moveBlock);
+  const items = useMemo(() => flattenTree(tree), [tree]);
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+  );
+
+  const label = (name: string): string => {
+    const spec = registry.get(name);
+    return spec?.title != null ? resolveLabel(spec.title, i18n) : name;
+  };
+
+  if (items.length === 0) {
+    return (
+      <div
+        className="text-muted-foreground p-3 text-sm"
+        data-testid="layers-empty"
+      >
+        <Trans id="editor.layers.empty" message="No blocks yet." />
+      </div>
+    );
+  }
+
+  const handleDragEnd = (event: DragEndEvent): void => {
+    const overId = event.over?.id;
+    const activeDragId = event.active.id;
+    if (overId == null || overId === activeDragId) return;
+    // The cumulative horizontal drag offset rides the drag-end event, so no
+    // per-move state is needed to know the projected nesting depth.
+    const target = projectMove(
+      items,
+      String(activeDragId),
+      String(overId),
+      event.delta.x,
+      INDENT_WIDTH,
+    );
+    if (target) moveBlock(String(activeDragId), target);
+  };
+
+  return (
+    <div className="p-2" data-testid="layers-tree">
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext
+          items={items.map((i) => i.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          {items.map((item) => (
+            <LayerRow
+              key={item.id}
+              item={item}
+              label={label(item.name)}
+              active={item.id === activeId}
+              onSelect={() => select(item.id)}
+            />
+          ))}
+        </SortableContext>
+      </DndContext>
+    </div>
+  );
+}
+
+interface LayerRowProps {
+  readonly item: FlatNode;
+  readonly label: string;
+  readonly active: boolean;
+  readonly onSelect: () => void;
+}
+
+function LayerRow({
+  item,
+  label,
+  active,
+  onSelect,
+}: LayerRowProps): ReactElement {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id: item.id });
+  return (
+    <div
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        paddingInlineStart: item.depth * INDENT_WIDTH,
+      }}
+    >
+      <button
+        type="button"
+        data-testid={`layer-${item.id}`}
+        aria-current={active ? "true" : undefined}
+        onClick={onSelect}
+        className="hover:bg-accent aria-[current]:bg-accent w-full truncate rounded p-1.5 text-start text-sm"
+        {...attributes}
+        {...listeners}
+      >
+        {label}
+      </button>
+    </div>
+  );
+}

--- a/packages/admin-editor/src/plumix-editor.tsx
+++ b/packages/admin-editor/src/plumix-editor.tsx
@@ -1,12 +1,20 @@
 import type { ReactElement } from "react";
 import { useEffect, useRef } from "react";
+import { Trans } from "@lingui/react";
 
 import type { BlockRegistry, EntryContent } from "@plumix/blocks";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@plumix/admin-ui/tabs";
 import { defineEntryContent } from "@plumix/blocks";
 
 import { BlockCatalog } from "./block-catalog-tab.js";
 import { BlockInspector } from "./block-inspector.js";
 import { CanvasFrame } from "./canvas-frame.js";
+import { LayersTab } from "./layers-tab.js";
 import { EditorProvider, useEditorStoreApi } from "./provider.js";
 
 const NO_CAPABILITIES: ReadonlySet<string> = new Set();
@@ -47,7 +55,22 @@ export function PlumixEditor({
           className="bg-background w-72 shrink-0 overflow-auto border-e"
           data-testid="plumix-editor-left"
         >
-          <BlockCatalog registry={registry} capabilities={capabilities} />
+          <Tabs defaultValue="blocks">
+            <TabsList className="m-2">
+              <TabsTrigger value="blocks" data-testid="plumix-tab-blocks">
+                <Trans id="editor.tab.blocks" message="Blocks" />
+              </TabsTrigger>
+              <TabsTrigger value="layers" data-testid="plumix-tab-layers">
+                <Trans id="editor.tab.layers" message="Layers" />
+              </TabsTrigger>
+            </TabsList>
+            <TabsContent value="blocks">
+              <BlockCatalog registry={registry} capabilities={capabilities} />
+            </TabsContent>
+            <TabsContent value="layers">
+              <LayersTab registry={registry} />
+            </TabsContent>
+          </Tabs>
         </aside>
         <CanvasFrame
           previewUrl={previewUrl}

--- a/packages/admin-editor/src/store.test.ts
+++ b/packages/admin-editor/src/store.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import type { BlockNode } from "@plumix/blocks";
 
-import { createEditorStore, findBlock, MAX_ZOOM, MIN_ZOOM } from "./store.js";
+import { createEditorStore, MAX_ZOOM, MIN_ZOOM } from "./store.js";
 
 describe("editor store", () => {
   test("select replaces the selection and marks the block active", () => {
@@ -155,27 +155,17 @@ describe("insertBlock", () => {
   });
 });
 
-describe("findBlock", () => {
-  test("finds a top-level block by id", () => {
-    const tree: readonly BlockNode[] = [
-      { id: "a", name: "core/heading" },
-      { id: "b", name: "core/spacer" },
-    ];
-    expect(findBlock(tree, "b")?.name).toBe("core/spacer");
-  });
+describe("moveBlock action", () => {
+  test("reorders the tree through the store", () => {
+    const store = createEditorStore({
+      tree: [
+        { id: "a", name: "core/x" },
+        { id: "b", name: "core/x" },
+      ],
+    });
 
-  test("finds a block nested inside a slot", () => {
-    const tree: readonly BlockNode[] = [
-      {
-        id: "g",
-        name: "core/group",
-        attrs: { content: [{ id: "deep", name: "core/heading" }] },
-      },
-    ];
-    expect(findBlock(tree, "deep")?.id).toBe("deep");
-  });
+    store.getState().moveBlock("a", { parentId: null, index: 1 });
 
-  test("returns undefined when absent", () => {
-    expect(findBlock([{ id: "a", name: "core/heading" }], "z")).toBeUndefined();
+    expect(store.getState().tree.map((n) => n.id)).toEqual(["b", "a"]);
   });
 });

--- a/packages/admin-editor/src/store.ts
+++ b/packages/admin-editor/src/store.ts
@@ -3,6 +3,9 @@ import { createStore } from "zustand/vanilla";
 import type { BlockNode, BlockSpec } from "@plumix/blocks";
 import { isBlockNodeArray } from "@plumix/blocks";
 
+import type { MoveTarget } from "./block-tree-ops.js";
+import { moveBlock as moveBlockOp } from "./block-tree-ops.js";
+
 export type EditorDevice = "desktop" | "tablet" | "mobile";
 
 // Default canvas widths per device. The theme can override these via the
@@ -33,6 +36,8 @@ export interface EditorActions {
   setTree: (tree: readonly BlockNode[]) => void;
   /** Insert a block at a top-level index (clamped) and select it. */
   insertBlock: (node: BlockNode, index: number) => void;
+  /** Move a block to a new parent + index (reorder / nest / un-nest). */
+  moveBlock: (sourceId: string, target: MoveTarget) => void;
   /** Merge a partial attrs patch into one block, anywhere in the tree. */
   updateBlockAttrs: (
     id: string,
@@ -45,22 +50,6 @@ export interface EditorActions {
   setZoom: (zoom: number) => void;
   startBlockDrag: (spec: BlockSpec) => void;
   endBlockDrag: () => void;
-}
-
-/** Find a block by id anywhere in the tree, descending into slot attrs. */
-export function findBlock(
-  nodes: readonly BlockNode[],
-  id: string,
-): BlockNode | undefined {
-  for (const node of nodes) {
-    if (node.id === id) return node;
-    for (const value of Object.values(node.attrs ?? {})) {
-      if (!isBlockNodeArray(value)) continue;
-      const found = findBlock(value, id);
-      if (found) return found;
-    }
-  }
-  return undefined;
 }
 
 // Merge `patch` into one node, returning the same reference when nothing
@@ -125,6 +114,8 @@ export function createEditorStore(
         ];
         return { tree, activeId: node.id, selectedIds: new Set([node.id]) };
       }),
+    moveBlock: (sourceId, target) =>
+      set((state) => ({ tree: moveBlockOp(state.tree, sourceId, target) })),
     updateBlockAttrs: (id, patch) =>
       set((state) => ({ tree: patchAttrs(state.tree, id, patch) })),
     select: (id, options) =>

--- a/packages/admin/e2e/bespoke-editor.spec.ts
+++ b/packages/admin/e2e/bespoke-editor.spec.ts
@@ -94,6 +94,39 @@ test.describe("bespoke editor route", () => {
     await expect(page.getByTestId("plumix-empty-add")).toBeVisible();
   });
 
+  test("the Layers tab outlines the entry's nested block structure", async ({
+    page,
+  }) => {
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/entry/get": editorEntry({
+        content: {
+          version: "plumix.v2",
+          blocks: [
+            { id: "h1", name: "core/heading", attrs: { text: "Hello" } },
+            {
+              id: "g1",
+              name: "core/group",
+              attrs: { content: [{ id: "p1", name: "core/rich-text" }] },
+            },
+          ],
+        },
+      }),
+      "/entry/createPreviewLink": {
+        token: "tok123",
+        url: "/post/hello?preview=tok123",
+      },
+    });
+
+    await page.goto("entries/posts/1/editor");
+
+    await page.getByTestId("plumix-tab-layers").click();
+    await expect(page.getByTestId("layer-h1")).toBeVisible();
+    await expect(page.getByTestId("layer-g1")).toBeVisible();
+    // The nested child appears in the outline too.
+    await expect(page.getByTestId("layer-p1")).toBeVisible();
+  });
+
   test("a failed preview mint surfaces the error placeholder, not a dead canvas", async ({
     page,
   }) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -461,6 +461,15 @@ importers:
 
   packages/admin-editor:
     dependencies:
+      '@dnd-kit/core':
+        specifier: 'catalog:'
+        version: 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/sortable':
+        specifier: 'catalog:'
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      '@dnd-kit/utilities':
+        specifier: 'catalog:'
+        version: 3.2.2(react@19.2.7)
       '@plumix/admin-ui':
         specifier: workspace:*
         version: link:../admin-ui


### PR DESCRIPTION
Adds the Layers tab (PRD #1104, slice #1108): the entry's nested block
structure as an indented outline in the left rail, which now switches between
Blocks and Layers.

- **Outline** — the nested tree flattened to indented rows.
- **Click to select** — selecting a layer drives the store selection, so the
  canvas overlay follows.
- **Drag to reorder/nest** — dnd-kit sortable over the flattened rows; the
  horizontal drag offset picks the nesting depth (the standard flattened-tree
  projection), and the move writes through the store so the canvas updates live
  and the change persists.

The tree surgery is split into a pure, fully-tested module (`block-tree-ops.ts`):
`flattenTree`, `moveBlock` (immutable remove + reinsert, with self/descendant/
no-slot guards), and `projectMove` (offset → depth → parent + index). `findBlock`
moved here from the store so the ops module owns the tree walks and the store no
longer forms an import cycle with it.

Two correctness guarantees from review: a drag never resolves to nesting under a
slotless leaf (the projection clamps depth by slot capacity, so a drop can't
silently no-op), and the outline descends only a block's first slot — the same
one `moveBlock` writes — so what's shown and what's draggable stay in agreement.

Test coverage note: the dnd-kit pointer choreography isn't unit-driveable, so
the reorder/nest correctness lives in the pure `projectMove`/`moveBlock` tests
(reorder, nest, un-nest, self/descendant/no-slot guards, no-nest-onto-leaf,
multi-slot first-slot consistency); the component tests cover outline render +
click-select; the e2e asserts the Layers tab outlines a seeded entry.

Known limitation: multi-slot blocks (e.g. columns' left/right) surface and
accept drags only on their first slot — full per-slot addressing is a tracked
follow-up.

Closes #1108