### PR TITLE
feat: JSON inspector + page-attributes tab for the bespoke editor

### DIFF
--- a/packages/admin-editor/locales/ar.po
+++ b/packages/admin-editor/locales/ar.po
@@ -19,8 +19,23 @@ msgid "editor.canvas.addBlock"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/json-inspector.tsx
+msgid "editor.json.block"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.block"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.blocks"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.json"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -39,6 +54,21 @@ msgid "editor.layers.empty"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.page.empty"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/json-inspector.tsx
+msgid "editor.json.page"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.page"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
 msgid "editor.toolbar.redo"
 msgstr ""
@@ -51,6 +81,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/block-inspector.tsx
 msgid "editor.inspector.empty"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/json-inspector.tsx
+msgid "editor.json.empty"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/de.po
+++ b/packages/admin-editor/locales/de.po
@@ -19,8 +19,23 @@ msgid "editor.canvas.addBlock"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/json-inspector.tsx
+msgid "editor.json.block"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.block"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.blocks"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.json"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -39,6 +54,21 @@ msgid "editor.layers.empty"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.page.empty"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/json-inspector.tsx
+msgid "editor.json.page"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.page"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
 msgid "editor.toolbar.redo"
 msgstr ""
@@ -51,6 +81,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/block-inspector.tsx
 msgid "editor.inspector.empty"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/json-inspector.tsx
+msgid "editor.json.empty"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/en.po
+++ b/packages/admin-editor/locales/en.po
@@ -19,9 +19,24 @@ msgid "editor.canvas.addBlock"
 msgstr "Add a block"
 
 #. js-lingui-explicit-id
+#: src/json-inspector.tsx
+msgid "editor.json.block"
+msgstr "Block"
+
+#. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.block"
+msgstr "Block"
+
+#. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.blocks"
 msgstr "Blocks"
+
+#. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.json"
+msgstr "JSON"
 
 #. js-lingui-explicit-id
 #: src/plumix-editor.tsx
@@ -39,6 +54,21 @@ msgid "editor.layers.empty"
 msgstr "No blocks yet."
 
 #. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.page.empty"
+msgstr "No document settings."
+
+#. js-lingui-explicit-id
+#: src/json-inspector.tsx
+msgid "editor.json.page"
+msgstr "Page"
+
+#. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.page"
+msgstr "Page"
+
+#. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
 msgid "editor.toolbar.redo"
 msgstr "Redo"
@@ -52,6 +82,11 @@ msgstr "Search blocks"
 #: src/block-inspector.tsx
 msgid "editor.inspector.empty"
 msgstr "Select a block to edit its attributes."
+
+#. js-lingui-explicit-id
+#: src/json-inspector.tsx
+msgid "editor.json.empty"
+msgstr "Select a block to inspect."
 
 #. js-lingui-explicit-id
 #: src/editor-toolbar.tsx

--- a/packages/admin-editor/locales/uk.po
+++ b/packages/admin-editor/locales/uk.po
@@ -19,8 +19,23 @@ msgid "editor.canvas.addBlock"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/json-inspector.tsx
+msgid "editor.json.block"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.block"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.blocks"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.json"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -39,6 +54,21 @@ msgid "editor.layers.empty"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.page.empty"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/json-inspector.tsx
+msgid "editor.json.page"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.page"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
 msgid "editor.toolbar.redo"
 msgstr ""
@@ -51,6 +81,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/block-inspector.tsx
 msgid "editor.inspector.empty"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/json-inspector.tsx
+msgid "editor.json.empty"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/zh-CN.po
+++ b/packages/admin-editor/locales/zh-CN.po
@@ -19,8 +19,23 @@ msgid "editor.canvas.addBlock"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/json-inspector.tsx
+msgid "editor.json.block"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.block"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.blocks"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.json"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -39,6 +54,21 @@ msgid "editor.layers.empty"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.page.empty"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/json-inspector.tsx
+msgid "editor.json.page"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.page"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
 msgid "editor.toolbar.redo"
 msgstr ""
