### PR TITLE
feat: undo/redo for the bespoke editor — snapshot history + coalescing

### DIFF
--- a/packages/admin-editor/locales/ar.po
+++ b/packages/admin-editor/locales/ar.po
@@ -39,6 +39,11 @@ msgid "editor.layers.empty"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.redo"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/block-catalog-tab.tsx
 msgid "editor.catalog.searchLabel"
 msgstr ""
@@ -46,4 +51,9 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/block-inspector.tsx
 msgid "editor.inspector.empty"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.undo"
 msgstr ""

--- a/packages/admin-editor/locales/de.po
+++ b/packages/admin-editor/locales/de.po
@@ -39,6 +39,11 @@ msgid "editor.layers.empty"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.redo"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/block-catalog-tab.tsx
 msgid "editor.catalog.searchLabel"
 msgstr ""
@@ -46,4 +51,9 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/block-inspector.tsx
 msgid "editor.inspector.empty"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.undo"
 msgstr ""

--- a/packages/admin-editor/locales/en.po
+++ b/packages/admin-editor/locales/en.po
@@ -39,6 +39,11 @@ msgid "editor.layers.empty"
 msgstr "No blocks yet."
 
 #. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.redo"
+msgstr "Redo"
+
+#. js-lingui-explicit-id
 #: src/block-catalog-tab.tsx
 msgid "editor.catalog.searchLabel"
 msgstr "Search blocks"
@@ -47,3 +52,8 @@ msgstr "Search blocks"
 #: src/block-inspector.tsx
 msgid "editor.inspector.empty"
 msgstr "Select a block to edit its attributes."
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.undo"
+msgstr "Undo"

--- a/packages/admin-editor/locales/uk.po
+++ b/packages/admin-editor/locales/uk.po
@@ -39,6 +39,11 @@ msgid "editor.layers.empty"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.redo"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/block-catalog-tab.tsx
 msgid "editor.catalog.searchLabel"
 msgstr ""
@@ -46,4 +51,9 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/block-inspector.tsx
 msgid "editor.inspector.empty"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.undo"
 msgstr ""

--- a/packages/admin-editor/locales/zh-CN.po
+++ b/packages/admin-editor/locales/zh-CN.po
@@ -39,6 +39,11 @@ msgid "editor.layers.empty"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.redo"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/block-catalog-tab.tsx
 msgid "editor.catalog.searchLabel"
 msgstr ""
@@ -46,4 +51,9 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/block-inspector.tsx
 msgid "editor.inspector.empty"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.undo"
 msgstr ""

--- a/packages/admin-editor/src/editor-toolbar.test.tsx
+++ b/packages/admin-editor/src/editor-toolbar.test.tsx
@@ -1,0 +1,82 @@
+import { useEffect } from "react";
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, test } from "vitest";
+
+import { EditorShortcuts, EditorToolbar } from "./editor-toolbar.js";
+import { EditorProvider, useEditorStoreApi } from "./provider.js";
+
+beforeAll(() => {
+  i18n.loadAndActivate({ locale: "en", messages: {} });
+});
+
+afterEach(cleanup);
+
+// Exposes the store so a test can drive edits the toolbar reacts to.
+let storeApi: ReturnType<typeof useEditorStoreApi> | undefined;
+function Capture(): null {
+  const api = useEditorStoreApi();
+  useEffect(() => {
+    storeApi = api;
+  }, [api]);
+  return null;
+}
+
+function renderToolbar(): ReturnType<typeof render> {
+  return render(
+    <I18nProvider i18n={i18n}>
+      <EditorProvider initialTree={[]}>
+        <EditorToolbar />
+        <EditorShortcuts />
+        <Capture />
+      </EditorProvider>
+    </I18nProvider>,
+  );
+}
+
+describe("EditorToolbar", () => {
+  const button = (el: HTMLElement): HTMLButtonElement =>
+    el as HTMLButtonElement;
+
+  test("undo/redo start disabled", () => {
+    const { getByTestId } = renderToolbar();
+    expect(button(getByTestId("plumix-undo")).disabled).toBe(true);
+    expect(button(getByTestId("plumix-redo")).disabled).toBe(true);
+  });
+
+  test("undo enables after an edit and reverts it on click", () => {
+    const { getByTestId } = renderToolbar();
+    act(() => storeApi?.getState().insertBlock({ id: "a", name: "core/x" }, 0));
+
+    const undoButton = getByTestId("plumix-undo");
+    expect(button(undoButton).disabled).toBe(false);
+    fireEvent.click(undoButton);
+
+    expect(storeApi?.getState().tree).toHaveLength(0);
+    expect(button(getByTestId("plumix-redo")).disabled).toBe(false);
+  });
+
+  test("Ctrl/Cmd+Z undoes via the keyboard", () => {
+    renderToolbar();
+    storeApi?.getState().insertBlock({ id: "a", name: "core/x" }, 0);
+
+    fireEvent.keyDown(window, { key: "z", ctrlKey: true });
+    expect(storeApi?.getState().tree).toHaveLength(0);
+
+    fireEvent.keyDown(window, { key: "z", ctrlKey: true, shiftKey: true });
+    expect(storeApi?.getState().tree).toHaveLength(1);
+  });
+
+  test("does not hijack undo while typing in a field", () => {
+    renderToolbar();
+    storeApi?.getState().insertBlock({ id: "a", name: "core/x" }, 0);
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    fireEvent.keyDown(input, { key: "z", ctrlKey: true });
+    // The edit survives — the shortcut deferred to the field's native undo.
+    expect(storeApi?.getState().tree).toHaveLength(1);
+    input.remove();
+  });
+});

