### PR TITLE
feat: wire publish / save-draft / discard + conflict handling in the editor

### DIFF
--- a/packages/admin-editor/locales/ar.po
+++ b/packages/admin-editor/locales/ar.po
@@ -34,6 +34,11 @@ msgid "editor.tab.blocks"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.discard"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.json"
 msgstr ""
@@ -70,7 +75,17 @@ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
+msgid "editor.toolbar.publish"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
 msgid "editor.toolbar.redo"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.saveDraft"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -91,4 +106,9 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
 msgid "editor.toolbar.undo"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.unpublished"
 msgstr ""

--- a/packages/admin-editor/locales/de.po
+++ b/packages/admin-editor/locales/de.po
@@ -34,6 +34,11 @@ msgid "editor.tab.blocks"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.discard"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.json"
 msgstr ""
@@ -70,7 +75,17 @@ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
+msgid "editor.toolbar.publish"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
 msgid "editor.toolbar.redo"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.saveDraft"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -91,4 +106,9 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
 msgid "editor.toolbar.undo"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.unpublished"
 msgstr ""

--- a/packages/admin-editor/locales/en.po
+++ b/packages/admin-editor/locales/en.po
@@ -34,6 +34,11 @@ msgid "editor.tab.blocks"
 msgstr "Blocks"
 
 #. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.discard"
+msgstr "Discard"
+
+#. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.json"
 msgstr "JSON"
@@ -70,8 +75,18 @@ msgstr "Page"
 
 #. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
+msgid "editor.toolbar.publish"
+msgstr "Publish"
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
 msgid "editor.toolbar.redo"
 msgstr "Redo"
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.saveDraft"
+msgstr "Save draft"
 
 #. js-lingui-explicit-id
 #: src/block-catalog-tab.tsx
@@ -92,3 +107,8 @@ msgstr "Select a block to inspect."
 #: src/editor-toolbar.tsx
 msgid "editor.toolbar.undo"
 msgstr "Undo"
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.unpublished"
+msgstr "Unpublished changes"

--- a/packages/admin-editor/locales/uk.po
+++ b/packages/admin-editor/locales/uk.po
@@ -34,6 +34,11 @@ msgid "editor.tab.blocks"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.discard"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.json"
 msgstr ""
@@ -70,7 +75,17 @@ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
+msgid "editor.toolbar.publish"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
 msgid "editor.toolbar.redo"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.saveDraft"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -91,4 +106,9 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
 msgid "editor.toolbar.undo"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.unpublished"
 msgstr ""

--- a/packages/admin-editor/locales/zh-CN.po
+++ b/packages/admin-editor/locales/zh-CN.po
@@ -34,6 +34,11 @@ msgid "editor.tab.blocks"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.discard"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.json"
 msgstr ""
@@ -70,7 +75,17 @@ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
+msgid "editor.toolbar.publish"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
 msgid "editor.toolbar.redo"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.saveDraft"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -91,4 +106,9 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
 msgid "editor.toolbar.undo"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.unpublished"
 msgstr ""

--- a/packages/admin-editor/src/editor-toolbar.test.tsx
+++ b/packages/admin-editor/src/editor-toolbar.test.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { i18n } from "@lingui/core";
 import { I18nProvider } from "@lingui/react";
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
-import { afterEach, beforeAll, describe, expect, test } from "vitest";
+import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
 
 import { EditorShortcuts, EditorToolbar } from "./editor-toolbar.js";
 import { EditorProvider, useEditorStoreApi } from "./provider.js";
@@ -23,11 +23,13 @@ function Capture(): null {
   return null;
 }
 