@@ -51,6 +81,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/block-inspector.tsx
 msgid "editor.inspector.empty"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/json-inspector.tsx
+msgid "editor.json.empty"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/src/json-inspector.test.tsx
+++ b/packages/admin-editor/src/json-inspector.test.tsx
@@ -1,0 +1,66 @@
+import { useEffect } from "react";
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, test } from "vitest";
+
+import type { BlockNode } from "@plumix/blocks";
+
+import { JsonInspector } from "./json-inspector.js";
+import { EditorProvider, useEditorStoreApi } from "./provider.js";
+
+beforeAll(() => {
+  i18n.loadAndActivate({ locale: "en", messages: {} });
+});
+
+afterEach(cleanup);
+
+const TREE: readonly BlockNode[] = [
+  { id: "h1", name: "core/heading", attrs: { text: "Hi" } },
+  { id: "s1", name: "core/spacer" },
+];
+
+// Selects a block on mount so the block view has something to show.
+function Selector({ id }: { readonly id?: string }): null {
+  const api = useEditorStoreApi();
+  useEffect(() => {
+    if (id) api.getState().select(id);
+  }, [id, api]);
+  return null;
+}
+
+function renderInspector(selectId?: string): ReturnType<typeof render> {
+  return render(
+    <I18nProvider i18n={i18n}>
+      <EditorProvider initialTree={TREE}>
+        <Selector id={selectId} />
+        <JsonInspector />
+      </EditorProvider>
+    </I18nProvider>,
+  );
+}
+
+describe("JsonInspector", () => {
+  test("shows the whole-page JSON by default", () => {
+    const { getByTestId } = renderInspector();
+    const output = getByTestId("json-inspector-output").textContent;
+    expect(output).toContain('"h1"');
+    expect(output).toContain('"s1"');
+  });
+
+  test("toggles to the selected block's JSON", () => {
+    const { getByTestId } = renderInspector("h1");
+    fireEvent.click(getByTestId("json-inspector-toggle-block"));
+    const output = getByTestId("json-inspector-output").textContent;
+    expect(output).toContain('"h1"');
+    // The other block is not in the single-block view.
+    expect(output).not.toContain('"s1"');
+  });
+
+  test("block view prompts when nothing is selected", () => {
+    const { getByTestId, queryByTestId } = renderInspector();
+    fireEvent.click(getByTestId("json-inspector-toggle-block"));
+    expect(getByTestId("json-inspector-empty")).toBeDefined();
+    expect(queryByTestId("json-inspector-output")).toBeNull();
+  });
+});