--- a/packages/admin-editor/src/editor-toolbar.tsx
+++ b/packages/admin-editor/src/editor-toolbar.tsx
@@ -1,0 +1,75 @@
+import type { ReactElement } from "react";
+import { useEffect } from "react";
+import { Trans } from "@lingui/react";
+
+import { Button } from "@plumix/admin-ui/button";
+
+import { canRedo, canUndo } from "./history.js";
+import { useEditorStore, useEditorStoreApi } from "./provider.js";
+
+/** Top toolbar: undo/redo (more controls land here in later slices). */
+export function EditorToolbar(): ReactElement {
+  const undoAvailable = useEditorStore((s) => canUndo(s.history));
+  const redoAvailable = useEditorStore((s) => canRedo(s.history));
+  const undo = useEditorStore((s) => s.undo);
+  const redo = useEditorStore((s) => s.redo);
+
+  return (
+    <header
+      className="bg-background flex items-center gap-1 border-b p-2"
+      data-testid="plumix-editor-toolbar"
+    >
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        data-testid="plumix-undo"
+        disabled={!undoAvailable}
+        onClick={undo}
+      >
+        <Trans id="editor.toolbar.undo" message="Undo" />
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        data-testid="plumix-redo"
+        disabled={!redoAvailable}
+        onClick={redo}
+      >
+        <Trans id="editor.toolbar.redo" message="Redo" />
+      </Button>
+    </header>
+  );
+}
+
+/**
+ * Global undo/redo keyboard shortcuts (Cmd/Ctrl+Z, +Shift to redo). Skips
+ * edits in form controls / contenteditable so native field undo isn't hijacked.
+ */
+export function EditorShortcuts(): null {
+  const store = useEditorStoreApi();
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent): void => {
+      if (!(event.metaKey || event.ctrlKey)) return;
+      if (event.key.toLowerCase() !== "z") return;
+      // A held chord auto-repeats keydown; one press should be one step.
+      if (event.repeat) return;
+      const target = event.target as HTMLElement | null;
+      if (
+        target?.isContentEditable ||
+        target?.tagName === "INPUT" ||
+        target?.tagName === "TEXTAREA" ||
+        target?.tagName === "SELECT"
+      ) {
+        return;
+      }
+      event.preventDefault();
+      if (event.shiftKey) store.getState().redo();
+      else store.getState().undo();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [store]);
+  return null;
+}