-function renderToolbar(): ReturnType<typeof render> {
+function renderToolbar(
+  publish?: Parameters<typeof EditorToolbar>[0]["publish"],
+): ReturnType<typeof render> {
   return render(
     <I18nProvider i18n={i18n}>
       <EditorProvider initialTree={[]}>
-        <EditorToolbar />
+        <EditorToolbar publish={publish} />
         <EditorShortcuts />
         <Capture />
       </EditorProvider>
@@ -78,5 +80,60 @@ describe("EditorToolbar", () => {
     // The edit survives — the shortcut deferred to the field's native undo.
     expect(storeApi?.getState().tree).toHaveLength(1);
     input.remove();
+  });
+
+  test("renders a Publish button that calls onPublish", () => {
+    const onPublish = vi.fn();
+    const { getByTestId } = renderToolbar({ onPublish, isPublished: false });
+    const publishButton = getByTestId("plumix-editor-publish-button");
+    expect(button(publishButton).disabled).toBe(false);
+    fireEvent.click(publishButton);
+    expect(onPublish).toHaveBeenCalledOnce();
+  });
+
+  test("the Publish button is disabled once published", () => {
+    const { getByTestId } = renderToolbar({
+      onPublish: vi.fn(),
+      isPublished: true,
+    });
+    expect(button(getByTestId("plumix-editor-publish-button")).disabled).toBe(
+      true,
+    );
+  });
+
+  test("draft mode shows save/publish/discard, gated on a pending draft", () => {
+    const draftMode = {
+      hasPendingDraft: false,
+      onSaveDraft: vi.fn(),
+      onPublishDraft: vi.fn(),
+      onDiscardDraft: vi.fn(),
+      isSaving: false,
+      isPublishing: false,
+      isDiscarding: false,
+    };
+    const { getByTestId, queryByTestId } = renderToolbar({ draftMode });
+    // No live Publish button in draft mode.
+    expect(queryByTestId("plumix-editor-publish-button")).toBeNull();
+    // Discard + Publish gated until there's a pending draft; Save always on.
+    expect(button(getByTestId("editor-draft-save")).disabled).toBe(false);
+    expect(button(getByTestId("editor-draft-discard")).disabled).toBe(true);
+    expect(button(getByTestId("editor-draft-publish")).disabled).toBe(true);
+    expect(queryByTestId("unpublished-changes-banner")).toBeNull();
+  });
+
+  test("a pending draft enables discard/publish and shows the banner", () => {
+    const draftMode = {
+      hasPendingDraft: true,
+      onSaveDraft: vi.fn(),
+      onPublishDraft: vi.fn(),
+      onDiscardDraft: vi.fn(),
+      isSaving: false,
+      isPublishing: false,
+      isDiscarding: false,
+    };
+    const { getByTestId } = renderToolbar({ draftMode });
+    expect(getByTestId("unpublished-changes-banner")).toBeDefined();
+    fireEvent.click(getByTestId("editor-draft-publish"));
+    expect(draftMode.onPublishDraft).toHaveBeenCalledOnce();
   });
 });

--- a/packages/admin-editor/src/editor-toolbar.tsx
+++ b/packages/admin-editor/src/editor-toolbar.tsx
@@ -7,8 +7,34 @@ import { Button } from "@plumix/admin-ui/button";
 import { canRedo, canUndo } from "./history.js";
 import { useEditorStore, useEditorStoreApi } from "./provider.js";
 
-/** Top toolbar: undo/redo (more controls land here in later slices). */
-export function EditorToolbar(): ReactElement {
+/** Draft-mode actions for a published entry with a pending autosave. The host
+ *  owns the mutations; the toolbar only renders the buttons and their state. */
+export interface DraftMode {
+  readonly hasPendingDraft: boolean;
+  readonly onSaveDraft: () => void;
+  readonly onPublishDraft: () => void;
+  readonly onDiscardDraft: () => void;
+  readonly isSaving: boolean;
+  readonly isPublishing: boolean;
+  readonly isDiscarding: boolean;
+}
+
+/** Publish wiring injected by the host (no orpc in this package). When
+ *  `draftMode` is set the toolbar shows save/publish/discard; otherwise a plain
+ *  Publish button (disabled once published). */
+export interface PublishActions {
+  readonly onPublish?: () => void;
+  readonly isPublished?: boolean;
+  readonly isPublishing?: boolean;
+  readonly draftMode?: DraftMode;
+}
+
+/** Top toolbar: undo/redo plus the host-wired publish / draft actions. */
+export function EditorToolbar({
+  publish,
+}: {
+  readonly publish?: PublishActions;
+}): ReactElement {
   const undoAvailable = useEditorStore((s) => canUndo(s.history));
   const redoAvailable = useEditorStore((s) => canRedo(s.history));
   const undo = useEditorStore((s) => s.undo);
@@ -39,7 +65,78 @@ export function EditorToolbar(): ReactElement {
       >
         <Trans id="editor.toolbar.redo" message="Redo" />
       </Button>
+      {publish ? <PublishControls publish={publish} /> : null}
     </header>
+  );
+}
+
+function PublishControls({
+  publish,
+}: {
+  readonly publish: PublishActions;
+}): ReactElement {
+  const { draftMode } = publish;
+  if (draftMode) {
+    const busy =
+      draftMode.isSaving || draftMode.isPublishing || draftMode.isDiscarding;
+    return (
+      <div className="ms-auto flex items-center gap-2">
+        {draftMode.hasPendingDraft ? (
+          <span
+            className="text-muted-foreground text-xs"
+            data-testid="unpublished-changes-banner"
+          >
+            <Trans
+              id="editor.toolbar.unpublished"
+              message="Unpublished changes"
+            />
+          </span>
+        ) : null}
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          data-testid="editor-draft-discard"
+          disabled={busy || !draftMode.hasPendingDraft}
+          onClick={draftMode.onDiscardDraft}
+        >
+          <Trans id="editor.toolbar.discard" message="Discard" />
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          data-testid="editor-draft-save"
+          disabled={busy}
+          onClick={draftMode.onSaveDraft}
+        >
+          <Trans id="editor.toolbar.saveDraft" message="Save draft" />
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          data-testid="editor-draft-publish"
+          disabled={busy || !draftMode.hasPendingDraft}
+          onClick={draftMode.onPublishDraft}
+        >
+          <Trans id="editor.toolbar.publish" message="Publish" />
+        </Button>
+      </div>
+    );
+  }
+  const { isPublishing = false, isPublished = false } = publish;
+  return (
+    <div className="ms-auto">
+      <Button
+        type="button"
+        size="sm"
+        data-testid="plumix-editor-publish-button"
+        disabled={isPublishing || isPublished}
+        onClick={publish.onPublish}
+      >
+        <Trans id="editor.toolbar.publish" message="Publish" />
+      </Button>
+    </div>
   );
 }
 

--- a/packages/admin-editor/src/plumix-editor.tsx
+++ b/packages/admin-editor/src/plumix-editor.tsx
@@ -11,6 +11,7 @@ import {
 } from "@plumix/admin-ui/tabs";
 import { defineEntryContent } from "@plumix/blocks";
 
+import type { PublishActions } from "./editor-toolbar.js";
 import { BlockCatalog } from "./block-catalog-tab.js";
 import { BlockInspector } from "./block-inspector.js";
 import { CanvasFrame } from "./canvas-frame.js";
@@ -38,6 +39,10 @@ interface PlumixEditorProps {
   /** Admin-provided document settings (slug/excerpt/parent/metaboxes) rendered
    *  in the Page tab; the host owns its persistence. */
   readonly documentPanel?: ReactNode;
+  /** Publish / save-draft / discard wiring for the toolbar (host mutations). */
+  readonly publish?: PublishActions;
+  /** Host-rendered overlay (e.g. the stale-draft resolution dialog). */
+  readonly overlay?: ReactNode;
 }
 
 /**
@@ -53,11 +58,13 @@ export function PlumixEditor({
   capabilities = NO_CAPABILITIES,
   onChange,
   documentPanel,
+  publish,
+  overlay,
 }: PlumixEditorProps): ReactElement {
   return (
     <EditorProvider initialTree={defaultValue?.blocks}>
       <div className="flex h-full flex-col" data-testid="plumix-editor-layout">
-        <EditorToolbar />
+        <EditorToolbar publish={publish} />
         <div className="flex min-h-0 flex-1">
           <aside
             className="bg-background w-72 shrink-0 overflow-auto border-e"
@@ -123,6 +130,7 @@ export function PlumixEditor({
         </div>
       </div>
       <EditorShortcuts />
+      {overlay}
       {onChange ? <TreeChangeEmitter onChange={onChange} /> : null}
     </EditorProvider>
   );

--- a/packages/admin/e2e/bespoke-editor.spec.ts
+++ b/packages/admin/e2e/bespoke-editor.spec.ts
@@ -7,7 +7,12 @@
 
 import { expect, test } from "@playwright/test";
 
-import { editorEntry } from "./support/editor.js";
+import {
+  editorEntry,
+  publishedEntry,
+  publishedEntryRpcBody,
+  T0,
+} from "./support/editor.js";
 import {
   AUTHED_ADMIN,
   MANIFEST_WITH_POST,
@@ -197,6 +202,72 @@ test.describe("bespoke editor route", () => {
     await expect(page.getByTestId("json-inspector-output")).toContainText(
       '"h1"',
     );
+  });
+
+  test("a draft entry shows a Publish button wired to the host", async ({
+    page,
+  }) => {
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/entry/get": editorEntry(),
+      "/entry/createPreviewLink": {
+        token: "tok123",
+        url: "/post/hello?preview=tok123",
+      },
+    });
+
+    await page.goto("entries/posts/1/editor");
+
+    const publishButton = page.getByTestId("plumix-editor-publish-button");
+    await expect(publishButton).toBeVisible();
+    await expect(publishButton).toBeEnabled();
+    await expect(page.getByTestId("editor-draft-save")).toHaveCount(0);
+  });
+
+  test("a published autosave-type entry shows draft save/publish/discard", async ({
+    page,
+  }) => {
+    await mockManifest(page, {
+      ...MANIFEST_WITH_POST,
+      entryTypes: [
+        {
+          name: "post",
+          adminSlug: "posts",
+          label: "Posts",
+          labels: { singular: "Post", plural: "Posts" },
+          supports: ["editor", "autosave"],
+        },
+      ],
+    });
+    await mockRpc(page, {
+      "/auth/session": AUTHED_ADMIN,
+      "/entry/list": [],
+      "/entry/createPreviewLink": {
+        token: "tok123",
+        url: "/post/hello?preview=tok123",
+      },
+    });
+    // A pending autosave (equal timestamps = fresh, not stale). The dedicated
+    // body builder encodes the `_preview` dates so the client revives them.
+    await page.route("**/_plumix/rpc/entry/get", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: publishedEntryRpcBody(publishedEntry({ autosaveUpdatedAt: T0 })),
+      }),
+    );
+
+    await page.goto("entries/posts/1/editor");
+
+    // Draft mode: the live Publish button is replaced by the draft trio, and
+    // the pending autosave enables Publish/Discard + shows the banner.
+    await expect(page.getByTestId("plumix-editor-publish-button")).toHaveCount(
+      0,
+    );
+    await expect(page.getByTestId("editor-draft-save")).toBeVisible();
+    await expect(page.getByTestId("editor-draft-publish")).toBeEnabled();
+    await expect(page.getByTestId("editor-draft-discard")).toBeEnabled();
+    await expect(page.getByTestId("unpublished-changes-banner")).toBeVisible();
   });
 
   test("a failed preview mint surfaces the error placeholder, not a dead canvas", async ({

--- a/packages/admin/locales/ar.po
+++ b/packages/admin/locales/ar.po
@@ -1043,6 +1043,11 @@ msgid "terms.create.error.emptySlug"
 msgstr "تعذّر اشتقاق slug من ذلك الاسم — يرجى كتابة واحد يدوياً."
 
 #. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.discardFailed"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
 msgid "editor.entry.edit.toast.discardFailed"
 msgstr "تعذّر تجاهل المسودة — حاول مرة أخرى."
@@ -1125,6 +1130,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/editor.tsx
 msgid "editor.bespoke.previewFailed"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.publishFailed"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -1526,6 +1536,11 @@ msgstr "تم"
 msgctxt "entry status"
 msgid "entries.list.statusFilter.draft"
 msgstr "مسودة"
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.discarded"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -2074,6 +2089,11 @@ msgstr "جارٍ تحميل المستخدم"
 #: src/routes/_authenticated/users/index.tsx
 msgid "users.list.loading"
 msgstr "جارٍ تحميل المستخدمين"
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.stale.loading"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -2739,6 +2759,11 @@ msgstr "منشور"
 #: src/lib/core-type-labels-i18n.ts
 msgid "type.generic.itemPublishedPrivately"
 msgstr "منشور بشكل خاص"
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.published"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx

--- a/packages/admin/locales/de.po
+++ b/packages/admin/locales/de.po
@@ -1043,6 +1043,11 @@ msgid "terms.create.error.emptySlug"
 msgstr "Aus diesem Namen konnte kein Slug abgeleitet werden — bitte manuell eingeben."
 
 #. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.discardFailed"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
 msgid "editor.entry.edit.toast.discardFailed"
 msgstr "Entwurf konnte nicht verworfen werden — bitte erneut versuchen."
@@ -1125,6 +1130,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/editor.tsx
 msgid "editor.bespoke.previewFailed"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.publishFailed"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -1526,6 +1536,11 @@ msgstr "Fertig"
 msgctxt "entry status"
 msgid "entries.list.statusFilter.draft"
 msgstr "Entwurf"
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.discarded"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -2074,6 +2089,11 @@ msgstr "Benutzer wird geladen"
 #: src/routes/_authenticated/users/index.tsx
 msgid "users.list.loading"
 msgstr "Benutzer werden geladen"
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.stale.loading"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -2739,6 +2759,11 @@ msgstr "Veröffentlicht"
 #: src/lib/core-type-labels-i18n.ts
 msgid "type.generic.itemPublishedPrivately"
 msgstr "Privat veröffentlicht"
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.published"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx

--- a/packages/admin/locales/en.po
+++ b/packages/admin/locales/en.po
@@ -1043,6 +1043,11 @@ msgid "terms.create.error.emptySlug"
 msgstr "Couldn't derive a slug from that name — please type one manually."
 
 #. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.discardFailed"
+msgstr "Couldn't discard the draft — try again."
+
+#. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
 msgid "editor.entry.edit.toast.discardFailed"
 msgstr "Couldn't discard the draft — try again."
@@ -1126,6 +1131,11 @@ msgstr "Couldn't open the editor"
 #: src/routes/_editor/entries/$slug/$id/editor.tsx
 msgid "editor.bespoke.previewFailed"
 msgstr "Couldn't open this entry in the editor."
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.publishFailed"
+msgstr "Couldn't publish — try again."
 
 #. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -1526,6 +1536,11 @@ msgstr "Done"
 msgctxt "entry status"
 msgid "entries.list.statusFilter.draft"
 msgstr "Draft"
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.discarded"
+msgstr "Draft discarded."
 
 #. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -2074,6 +2089,11 @@ msgstr "Loading user"
 #: src/routes/_authenticated/users/index.tsx
 msgid "users.list.loading"
 msgstr "Loading users"
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.stale.loading"
+msgstr "Loading…"
 
 #. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -2739,6 +2759,11 @@ msgstr "Published"
 #: src/lib/core-type-labels-i18n.ts
 msgid "type.generic.itemPublishedPrivately"
 msgstr "Published privately"
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.published"
+msgstr "Published."
 
 #. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx

--- a/packages/admin/locales/uk.po
+++ b/packages/admin/locales/uk.po
@@ -1043,6 +1043,11 @@ msgid "terms.create.error.emptySlug"
 msgstr "Не вдалося визначити slug з цієї назви — введіть його вручну."
 
 #. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.discardFailed"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
 msgid "editor.entry.edit.toast.discardFailed"
 msgstr "Не вдалося відхилити чернетку — спробуйте ще раз."
@@ -1125,6 +1130,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/editor.tsx
 msgid "editor.bespoke.previewFailed"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.publishFailed"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -1526,6 +1536,11 @@ msgstr "Готово"
 msgctxt "entry status"
 msgid "entries.list.statusFilter.draft"
 msgstr "Чернетка"
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.discarded"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -2074,6 +2089,11 @@ msgstr "Завантаження користувача"
 #: src/routes/_authenticated/users/index.tsx
 msgid "users.list.loading"
 msgstr "Завантаження користувачів"
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.stale.loading"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -2739,6 +2759,11 @@ msgstr "Опубліковано"
 #: src/lib/core-type-labels-i18n.ts
 msgid "type.generic.itemPublishedPrivately"
 msgstr "Опубліковано приватно"
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.published"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx

--- a/packages/admin/locales/zh-CN.po
+++ b/packages/admin/locales/zh-CN.po
@@ -1043,6 +1043,11 @@ msgid "terms.create.error.emptySlug"
 msgstr "无法从此名称生成别名 — 请手动输入。"
 
 #. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.discardFailed"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
 msgid "editor.entry.edit.toast.discardFailed"
 msgstr "无法放弃草稿，请重试。"
@@ -1125,6 +1130,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/editor.tsx
 msgid "editor.bespoke.previewFailed"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.publishFailed"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -1526,6 +1536,11 @@ msgstr "完成"
 msgctxt "entry status"
 msgid "entries.list.statusFilter.draft"
 msgstr "草稿"
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.discarded"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -2074,6 +2089,11 @@ msgstr "正在加载用户"
 #: src/routes/_authenticated/users/index.tsx
 msgid "users.list.loading"
 msgstr "正在加载用户"
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.stale.loading"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -2739,6 +2759,11 @@ msgstr "已发布"
 #: src/lib/core-type-labels-i18n.ts
 msgid "type.generic.itemPublishedPrivately"
 msgstr "已私密发布"
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.published"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/editor.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/editor.tsx
@@ -1,15 +1,23 @@
+import type { MessageDescriptor } from "@lingui/core";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { DocumentSettingsPanel } from "@/components/editor/document-settings.js";
 import { ErrorPlaceholder } from "@/components/error-placeholder.js";
 import { AUTOSAVE_DEBOUNCE_MS, freshLiveUpdatedAt } from "@/editor/autosave.js";
 import { createDebouncer } from "@/editor/debounce.js";
+import { detectStaleAutosave } from "@/editor/detect-stale-autosave.js";
 import { registerCoreBlocks } from "@/editor/register-core-blocks.js";
+import { resolveEditorMode } from "@/editor/resolve-editor-mode.js";
+import { StaleDraftDialog } from "@/editor/StaleDraftDialog.js";
 import { entryMetaBoxesForType, findEntryTypeBySlug } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import { getRegisteredBlocks } from "@/lib/plugin-registry.js";
+import { toastError, toastSuccess } from "@/lib/toast.js";
+import { useLabel } from "@/lib/use-label.js";
+import { defineMessage } from "@lingui/core/macro";
 import { Trans } from "@lingui/react";
 import {
+  useMutation,
   useQuery,
   useQueryClient,
   useSuspenseQuery,
@@ -26,6 +34,29 @@ import {
   isEntryContent,
 } from "@plumix/blocks";
 import { idPathParam } from "@plumix/core/validation";
+
+const M = {
+  published: defineMessage({
+    id: "editor.bespoke.toast.published",
+    message: "Published.",
+  }),
+  publishFailed: defineMessage({
+    id: "editor.bespoke.toast.publishFailed",
+    message: "Couldn't publish — try again.",
+  }),
+  discarded: defineMessage({
+    id: "editor.bespoke.toast.discarded",
+    message: "Draft discarded.",
+  }),
+  discardFailed: defineMessage({
+    id: "editor.bespoke.toast.discardFailed",
+    message: "Couldn't discard the draft — try again.",
+  }),
+  staleLoading: defineMessage({
+    id: "editor.bespoke.stale.loading",
+    message: "Loading…",
+  }),
+} satisfies Record<string, MessageDescriptor>;
 
 // Core + plugin blocks supply the inspector's input schemas. Built once at
 // module load, mirroring the Puck route.
@@ -103,15 +134,30 @@ function ErrorScreen(): ReactNode {
 }
 
 function BespokeEditorRoute(): ReactNode {
-  const { slug } = Route.useParams();
+  const { slug, id } = Route.useParams();
   const { user } = Route.useRouteContext();
-  // Pass capabilities + entryType across a prop boundary so the React Compiler
-  // treats them as stable inputs (member/derived reads inline read as
+  const { data: entry } = useSuspenseQuery(
+    orpc.entry.get.queryOptions({ input: { id, preview: true } }),
+  );
+  // The store seeds once (uncontrolled), so the canvas only re-seeds on a
+  // remount. The preview source flip covers load-time-draft publish/discard
+  // (autosave↔live); `reseedNonce` covers the in-session case where discarding
+  // a freshly-made draft leaves the source at "live" (no flip) — the inner
+  // bumps it so the canvas drops the discarded edits. (Mirrors the Puck route,
+  // which reseeds Puck in place instead.)
+  const previewSource = entry._preview?.source ?? "live";
+  const [reseedNonce, setReseedNonce] = useState(0);
+  const reseed = useCallback(() => setReseedNonce((n) => n + 1), []);
+  // Pass capabilities + entryType + userId across a prop boundary so the React
+  // Compiler treats them as stable inputs (member/derived reads inline read as
   // possibly-mutated, which forces the compiler to skip optimizing).
   return (
     <BespokeEditor
+      key={`${previewSource}:${reseedNonce}`}
       capabilities={user.capabilities}
       entryType={findEntryTypeBySlug(slug)}
+      userId={user.id}
+      onReseed={reseed}
     />
   );
 }
@@ -119,6 +165,8 @@ function BespokeEditorRoute(): ReactNode {
 interface BespokeEditorProps {
   readonly capabilities: readonly string[];
   readonly entryType: EntryTypeManifestEntry | undefined;
+  readonly userId: number;
+  readonly onReseed: () => void;
 }
 
 // Persistence lives inline in the component (not a custom hook) so the React
@@ -129,6 +177,8 @@ interface BespokeEditorProps {
 function BespokeEditor({
   capabilities,
   entryType,
+  userId,
+  onReseed,
 }: BespokeEditorProps): ReactNode {
   const { id } = Route.useParams();
   const { data: entry } = useSuspenseQuery(
@@ -136,8 +186,10 @@ function BespokeEditor({
   );
   const { data: previewLink } = useSuspenseQuery(previewLinkQuery(id));
   const queryClient = useQueryClient();
+  const renderLabel = useLabel();
   const entryTypeName = entryType?.name;
   const capabilitySet = useMemo(() => new Set(capabilities), [capabilities]);
+  const [hasLocalDraft, setHasLocalDraft] = useState(false);
 
   const liveUpdatedAtRef = useRef<Date>(entry.updatedAt);
   const seedContent = isEntryContent(entry.content)
@@ -190,6 +242,10 @@ function BespokeEditor({
           });
           if (updated.type === entry.type) {
             liveUpdatedAtRef.current = updated.updatedAt;
+          } else {
+            // The write landed on the per-user autosave row — a pending draft
+            // now exists. Surface it so the draft actions wake without a reload.
+            setHasLocalDraft(true);
           }
           if (contentChanged) lastSavedContentRef.current = serializedBlocks;
           if (excerptChanged) lastSavedExcerptRef.current = nextExcerpt;
@@ -350,6 +406,187 @@ function BespokeEditor({
     ],
   );
 
+  // Publish / draft / discard. A published entry whose type opts into autosave
+  // edits a per-user draft (edit-with-draft); everything else publishes the
+  // live row directly. The mutations are the existing admin ones.
+  const editorMode = resolveEditorMode({
+    entryType,
+    currentStatus: entry.status,
+    isAuthor: entry.authorId === userId,
+    capabilities: capabilitySet,
+  });
+  const isEditWithDraft = editorMode === "edit-with-draft";
+  const isPublished = entry.status === "published";
+  const hasPendingDraft =
+    entry._preview?.source === "autosave" || hasLocalDraft;
+  const staleState = entry._preview
+    ? detectStaleAutosave(
+        entry._preview.autosaveUpdatedAt,
+        entry._preview.liveUpdatedAt,
+      )
+    : "none";
+  const [staleResolved, setStaleResolved] = useState(false);
+  const showStaleDialog = staleState === "stale" && !staleResolved;
+  const liveAnchorAfterResolve = entry._preview?.liveUpdatedAt;
+
+  const invalidateEntry = useCallback(
+    () =>
+      Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: orpc.entry.get.queryOptions({ input: { id } }).queryKey,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: orpc.entry.get.queryOptions({
+            input: { id, preview: true },
+          }).queryKey,
+        }),
+        // Keep the entries list + revisions sheet in step with the new status.
+        ...(entryTypeName
+          ? [
+              queryClient.invalidateQueries({
+                queryKey: orpc.entry.list.key({
+                  input: { type: entryTypeName },
+                }),
+              }),
+              queryClient.invalidateQueries({
+                queryKey: ["entry.revisions", id],
+              }),
+            ]
+          : []),
+      ]),
+    [id, entryTypeName, queryClient],
+  );
+  const publish = useMutation({
+    mutationFn: async () => {
+      const updated = await orpc.entry.update.call({
+        id,
+        status: "published",
+        expectedLiveUpdatedAt: liveUpdatedAtRef.current,
+      });
+      liveUpdatedAtRef.current = updated.updatedAt;
+      return updated;
+    },
+    onSuccess: () => {
+      toastSuccess(renderLabel(M.published));
+      return invalidateEntry();
+    },
+    onError: () => toastError(renderLabel(M.publishFailed)),
+  });
+  const publishDraft = useMutation({
+    mutationFn: () =>
+      orpc.entry.publish.call({
+        id,
+        expectedLiveUpdatedAt: liveUpdatedAtRef.current,
+      }),
+    onSuccess: async (updated) => {
+      toastSuccess(renderLabel(M.published));
+      liveUpdatedAtRef.current = updated.updatedAt;
+      setHasLocalDraft(false);
+      await invalidateEntry();
+    },
+    onError: () => toastError(renderLabel(M.publishFailed)),
+  });
+  const discardDraft = useMutation({
+    mutationFn: () => orpc.entry.discardDraft.call({ id }),
+    onSuccess: async () => {
+      toastSuccess(renderLabel(M.discarded));
+      setHasLocalDraft(false);
+      await invalidateEntry();
+      // Drop any pending write so the unmount flush can't re-save the
+      // discarded edits, then remount to reseed the canvas from the live row.
+      contentDebouncer.cancel();
+      structuralDebouncer.cancel();
+      onReseed();
+    },
+    onError: () => toastError(renderLabel(M.discardFailed)),
+  });
+
+  const handlePublish = useCallback(() => publish.mutate(), [publish]);
+  const handleSaveDraft = useCallback(
+    () => contentDebouncer.flush(),
+    [contentDebouncer],
+  );
+  const handlePublishDraft = useCallback(
+    () => publishDraft.mutate(),
+    [publishDraft],
+  );
+  const handleDiscardDraft = useCallback(
+    () => discardDraft.mutate(),
+    [discardDraft],
+  );
+  const handleUseMine = useCallback(() => {
+    if (liveAnchorAfterResolve)
+      liveUpdatedAtRef.current = liveAnchorAfterResolve;
+    setStaleResolved(true);
+  }, [liveAnchorAfterResolve]);
+  const handleUseTheirs = useCallback(() => {
+    discardDraft.mutate(undefined, {
+      onSuccess: () => setStaleResolved(true),
+    });
+  }, [discardDraft]);
+
+  const publishActions = useMemo(
+    () =>
+      isEditWithDraft
+        ? {
+            draftMode: {
+              hasPendingDraft,
+              onSaveDraft: handleSaveDraft,
+              onPublishDraft: handlePublishDraft,
+              onDiscardDraft: handleDiscardDraft,
+              isSaving: false,
+              isPublishing: publishDraft.isPending,
+              isDiscarding: discardDraft.isPending,
+            },
+          }
+        : {
+            onPublish: handlePublish,
+            isPublished,
+            isPublishing: publish.isPending,
+          },
+    [
+      isEditWithDraft,
+      hasPendingDraft,
+      handleSaveDraft,
+      handlePublishDraft,
+      handleDiscardDraft,
+      publishDraft.isPending,
+      discardDraft.isPending,
+      handlePublish,
+      isPublished,
+      publish.isPending,
+    ],
+  );
+
+  // Live snapshot for the stale-draft compare pane — only fetched while the
+  // resolver dialog is open.
+  const liveSnapshotQuery = useQuery({
+    ...orpc.entry.get.queryOptions({ input: { id } }),
+    enabled: showStaleDialog,
+  });
+  const overlay = (
+    <StaleDraftDialog
+      open={showStaleDialog}
+      autosaveSnapshot={{
+        title: entry.title,
+        content: entry.content,
+        excerpt: entry.excerpt,
+      }}
+      liveSnapshot={
+        liveSnapshotQuery.data
+          ? {
+              title: liveSnapshotQuery.data.title,
+              content: liveSnapshotQuery.data.content,
+              excerpt: liveSnapshotQuery.data.excerpt,
+            }
+          : { title: renderLabel(M.staleLoading), content: null, excerpt: null }
+      }
+      onUseMine={handleUseMine}
+      onUseTheirs={handleUseTheirs}
+      isResolving={discardDraft.isPending}
+    />
+  );
+
   // `createPreviewLink` returns a site-relative url (`/blog/hello?preview=…`);
   // resolve it against the admin's own origin (the public site is same-origin)
   // and flip on `plumix.edit` so the public render boots the editor runtime.
@@ -365,6 +602,8 @@ function BespokeEditor({
       capabilities={capabilitySet}
       onChange={handleChange}
       documentPanel={documentPanel}
+      publish={publishActions}
+      overlay={overlay}
     />
   );
 }


### PR DESCRIPTION
Adds the publish lifecycle to the bespoke editor (PRD #1104, slice #1116).

The toolbar now shows a **Publish** button for live entries, or a **Save draft /
Publish / Discard** trio plus an "unpublished changes" banner when a published
autosave-type entry is being edited as a draft. These are callback + flag props
on `PlumixEditor`; the package stays orpc-free.

The admin route wires them to the **existing** mutations: `resolveEditorMode`
picks live vs draft, `entry.update` publishes the live row, `entry.publish`
promotes a draft, `entry.discardDraft` drops one — all sharing the autosave's
optimistic-concurrency token. A **stale autosave** (anchor older than the live
row) surfaces the existing `StaleDraftDialog` as an injected overlay; Use-mine
re-anchors the token, Use-theirs discards.

Because the editor store seeds once (uncontrolled), the canvas re-seeds on a
remount: the `_preview.source` flip covers load-time-draft publish/discard, and
a reseed nonce covers discarding a draft made **in-session** (no source flip) —
the pending write is cancelled first so the unmount flush can't resurrect the
discarded edits. Publish/discard also invalidate the entries list + revisions so
other views don't go stale.

Structure note: the publish/draft wiring is inlined in the route (not a hook),
mirroring the Puck route — a hook or inline member-access reads make the React
Compiler bail. The pure helpers (`resolveEditorMode`, `detectStaleAutosave`,
`StaleDraftDialog`, `freshLiveUpdatedAt`) are shared; only the compiler-sensitive
orchestration is duplicated, and the Puck route is slated for deletion.

Tests: toolbar publish/draft states unit-tested; e2e covers the live Publish
button and the draft trio + banner on a published autosave entry.

Closes #1116