--- a/packages/admin-editor/src/json-inspector.tsx
+++ b/packages/admin-editor/src/json-inspector.tsx
@@ -1,0 +1,84 @@
+import type { ReactElement } from "react";
+import { useState } from "react";
+import { Trans } from "@lingui/react";
+
+import { findBlock } from "./block-tree-ops.js";
+import { useEditorStore } from "./provider.js";
+
+type JsonScope = "page" | "block";
+
+/**
+ * Read-only JSON view of the canonical tree, switchable between the selected
+ * block and the whole page. A debugging/escape-hatch surface — it never
+ * mutates the tree.
+ */
+export function JsonInspector(): ReactElement {
+  const [scope, setScope] = useState<JsonScope>("page");
+  const tree = useEditorStore((s) => s.tree);
+  const activeId = useEditorStore((s) => s.activeId);
+
+  const block =
+    scope === "block" && activeId ? findBlock(tree, activeId) : null;
+  const value = scope === "page" ? tree : block;
+
+  return (
+    <div className="flex flex-col gap-2 p-3" data-testid="json-inspector">
+      <div className="flex gap-1" role="tablist">
+        <ScopeButton
+          scope="page"
+          active={scope === "page"}
+          onClick={() => setScope("page")}
+        >
+          <Trans id="editor.json.page" message="Page" />
+        </ScopeButton>
+        <ScopeButton
+          scope="block"
+          active={scope === "block"}
+          onClick={() => setScope("block")}
+        >
+          <Trans id="editor.json.block" message="Block" />
+        </ScopeButton>
+      </div>
+      {scope === "block" && !block ? (
+        <p
+          className="text-muted-foreground text-sm"
+          data-testid="json-inspector-empty"
+        >
+          <Trans id="editor.json.empty" message="Select a block to inspect." />
+        </p>
+      ) : (
+        <pre
+          className="bg-muted overflow-auto rounded p-2 text-xs"
+          data-testid="json-inspector-output"
+        >
+          {JSON.stringify(value, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function ScopeButton({
+  scope,
+  active,
+  onClick,
+  children,
+}: {
+  readonly scope: JsonScope;
+  readonly active: boolean;
+  readonly onClick: () => void;
+  readonly children: ReactElement;
+}): ReactElement {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      data-testid={`json-inspector-toggle-${scope}`}
+      onClick={onClick}
+      className="hover:bg-accent aria-selected:bg-accent rounded px-2 py-1 text-sm"
+    >
+      {children}
+    </button>
+  );
+}

--- a/packages/admin-editor/src/plumix-editor.test.tsx
+++ b/packages/admin-editor/src/plumix-editor.test.tsx
@@ -29,6 +29,7 @@ function renderEditor(): ReturnType<typeof render> {
         origin="http://localhost:3000"
         defaultValue={{ version: "plumix.v2", blocks: [] }}
         registry={registry}
+        documentPanel={<div data-testid="doc-panel">document settings</div>}
       />
     </I18nProvider>,
   );
@@ -43,10 +44,13 @@ describe("PlumixEditor", () => {
     );
   });
 
-  test("mounts the right-rail inspector", () => {
+  test("mounts the right-rail inspector with Block/Page/JSON tabs", () => {
     const { getByTestId } = renderEditor();
     expect(getByTestId("plumix-editor-right")).toBeDefined();
-    // Nothing selected yet → inspector shows its empty state.
+    expect(getByTestId("plumix-tab-block")).toBeDefined();
+    expect(getByTestId("plumix-tab-page")).toBeDefined();
+    expect(getByTestId("plumix-tab-json")).toBeDefined();
+    // Block tab is active by default → inspector empty state shows.
     expect(getByTestId("block-inspector-empty")).toBeDefined();
   });
 });

--- a/packages/admin-editor/src/plumix-editor.tsx
+++ b/packages/admin-editor/src/plumix-editor.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from "react";
+import type { ReactElement, ReactNode } from "react";
 import { useEffect, useRef } from "react";
 import { Trans } from "@lingui/react";
 
@@ -15,6 +15,7 @@ import { BlockCatalog } from "./block-catalog-tab.js";
 import { BlockInspector } from "./block-inspector.js";
 import { CanvasFrame } from "./canvas-frame.js";
 import { EditorShortcuts, EditorToolbar } from "./editor-toolbar.js";
+import { JsonInspector } from "./json-inspector.js";
 import { LayersTab } from "./layers-tab.js";
 import { EditorProvider, useEditorStoreApi } from "./provider.js";
 
@@ -34,6 +35,9 @@ interface PlumixEditorProps {
   /** Fires with the full content envelope whenever the tree changes. The host
    *  debounces + persists (orpc lives in the app, never in this package). */
   readonly onChange?: (content: EntryContent) => void;
+  /** Admin-provided document settings (slug/excerpt/parent/metaboxes) rendered
+   *  in the Page tab; the host owns its persistence. */
+  readonly documentPanel?: ReactNode;
 }
 
 /**
@@ -48,6 +52,7 @@ export function PlumixEditor({
   registry,
   capabilities = NO_CAPABILITIES,
   onChange,
+  documentPanel,
 }: PlumixEditorProps): ReactElement {
   return (
     <EditorProvider initialTree={defaultValue?.blocks}>
@@ -85,7 +90,35 @@ export function PlumixEditor({
             className="bg-background w-80 shrink-0 overflow-auto border-s"
             data-testid="plumix-editor-right"
           >
-            <BlockInspector registry={registry} />
+            <Tabs defaultValue="block">
+              <TabsList className="m-2">
+                <TabsTrigger value="block" data-testid="plumix-tab-block">
+                  <Trans id="editor.tab.block" message="Block" />
+                </TabsTrigger>
+                <TabsTrigger value="page" data-testid="plumix-tab-page">
+                  <Trans id="editor.tab.page" message="Page" />
+                </TabsTrigger>
+                <TabsTrigger value="json" data-testid="plumix-tab-json">
+                  <Trans id="editor.tab.json" message="JSON" />
+                </TabsTrigger>
+              </TabsList>
+              <TabsContent value="block">
+                <BlockInspector registry={registry} />
+              </TabsContent>
+              <TabsContent value="page" data-testid="plumix-page-panel">
+                {documentPanel ?? (
+                  <p className="text-muted-foreground p-4 text-sm">
+                    <Trans
+                      id="editor.page.empty"
+                      message="No document settings."
+                    />
+                  </p>
+                )}
+              </TabsContent>
+              <TabsContent value="json">
+                <JsonInspector />
+              </TabsContent>
+            </Tabs>
           </aside>
         </div>
       </div>

--- a/packages/admin/e2e/bespoke-editor.spec.ts
+++ b/packages/admin/e2e/bespoke-editor.spec.ts
@@ -168,6 +168,37 @@ test.describe("bespoke editor route", () => {
     await expect(page.getByTestId("plumix-redo")).toBeEnabled();
   });
 
+  test("the Page tab shows document settings and the JSON tab shows the tree", async ({
+    page,
+  }) => {
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/entry/get": editorEntry({
+        content: {
+          version: "plumix.v2",
+          blocks: [{ id: "h1", name: "core/heading", attrs: { text: "Hi" } }],
+        },
+      }),
+      "/entry/list": [],
+      "/entry/createPreviewLink": {
+        token: "tok123",
+        url: "/post/hello?preview=tok123",
+      },
+    });
+
+    await page.goto("entries/posts/1/editor");
+
+    // Page tab hosts the admin-provided document settings (slug at minimum).
+    await page.getByTestId("plumix-tab-page").click();
+    await expect(page.getByTestId("entry-slug-input")).toHaveValue("entry-1");
+
+    // JSON tab renders the whole-page tree.
+    await page.getByTestId("plumix-tab-json").click();
+    await expect(page.getByTestId("json-inspector-output")).toContainText(
+      '"h1"',
+    );
+  });
+
   test("a failed preview mint surfaces the error placeholder, not a dead canvas", async ({
     page,
   }) => {

--- a/packages/admin/src/editor/autosave.ts
+++ b/packages/admin/src/editor/autosave.ts
@@ -1,3 +1,5 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { orpc } from "@/lib/orpc.js";
 import { ORPCError } from "@orpc/client";
 
 // 1 s batches typing bursts; the dedup snapshot in each autosave closure is
@@ -13,4 +15,27 @@ export function isStaleConflictError(err: unknown): boolean {
   if (err.code !== "CONFLICT") return false;
   const data = err.data as { reason?: unknown };
   return data.reason === "stale_expected_updated_at";
+}
+
+/**
+ * On a stale-token conflict, refetch the live row and return its `updatedAt`
+ * so the caller can re-anchor the optimistic-concurrency token; null when the
+ * error isn't a stale conflict or the refetch fails (best-effort — the next
+ * edit retries). Shared by both autosave debouncers.
+ */
+export async function freshLiveUpdatedAt(
+  err: unknown,
+  queryClient: QueryClient,
+  id: number,
+): Promise<Date | null> {
+  if (!isStaleConflictError(err)) return null;
+  try {
+    const fresh = await queryClient.fetchQuery({
+      ...orpc.entry.get.queryOptions({ input: { id } }),
+      staleTime: 0,
+    });
+    return fresh.updatedAt;
+  } catch {
+    return null;
+  }
 }

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/editor.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/editor.tsx
@@ -1,22 +1,30 @@
 import type { ReactNode } from "react";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { DocumentSettingsPanel } from "@/components/editor/document-settings.js";
 import { ErrorPlaceholder } from "@/components/error-placeholder.js";
-import {
-  AUTOSAVE_DEBOUNCE_MS,
-  isStaleConflictError,
-} from "@/editor/autosave.js";
+import { AUTOSAVE_DEBOUNCE_MS, freshLiveUpdatedAt } from "@/editor/autosave.js";
 import { createDebouncer } from "@/editor/debounce.js";
 import { registerCoreBlocks } from "@/editor/register-core-blocks.js";
+import { entryMetaBoxesForType, findEntryTypeBySlug } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import { getRegisteredBlocks } from "@/lib/plugin-registry.js";
 import { Trans } from "@lingui/react";
-import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
+import {
+  useQuery,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
 import { createFileRoute, notFound } from "@tanstack/react-router";
 import * as v from "valibot";
 
 import type { EntryContent } from "@plumix/blocks";
+import type { EntryTypeManifestEntry } from "@plumix/core/manifest";
 import { PlumixEditor } from "@plumix/admin-editor";
-import { createBlockRegistry, isEntryContent } from "@plumix/blocks";
+import {
+  createBlockRegistry,
+  defineEntryContent,
+  isEntryContent,
+} from "@plumix/blocks";
 import { idPathParam } from "@plumix/core/validation";
 
 // Core + plugin blocks supply the inspector's input schemas. Built once at
@@ -95,17 +103,252 @@ function ErrorScreen(): ReactNode {
 }
 
 function BespokeEditorRoute(): ReactNode {
+  const { slug } = Route.useParams();
+  const { user } = Route.useRouteContext();
+  // Pass capabilities + entryType across a prop boundary so the React Compiler
+  // treats them as stable inputs (member/derived reads inline read as
+  // possibly-mutated, which forces the compiler to skip optimizing).
+  return (
+    <BespokeEditor
+      capabilities={user.capabilities}
+      entryType={findEntryTypeBySlug(slug)}
+    />
+  );
+}
+
+interface BespokeEditorProps {
+  readonly capabilities: readonly string[];
+  readonly entryType: EntryTypeManifestEntry | undefined;
+}
+
+// Persistence lives inline in the component (not a custom hook) so the React
+// Compiler can optimize it — the same shape that compiles for the Puck route.
+// Content + excerpt + meta ride one debounced autosave-row write; slug + parent
+// ride a second debouncer that writes the live row (`saveAs: "live"`). Both
+// share one optimistic-concurrency token, refreshed on a stale conflict.
+function BespokeEditor({
+  capabilities,
+  entryType,
+}: BespokeEditorProps): ReactNode {
   const { id } = Route.useParams();
   const { data: entry } = useSuspenseQuery(
     orpc.entry.get.queryOptions({ input: { id, preview: true } }),
   );
   const { data: previewLink } = useSuspenseQuery(previewLinkQuery(id));
-  const { user } = Route.useRouteContext();
-  const capabilities = useMemo(
-    () => new Set(user.capabilities),
-    [user.capabilities],
+  const queryClient = useQueryClient();
+  const entryTypeName = entryType?.name;
+  const capabilitySet = useMemo(() => new Set(capabilities), [capabilities]);
+
+  const liveUpdatedAtRef = useRef<Date>(entry.updatedAt);
+  const seedContent = isEntryContent(entry.content)
+    ? entry.content
+    : defineEntryContent([]);
+  const contentRef = useRef<EntryContent>(seedContent);
+  const lastSavedContentRef = useRef<string>(
+    JSON.stringify(seedContent.blocks),
   );
-  const handleChange = useContentAutosave(id, entry);
+  const [excerpt, setExcerpt] = useState<string>(entry.excerpt ?? "");
+  const excerptRef = useRef(excerpt);
+  const lastSavedExcerptRef = useRef<string>(entry.excerpt ?? "");
+  const metaRef = useRef<Record<string, unknown>>(entry.meta);
+  const lastSavedMetaRef = useRef<string>(JSON.stringify(entry.meta));
+  const [slugValue, setSlugValue] = useState<string>(entry.slug);
+  const [parentValue, setParentValue] = useState<number | null>(entry.parentId);
+  const slugRef = useRef(slugValue);
+  const parentRef = useRef(parentValue);
+  const lastSavedSlugRef = useRef<string>(entry.slug);
+  const lastSavedParentRef = useRef<number | null>(entry.parentId);
+  useEffect(() => {
+    excerptRef.current = excerpt;
+    slugRef.current = slugValue;
+    parentRef.current = parentValue;
+  });
+
+  /* eslint-disable react-hooks/refs -- callbacks fire post-keystroke, not during render */
+  const contentDebouncer = useMemo(
+    () =>
+      createDebouncer(async () => {
+        const blocks = contentRef.current.blocks;
+        const serializedBlocks = JSON.stringify(blocks);
+        const contentChanged = serializedBlocks !== lastSavedContentRef.current;
+        const nextExcerpt = excerptRef.current;
+        const excerptChanged = nextExcerpt !== lastSavedExcerptRef.current;
+        const serializedMeta = JSON.stringify(metaRef.current);
+        const metaChanged = serializedMeta !== lastSavedMetaRef.current;
+        if (!contentChanged && !excerptChanged && !metaChanged) return;
+        try {
+          const updated = await orpc.entry.update.call({
+            id,
+            ...(contentChanged
+              ? { content: { version: "plumix.v2", blocks } }
+              : {}),
+            ...(excerptChanged
+              ? { excerpt: nextExcerpt.length === 0 ? null : nextExcerpt }
+              : {}),
+            ...(metaChanged ? { meta: metaRef.current } : {}),
+            expectedLiveUpdatedAt: liveUpdatedAtRef.current,
+          });
+          if (updated.type === entry.type) {
+            liveUpdatedAtRef.current = updated.updatedAt;
+          }
+          if (contentChanged) lastSavedContentRef.current = serializedBlocks;
+          if (excerptChanged) lastSavedExcerptRef.current = nextExcerpt;
+          if (metaChanged) lastSavedMetaRef.current = serializedMeta;
+        } catch (err) {
+          const fresh = await freshLiveUpdatedAt(err, queryClient, id);
+          if (fresh) liveUpdatedAtRef.current = fresh;
+        }
+      }, AUTOSAVE_DEBOUNCE_MS),
+    [id, entry.type, queryClient],
+  );
+  const structuralDebouncer = useMemo(
+    () =>
+      createDebouncer(async () => {
+        const nextSlug = slugRef.current.trim();
+        const nextParent = parentRef.current;
+        const slugChanged =
+          nextSlug.length > 0 && nextSlug !== lastSavedSlugRef.current;
+        const parentChanged = nextParent !== lastSavedParentRef.current;
+        if (!slugChanged && !parentChanged) return;
+        try {
+          const updated = await orpc.entry.update.call({
+            id,
+            ...(slugChanged ? { slug: nextSlug } : {}),
+            ...(parentChanged ? { parentId: nextParent } : {}),
+            saveAs: "live",
+            expectedLiveUpdatedAt: liveUpdatedAtRef.current,
+          });
+          liveUpdatedAtRef.current = updated.updatedAt;
+          if (slugChanged) lastSavedSlugRef.current = updated.slug;
+          if (parentChanged) lastSavedParentRef.current = updated.parentId;
+        } catch (err) {
+          const fresh = await freshLiveUpdatedAt(err, queryClient, id);
+          if (fresh) liveUpdatedAtRef.current = fresh;
+        }
+      }, AUTOSAVE_DEBOUNCE_MS),
+    [id, queryClient],
+  );
+  /* eslint-enable react-hooks/refs */
+  useEffect(
+    () => () => {
+      contentDebouncer.flush();
+      structuralDebouncer.flush();
+    },
+    [contentDebouncer, structuralDebouncer],
+  );
+
+  const handleChange = useCallback(
+    (content: EntryContent): void => {
+      contentRef.current = content;
+      contentDebouncer.call();
+    },
+    [contentDebouncer],
+  );
+  const handleSlugChange = useCallback(
+    (next: string): void => {
+      setSlugValue(next);
+      structuralDebouncer.call();
+    },
+    [structuralDebouncer, setSlugValue],
+  );
+  const handleParentChange = useCallback(
+    (next: number | null): void => {
+      setParentValue(next);
+      structuralDebouncer.call();
+    },
+    [structuralDebouncer, setParentValue],
+  );
+  const handleExcerptChange = useCallback(
+    (next: string): void => {
+      setExcerpt(next);
+      contentDebouncer.call();
+    },
+    [contentDebouncer, setExcerpt],
+  );
+  const handleMetaChange = useCallback(
+    (next: Record<string, unknown>): void => {
+      metaRef.current = next;
+      if (JSON.stringify(next) === lastSavedMetaRef.current) return;
+      contentDebouncer.call();
+    },
+    [contentDebouncer],
+  );
+
+  const metaBoxes = useMemo(
+    () =>
+      entryTypeName ? entryMetaBoxesForType(entryTypeName, capabilities) : [],
+    [entryTypeName, capabilities],
+  );
+  const supportsExcerpt =
+    // `supports` list code, not a display label.
+    // eslint-disable-next-line lingui/no-unlocalized-strings
+    entryType?.supports?.includes("excerpt") ?? false;
+  const isHierarchical = entryType?.isHierarchical === true;
+  const parentCandidates = useQuery({
+    ...orpc.entry.list.queryOptions({
+      input: {
+        type: entryTypeName ?? "",
+        limit: 100,
+        // SQL column picklist code, not a display label.
+        // eslint-disable-next-line lingui/no-unlocalized-strings
+        orderBy: "title",
+        order: "asc",
+      },
+    }),
+    enabled: isHierarchical && entryTypeName !== undefined,
+  });
+  const parentOptions = useMemo(
+    () =>
+      (parentCandidates.data ?? [])
+        .filter((candidate) => candidate.id !== id)
+        .map((candidate) => ({ id: candidate.id, title: candidate.title })),
+    [parentCandidates.data, id],
+  );
+  const documentPanel = useMemo(
+    () => (
+      <DocumentSettingsPanel
+        slug={slugValue}
+        onSlugChange={handleSlugChange}
+        excerpt={
+          supportsExcerpt
+            ? { value: excerpt, onChange: handleExcerptChange }
+            : undefined
+        }
+        parent={
+          isHierarchical
+            ? {
+                value: parentValue,
+                options: parentOptions,
+                onChange: handleParentChange,
+              }
+            : undefined
+        }
+        metaBoxes={
+          metaBoxes.length > 0
+            ? {
+                boxes: metaBoxes,
+                initialMeta: entry.meta,
+                onMetaChange: handleMetaChange,
+              }
+            : undefined
+        }
+      />
+    ),
+    [
+      slugValue,
+      handleSlugChange,
+      supportsExcerpt,
+      excerpt,
+      handleExcerptChange,
+      isHierarchical,
+      parentValue,
+      parentOptions,
+      handleParentChange,
+      metaBoxes,
+      entry.meta,
+      handleMetaChange,
+    ],
+  );
 
   // `createPreviewLink` returns a site-relative url (`/blog/hello?preview=…`);
   // resolve it against the admin's own origin (the public site is same-origin)
@@ -119,79 +362,9 @@ function BespokeEditorRoute(): ReactNode {
       origin={target.origin}
       defaultValue={isEntryContent(entry.content) ? entry.content : undefined}
       registry={registry}
-      capabilities={capabilities}
+      capabilities={capabilitySet}
       onChange={handleChange}
+      documentPanel={documentPanel}
     />
-  );
-}
-
-interface EntryRow {
-  readonly type: string;
-  readonly updatedAt: Date;
-  readonly content: unknown;
-}
-
-// Debounced content autosave. The editor package emits the full content
-// envelope on every tree change; this is the only place orpc lives (the
-// package stays persistence-free). Mirrors the Puck route's content path:
-// dedup against the last save, ride the optimistic-concurrency token, and
-// refresh it on a stale conflict so the next save recovers.
-function useContentAutosave(
-  id: number,
-  entry: EntryRow,
-): (content: EntryContent) => void {
-  const queryClient = useQueryClient();
-  const liveUpdatedAtRef = useRef<Date>(entry.updatedAt);
-  const lastSavedRef = useRef<string>(
-    JSON.stringify(isEntryContent(entry.content) ? entry.content.blocks : []),
-  );
-  const pendingRef = useRef<EntryContent | null>(null);
-  /* eslint-disable react-hooks/refs -- callback fires post-keystroke, not during render */
-  const debouncer = useMemo(
-    () =>
-      createDebouncer(async () => {
-        const content = pendingRef.current;
-        if (!content) return;
-        const serialized = JSON.stringify(content.blocks);
-        if (serialized === lastSavedRef.current) return;
-        try {
-          const updated = await orpc.entry.update.call({
-            id,
-            // Spread to a fresh object literal — the `content` RPC field is a
-            // `Record<string, unknown>`, which the named EntryContent interface
-            // doesn't satisfy without an index signature.
-            content: { ...content },
-            expectedLiveUpdatedAt: liveUpdatedAtRef.current,
-          });
-          // Only stamp the live token when the write landed on the live row;
-          // autosave-supporting types route to a per-user autosave row whose
-          // updatedAt isn't the live anchor (poisoning it would 409 publish).
-          if (updated.type === entry.type) {
-            liveUpdatedAtRef.current = updated.updatedAt;
-          }
-          lastSavedRef.current = serialized;
-        } catch (err) {
-          if (!isStaleConflictError(err)) return;
-          try {
-            const fresh = await queryClient.fetchQuery({
-              ...orpc.entry.get.queryOptions({ input: { id } }),
-              staleTime: 0,
-            });
-            liveUpdatedAtRef.current = fresh.updatedAt;
-          } catch {
-            // Best-effort: the next edit retries with the stale token.
-          }
-        }
-      }, AUTOSAVE_DEBOUNCE_MS),
-    [id, entry.type, queryClient],
-  );
-  /* eslint-enable react-hooks/refs */
-  useEffect(() => () => debouncer.flush(), [debouncer]);
-  return useCallback(
-    (content: EntryContent): void => {
-      pendingRef.current = content;
-      debouncer.call();
-    },
-    [debouncer],
   );
 }


### PR DESCRIPTION
Adds two right-rail tabs to the bespoke editor (PRD #1104, slice #1110).

- **JSON** — a read-only view of the canonical tree, switchable between the
  selected block and the whole page. A debugging/escape-hatch surface; it never
  mutates.
- **Page** — admin-provided document settings (slug, excerpt, parent,
  metaboxes), injected via a new `documentPanel` prop so the editor package
  stays orpc-free.

The admin route builds the document panel and wires persistence the same way the
Puck route does: content + excerpt + meta on one debounced autosave-row write,
slug + parent on a structural debouncer that writes the live row
(`saveAs: "live"`), both sharing one optimistic-concurrency token with
stale-conflict recovery. The shared stale-token refetch is extracted to
`@/editor/autosave.ts`.

Note on structure: the route is split outer/inner with `capabilities` +
`entryType` passed as props, and the persistence is inlined (not a custom hook).
The React Compiler can't preserve the intentional manual memoization through a
custom hook or inline member-access reads — both make it bail — so this mirrors
the exact shape that compiles for the sibling Puck route.

Test coverage: JSON inspector (toggle + empty state) and the right-rail tabs are
unit-tested; the e2e drives the Page tab (document settings render) and the JSON
tab (whole-page tree). The autosave path reuses the Puck route's e2e-proven
logic.

Closes #1110