--- a/packages/admin-editor/src/history.test.ts
+++ b/packages/admin-editor/src/history.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  canRedo,
+  canUndo,
+  initHistory,
+  recordHistory,
+  redo,
+  undo,
+} from "./history.js";
+
+describe("history", () => {
+  test("a fresh history can neither undo nor redo", () => {
+    const h = initHistory("a");
+    expect(h.present).toBe("a");
+    expect(canUndo(h)).toBe(false);
+    expect(canRedo(h)).toBe(false);
+  });
+
+  test("recording a discrete edit enables undo and restores the prior value", () => {
+    let h = initHistory("a");
+    h = recordHistory(h, "b", null);
+    expect(h.present).toBe("b");
+    expect(canUndo(h)).toBe(true);
+
+    h = undo(h);
+    expect(h.present).toBe("a");
+    expect(canRedo(h)).toBe(true);
+
+    h = redo(h);
+    expect(h.present).toBe("b");
+  });
+
+  test("consecutive same-key edits coalesce into one undo step", () => {
+    let h = initHistory("");
+    h = recordHistory(h, "h", "type");
+    h = recordHistory(h, "he", "type");
+    h = recordHistory(h, "hel", "type");
+    expect(h.present).toBe("hel");
+
+    // One undo jumps straight back past the whole typing burst.
+    h = undo(h);
+    expect(h.present).toBe("");
+    expect(canUndo(h)).toBe(false);
+  });
+
+  test("a different key starts a new undo step", () => {
+    let h = initHistory("");
+    h = recordHistory(h, "a", "type");
+    h = recordHistory(h, "ab", "type");
+    h = recordHistory(h, "ab+block", "insert");
+
+    h = undo(h);
+    expect(h.present).toBe("ab");
+    h = undo(h);
+    expect(h.present).toBe("");
+  });
+
+  test("a null key never coalesces, even back to back", () => {
+    let h = initHistory("a");
+    h = recordHistory(h, "b", null);
+    h = recordHistory(h, "c", null);
+    h = undo(h);
+    expect(h.present).toBe("b");
+  });
+
+  test("a new edit after undo clears the redo stack", () => {
+    let h = initHistory("a");
+    h = recordHistory(h, "b", null);
+    h = undo(h);
+    expect(canRedo(h)).toBe(true);
+
+    h = recordHistory(h, "c", null);
+    expect(canRedo(h)).toBe(false);
+    expect(h.present).toBe("c");
+  });
+
+  test("undo at the start and redo at the end are no-ops", () => {
+    const h = initHistory("a");
+    expect(undo(h)).toBe(h);
+    expect(redo(h)).toBe(h);
+  });
+
+  test("the past is capped so a long session can't grow unbounded", () => {
+    let h = initHistory(0);
+    for (let i = 1; i <= 250; i++) h = recordHistory(h, i, null);
+
+    let steps = 0;
+    while (canUndo(h)) {
+      h = undo(h);
+      steps++;
+    }
+    // Bounded, and the oldest values fell off (never reach 0).
+    expect(steps).toBeLessThanOrEqual(100);
+    expect(h.present).toBeGreaterThan(0);
+  });
+});

--- a/packages/admin-editor/src/history.ts
+++ b/packages/admin-editor/src/history.ts
@@ -1,0 +1,82 @@
+interface Entry<T> {
+  readonly value: T;
+  /** Edits sharing a non-null key collapse into the current step (typing,
+   *  dragging); null is always a discrete step. */
+  readonly coalesceKey: string | null;
+}
+
+// Cap retained undo steps so a long session can't grow the stack unbounded
+// (each entry holds a full tree snapshot). Oldest steps fall off the back.
+const MAX_HISTORY = 100;
+
+export interface History<T> {
+  readonly past: readonly Entry<T>[];
+  readonly present: T;
+  readonly presentKey: string | null;
+  readonly future: readonly Entry<T>[];
+}
+
+export function initHistory<T>(value: T): History<T> {
+  return { past: [], present: value, presentKey: null, future: [] };
+}
+
+/**
+ * Record a new value. When `coalesceKey` matches the current step's key the
+ * value replaces it in place (one undo step for a typing/drag burst);
+ * otherwise the current value is pushed onto the past as a discrete step. Any
+ * recorded edit clears the redo stack.
+ */
+export function recordHistory<T>(
+  history: History<T>,
+  value: T,
+  coalesceKey: string | null,
+): History<T> {
+  if (coalesceKey !== null && coalesceKey === history.presentKey) {
+    return { ...history, present: value, future: [] };
+  }
+  return {
+    past: [
+      ...history.past,
+      { value: history.present, coalesceKey: history.presentKey },
+    ].slice(-MAX_HISTORY),
+    present: value,
+    presentKey: coalesceKey,
+    future: [],
+  };
+}
+
+export function undo<T>(history: History<T>): History<T> {
+  const prior = history.past.at(-1);
+  if (!prior) return history;
+  return {
+    past: history.past.slice(0, -1),
+    present: prior.value,
+    presentKey: prior.coalesceKey,
+    future: [
+      { value: history.present, coalesceKey: history.presentKey },
+      ...history.future,
+    ],
+  };
+}
+
+export function redo<T>(history: History<T>): History<T> {
+  const [next, ...rest] = history.future;
+  if (!next) return history;
+  return {
+    past: [
+      ...history.past,
+      { value: history.present, coalesceKey: history.presentKey },
+    ],
+    present: next.value,
+    presentKey: next.coalesceKey,
+    future: rest,
+  };
+}
+
+export function canUndo<T>(history: History<T>): boolean {
+  return history.past.length > 0;
+}
+
+export function canRedo<T>(history: History<T>): boolean {
+  return history.future.length > 0;
+}

--- a/packages/admin-editor/src/plumix-editor.tsx
+++ b/packages/admin-editor/src/plumix-editor.tsx
@@ -14,6 +14,7 @@ import { defineEntryContent } from "@plumix/blocks";
 import { BlockCatalog } from "./block-catalog-tab.js";
 import { BlockInspector } from "./block-inspector.js";
 import { CanvasFrame } from "./canvas-frame.js";
+import { EditorShortcuts, EditorToolbar } from "./editor-toolbar.js";
 import { LayersTab } from "./layers-tab.js";
 import { EditorProvider, useEditorStoreApi } from "./provider.js";
 
@@ -50,41 +51,45 @@ export function PlumixEditor({
 }: PlumixEditorProps): ReactElement {
   return (
     <EditorProvider initialTree={defaultValue?.blocks}>
-      <div className="flex h-full" data-testid="plumix-editor-layout">
-        <aside
-          className="bg-background w-72 shrink-0 overflow-auto border-e"
-          data-testid="plumix-editor-left"
-        >
-          <Tabs defaultValue="blocks">
-            <TabsList className="m-2">
-              <TabsTrigger value="blocks" data-testid="plumix-tab-blocks">
-                <Trans id="editor.tab.blocks" message="Blocks" />
-              </TabsTrigger>
-              <TabsTrigger value="layers" data-testid="plumix-tab-layers">
-                <Trans id="editor.tab.layers" message="Layers" />
-              </TabsTrigger>
-            </TabsList>
-            <TabsContent value="blocks">
-              <BlockCatalog registry={registry} capabilities={capabilities} />
-            </TabsContent>
-            <TabsContent value="layers">
-              <LayersTab registry={registry} />
-            </TabsContent>
-          </Tabs>
-        </aside>
-        <CanvasFrame
-          previewUrl={previewUrl}
-          origin={origin}
-          registry={registry}
-          capabilities={capabilities}
-        />
-        <aside
-          className="bg-background w-80 shrink-0 overflow-auto border-s"
-          data-testid="plumix-editor-right"
-        >
-          <BlockInspector registry={registry} />
-        </aside>
+      <div className="flex h-full flex-col" data-testid="plumix-editor-layout">
+        <EditorToolbar />
+        <div className="flex min-h-0 flex-1">
+          <aside
+            className="bg-background w-72 shrink-0 overflow-auto border-e"
+            data-testid="plumix-editor-left"
+          >
+            <Tabs defaultValue="blocks">
+              <TabsList className="m-2">
+                <TabsTrigger value="blocks" data-testid="plumix-tab-blocks">
+                  <Trans id="editor.tab.blocks" message="Blocks" />
+                </TabsTrigger>
+                <TabsTrigger value="layers" data-testid="plumix-tab-layers">
+                  <Trans id="editor.tab.layers" message="Layers" />
+                </TabsTrigger>
+              </TabsList>
+              <TabsContent value="blocks">
+                <BlockCatalog registry={registry} capabilities={capabilities} />
+              </TabsContent>
+              <TabsContent value="layers">
+                <LayersTab registry={registry} />
+              </TabsContent>
+            </Tabs>
+          </aside>
+          <CanvasFrame
+            previewUrl={previewUrl}
+            origin={origin}
+            registry={registry}
+            capabilities={capabilities}
+          />
+          <aside
+            className="bg-background w-80 shrink-0 overflow-auto border-s"
+            data-testid="plumix-editor-right"
+          >
+            <BlockInspector registry={registry} />
+          </aside>
+        </div>
       </div>
+      <EditorShortcuts />
       {onChange ? <TreeChangeEmitter onChange={onChange} /> : null}
     </EditorProvider>
   );

--- a/packages/admin-editor/src/store.test.ts
+++ b/packages/admin-editor/src/store.test.ts
@@ -155,6 +155,46 @@ describe("insertBlock", () => {
   });
 });
 
+describe("undo / redo", () => {
+  test("undo reverts an insert; redo replays it", () => {
+    const store = createEditorStore({ tree: [{ id: "a", name: "core/x" }] });
+
+    store.getState().insertBlock({ id: "b", name: "core/y" }, 1);
+    expect(store.getState().tree.map((n) => n.id)).toEqual(["a", "b"]);
+
+    store.getState().undo();
+    expect(store.getState().tree.map((n) => n.id)).toEqual(["a"]);
+
+    store.getState().redo();
+    expect(store.getState().tree.map((n) => n.id)).toEqual(["a", "b"]);
+  });
+
+  test("a typing burst on one field collapses into one undo step", () => {
+    const store = createEditorStore({
+      tree: [{ id: "h", name: "core/heading", attrs: { text: "" } }],
+    });
+
+    store.getState().updateBlockAttrs("h", { text: "H" });
+    store.getState().updateBlockAttrs("h", { text: "He" });
+    store.getState().updateBlockAttrs("h", { text: "Hey" });
+
+    // One undo jumps back past the whole burst to the original.
+    store.getState().undo();
+    expect(store.getState().tree[0]?.attrs?.text).toBe("");
+  });
+
+  test("a new edit after undo drops the redo", () => {
+    const store = createEditorStore({ tree: [] });
+    store.getState().insertBlock({ id: "a", name: "core/x" }, 0);
+    store.getState().undo();
+    store.getState().insertBlock({ id: "b", name: "core/y" }, 0);
+
+    store.getState().redo();
+    // Redo was cleared by the post-undo edit; the tree stays at [b].
+    expect(store.getState().tree.map((n) => n.id)).toEqual(["b"]);
+  });
+});
+
 describe("moveBlock action", () => {
   test("reorders the tree through the store", () => {
     const store = createEditorStore({

--- a/packages/admin-editor/src/store.ts
+++ b/packages/admin-editor/src/store.ts
@@ -4,7 +4,11 @@ import type { BlockNode, BlockSpec } from "@plumix/blocks";
 import { isBlockNodeArray } from "@plumix/blocks";
 
 import type { MoveTarget } from "./block-tree-ops.js";
+import type { History } from "./history.js";
 import { moveBlock as moveBlockOp } from "./block-tree-ops.js";
+import { initHistory, recordHistory, redo, undo } from "./history.js";
+
+type TreeHistory = History<readonly BlockNode[]>;
 
 export type EditorDevice = "desktop" | "tablet" | "mobile";
 
@@ -30,6 +34,8 @@ export interface EditorState {
   readonly zoom: number;
   /** The catalog block currently being dragged toward the canvas, if any. */
   readonly dragSpec: BlockSpec | null;
+  /** Snapshot history of the tree, driving undo/redo. */
+  readonly history: TreeHistory;
 }
 
 export interface EditorActions {
@@ -50,6 +56,9 @@ export interface EditorActions {
   setZoom: (zoom: number) => void;
   startBlockDrag: (spec: BlockSpec) => void;
   endBlockDrag: () => void;
+  /** Restore the previous / next tree snapshot. */
+  undo: () => void;
+  redo: () => void;
 }
 
 // Merge `patch` into one node, returning the same reference when nothing
@@ -102,7 +111,10 @@ export function createEditorStore(
     device: initial?.device ?? "desktop",
     zoom: initial?.zoom ?? 1,
     dragSpec: null,
+    history: initHistory(initial?.tree ?? []),
 
+    // Raw seed/programmatic setter — intentionally does not record history
+    // (user edits go through insert/move/updateBlockAttrs).
     setTree: (tree) => set({ tree }),
     insertBlock: (node, index) =>
       set((state) => {
@@ -112,12 +124,27 @@ export function createEditorStore(
           node,
           ...state.tree.slice(at),
         ];
-        return { tree, activeId: node.id, selectedIds: new Set([node.id]) };
+        return {
+          tree,
+          activeId: node.id,
+          selectedIds: new Set([node.id]),
+          history: recordHistory(state.history, tree, null),
+        };
       }),
     moveBlock: (sourceId, target) =>
-      set((state) => ({ tree: moveBlockOp(state.tree, sourceId, target) })),
+      set((state) => {
+        const tree = moveBlockOp(state.tree, sourceId, target);
+        if (tree === state.tree) return {};
+        return { tree, history: recordHistory(state.history, tree, null) };
+      }),
     updateBlockAttrs: (id, patch) =>
-      set((state) => ({ tree: patchAttrs(state.tree, id, patch) })),
+      set((state) => {
+        const tree = patchAttrs(state.tree, id, patch);
+        if (tree === state.tree) return {};
+        // Coalesce a typing burst on one field into a single undo step.
+        const key = `attr:${id}:${Object.keys(patch).sort().join(",")}`;
+        return { tree, history: recordHistory(state.history, tree, key) };
+      }),
     select: (id, options) =>
       set((state) => ({
         selectedIds: options?.additive
@@ -132,5 +159,15 @@ export function createEditorStore(
       set({ zoom: Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoom)) }),
     startBlockDrag: (dragSpec) => set({ dragSpec }),
     endBlockDrag: () => set({ dragSpec: null }),
+    undo: () =>
+      set((state) => {
+        const history = undo(state.history);
+        return { history, tree: history.present };
+      }),
+    redo: () =>
+      set((state) => {
+        const history = redo(state.history);
+        return { history, tree: history.present };
+      }),
   }));
 }

--- a/packages/admin/e2e/bespoke-editor.spec.ts
+++ b/packages/admin/e2e/bespoke-editor.spec.ts
@@ -127,6 +127,47 @@ test.describe("bespoke editor route", () => {
     await expect(page.getByTestId("layer-p1")).toBeVisible();
   });
 
+  test("undo reverts an inspector edit and re-enables redo", async ({
+    page,
+  }) => {
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/entry/get": editorEntry({
+        content: {
+          version: "plumix.v2",
+          blocks: [
+            {
+              id: "h1",
+              name: "core/heading",
+              attrs: { level: 2, text: "Welcome" },
+            },
+          ],
+        },
+      }),
+      "/entry/createPreviewLink": {
+        token: "tok123",
+        url: "/post/hello?preview=tok123",
+      },
+    });
+
+    await page.goto("entries/posts/1/editor");
+
+    // Nothing edited yet — undo is disabled.
+    await expect(page.getByTestId("plumix-undo")).toBeDisabled();
+
+    // Select the heading via the Layers tab and edit its Text in the inspector.
+    await page.getByTestId("plumix-tab-layers").click();
+    await page.getByTestId("layer-h1").click();
+    const textField = page.getByTestId("block-input-text");
+    await textField.fill("Changed");
+    await expect(textField).toHaveValue("Changed");
+
+    // Undo restores the original text; redo becomes available.
+    await page.getByTestId("plumix-undo").click();
+    await expect(page.getByTestId("block-input-text")).toHaveValue("Welcome");
+    await expect(page.getByTestId("plumix-redo")).toBeEnabled();
+  });
+
   test("a failed preview mint surfaces the error placeholder, not a dead canvas", async ({
     page,
   }) => {


### PR DESCRIPTION
Adds undo/redo to the bespoke editor (PRD #1104, slice #1113).

A pure, generic history module (`history.ts`) drives it — `past`/`present`/
`future` plus the present step's coalesce key. The store records a snapshot on
every insert, move and attribute edit; consecutive edits sharing a key (a typing
burst on one field, keyed `attr:<id>:<fields>`) collapse into a single undo step,
switching field or block starts a new one, and any edit after an undo drops the
redo stack. The past is capped (100 steps) so a long session can't grow
unbounded.

A new top toolbar exposes undo/redo buttons (disabled at the ends of the stack),
and Cmd/Ctrl+Z / +Shift restores via the keyboard — guarded to skip form fields
and contenteditable (so native field undo isn't hijacked) and to ignore
key-repeat (a held chord is one step, not a stack walk). Undo/redo emit a fresh
tree, so they ride the existing `onChange` autosave and persist.

The history algebra is a standalone unit-tested module (coalesce, null-never-
coalesce, redo-clear-on-edit, no-op ref stability, cap); the store tests cover
insert-undo-redo, typing-burst-collapse, and redo-drop-after-edit; the e2e drives
a real inspector edit → undo → revert through the built admin.

`setTree` stays the raw seed/programmatic setter and intentionally records no
history — only user edits (insert/move/updateBlockAttrs) do.

Closes #1113