### PR TITLE
feat: add a floating selection toolbar with multi-select and bulk ops

### DIFF
--- a/packages/admin-editor/locales/ar.po
+++ b/packages/admin-editor/locales/ar.po
@@ -14,6 +14,11 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.count"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/canvas-frame.tsx
 msgid "editor.canvas.addBlock"
 msgstr ""
@@ -34,8 +39,18 @@ msgid "editor.tab.blocks"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.delete"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
 msgid "editor.toolbar.discard"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.duplicate"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -46,6 +61,16 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.layers"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.moveDown"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.moveUp"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -101,6 +126,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/json-inspector.tsx
 msgid "editor.json.empty"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.selectParent"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/de.po
+++ b/packages/admin-editor/locales/de.po
@@ -14,6 +14,11 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.count"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/canvas-frame.tsx
 msgid "editor.canvas.addBlock"
 msgstr ""
@@ -34,8 +39,18 @@ msgid "editor.tab.blocks"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.delete"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
 msgid "editor.toolbar.discard"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.duplicate"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -46,6 +61,16 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.layers"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.moveDown"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.moveUp"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -101,6 +126,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/json-inspector.tsx
 msgid "editor.json.empty"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.selectParent"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/en.po
+++ b/packages/admin-editor/locales/en.po
@@ -14,6 +14,11 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.count"
+msgstr "{count} selected"
+
+#. js-lingui-explicit-id
 #: src/canvas-frame.tsx
 msgid "editor.canvas.addBlock"
 msgstr "Add a block"
@@ -34,9 +39,19 @@ msgid "editor.tab.blocks"
 msgstr "Blocks"
 
 #. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.delete"
+msgstr "Delete"
+
+#. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
 msgid "editor.toolbar.discard"
 msgstr "Discard"
+
+#. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.duplicate"
+msgstr "Duplicate"
 
 #. js-lingui-explicit-id
 #: src/plumix-editor.tsx
@@ -47,6 +62,16 @@ msgstr "JSON"
 #: src/plumix-editor.tsx
 msgid "editor.tab.layers"
 msgstr "Layers"
+
+#. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.moveDown"
+msgstr "Move down"
+
+#. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.moveUp"
+msgstr "Move up"
 
 #. js-lingui-explicit-id
 #: src/block-catalog-tab.tsx
@@ -102,6 +127,11 @@ msgstr "Select a block to edit its attributes."
 #: src/json-inspector.tsx
 msgid "editor.json.empty"
 msgstr "Select a block to inspect."
+
+#. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.selectParent"
+msgstr "Select parent"
 
 #. js-lingui-explicit-id
 #: src/editor-toolbar.tsx

--- a/packages/admin-editor/locales/uk.po
+++ b/packages/admin-editor/locales/uk.po
@@ -14,6 +14,11 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.count"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/canvas-frame.tsx
 msgid "editor.canvas.addBlock"
 msgstr ""
@@ -34,8 +39,18 @@ msgid "editor.tab.blocks"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.delete"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
 msgid "editor.toolbar.discard"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.duplicate"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -46,6 +61,16 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.layers"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.moveDown"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.moveUp"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -101,6 +126,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/json-inspector.tsx
 msgid "editor.json.empty"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.selectParent"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/zh-CN.po
+++ b/packages/admin-editor/locales/zh-CN.po
@@ -14,6 +14,11 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.count"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/canvas-frame.tsx
 msgid "editor.canvas.addBlock"
 msgstr ""
@@ -34,8 +39,18 @@ msgid "editor.tab.blocks"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.delete"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
 msgid "editor.toolbar.discard"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.duplicate"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -46,6 +61,16 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.layers"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.moveDown"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.moveUp"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -101,6 +126,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/json-inspector.tsx
 msgid "editor.json.empty"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/selection-toolbar.tsx
+msgid "editor.selection.selectParent"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/src/block-tree-ops.test.ts
+++ b/packages/admin-editor/src/block-tree-ops.test.ts
@@ -3,10 +3,15 @@ import { describe, expect, test } from "vitest";
 import type { BlockNode } from "@plumix/blocks";
 
 import {
+  duplicateBlock,
   findBlock,
+  findParentId,
   flattenTree,
   moveBlock,
+  moveBlockBy,
   projectMove,
+  removeBlocks,
+  selectionRoots,
 } from "./block-tree-ops.js";
 
 const ids = (tree: readonly BlockNode[]): string[] =>
@@ -178,6 +183,144 @@ describe("projectMove", () => {
 
   test("returns null when the active block is unknown", () => {
     expect(projectMove(FLAT, "zzz", "b", 0, INDENT)).toBeNull();
+  });
+});
+
+describe("removeBlocks", () => {
+  test("removes top-level and nested blocks in one pass", () => {
+    const moved = removeBlocks(TREE, new Set(["a", "deep"]));
+    expect(ids(moved)).toEqual(["-/g", "g/c1", "g/c2"]);
+  });
+
+  test("returns the same reference when nothing matches", () => {
+    expect(removeBlocks(TREE, new Set(["zzz"]))).toBe(TREE);
+  });
+
+  test("returns the same reference for an empty id set", () => {
+    expect(removeBlocks(TREE, new Set())).toBe(TREE);
+  });
+
+  test("leaves untouched branches referentially stable", () => {
+    const moved = removeBlocks(TREE, new Set(["c1"]));
+    // The heading sibling is in a branch with no removal — its node is reused.
+    expect(moved[0]).toBe(TREE[0]);
+  });
+});
+
+describe("findParentId", () => {
+  test("returns null for a top-level block", () => {
+    expect(findParentId(TREE, "g")).toBeNull();
+  });
+
+  test("returns the immediate slot owner for a nested block", () => {
+    expect(findParentId(TREE, "c1")).toBe("g");
+  });
+
+  test("walks past the first slot to deeper ancestors", () => {
+    expect(findParentId(TREE, "deep")).toBe("c2");
+  });
+
+  test("returns null when the block is absent", () => {
+    expect(findParentId(TREE, "zzz")).toBeNull();
+  });
+
+  test("finds a parent in a non-first slot", () => {
+    const tree: readonly BlockNode[] = [
+      {
+        id: "cols",
+        name: "core/columns",
+        attrs: {
+          left: [{ id: "l", name: "x" }],
+          right: [{ id: "r", name: "x" }],
+        },
+      },
+    ];
+    expect(findParentId(tree, "r")).toBe("cols");
+  });
+});
+
+describe("duplicateBlock", () => {
+  test("clones a top-level block right after it with a fresh id", () => {
+    const tree: readonly BlockNode[] = [
+      { id: "a", name: "core/heading", attrs: { text: "Hi" } },
+      { id: "b", name: "core/spacer" },
+    ];
+    const { tree: next, newId } = duplicateBlock(tree, "a");
+    expect(next.map((n) => n.id)).toEqual(["a", newId, "b"]);
+    expect(newId).not.toBe("a");
+    expect(findBlock(next, newId ?? "")?.attrs?.text).toBe("Hi");
+  });
+
+  test("clones a nested block within its own slot, ids rewritten deeply", () => {
+    const { tree: next, newId } = duplicateBlock(TREE, "c2");
+    const slot = findBlock(next, "g")?.attrs?.content as readonly BlockNode[];
+    expect(slot.map((n) => n.id)).toEqual(["c1", "c2", newId]);
+    // The clone's nested child got a fresh id too (not the original "deep").
+    const clone = findBlock(next, newId ?? "");
+    const childIds = (clone?.attrs?.content as readonly BlockNode[]).map(
+      (n) => n.id,
+    );
+    expect(childIds).not.toContain("deep");
+  });
+
+  test("is a no-op with a null id when the source is absent", () => {
+    expect(duplicateBlock(TREE, "zzz")).toEqual({ tree: TREE, newId: null });
+  });
+});
+
+describe("moveBlockBy", () => {
+  const tree: readonly BlockNode[] = [
+    { id: "a", name: "x" },
+    { id: "b", name: "x" },
+    { id: "c", name: "x" },
+  ];
+
+  test("moves a block down among its siblings", () => {
+    expect(moveBlockBy(tree, "a", 1).map((n) => n.id)).toEqual(["b", "a", "c"]);
+  });
+
+  test("moves a block up among its siblings", () => {
+    expect(moveBlockBy(tree, "c", -1).map((n) => n.id)).toEqual([
+      "a",
+      "c",
+      "b",
+    ]);
+  });
+
+  test("reorders within a nested slot", () => {
+    const nested: readonly BlockNode[] = [
+      group("g", [
+        { id: "c1", name: "x" },
+        { id: "c2", name: "x" },
+      ]),
+    ];
+    const moved = moveBlockBy(nested, "c1", 1);
+    const slot = findBlock(moved, "g")?.attrs?.content as readonly BlockNode[];
+    expect(slot.map((n) => n.id)).toEqual(["c2", "c1"]);
+  });
+
+  test("is a no-op at the ends", () => {
+    expect(moveBlockBy(tree, "a", -1)).toBe(tree);
+    expect(moveBlockBy(tree, "c", 1)).toBe(tree);
+  });
+
+  test("is a no-op when the block is absent", () => {
+    expect(moveBlockBy(tree, "zzz", 1)).toBe(tree);
+  });
+});
+
+describe("selectionRoots", () => {
+  test("drops a selected block that is nested inside another selection", () => {
+    // g and its descendant deep are both selected → only g is a root.
+    expect(selectionRoots(TREE, new Set(["g", "deep"]))).toEqual(["g"]);
+  });
+
+  test("keeps independent selections", () => {
+    expect(selectionRoots(TREE, new Set(["a", "c1"]))).toEqual(["a", "c1"]);
+  });
+
+  test("returns an empty array for an empty set", () => {
+    expect(selectionRoots(TREE, new Set())).toEqual([]);
   });
 });
 

--- a/packages/admin-editor/src/block-tree-ops.ts
+++ b/packages/admin-editor/src/block-tree-ops.ts
@@ -1,5 +1,5 @@
 import type { BlockNode } from "@plumix/blocks";
-import { isBlockNodeArray } from "@plumix/blocks";
+import { isBlockNodeArray, rewriteBlockNodeIds } from "@plumix/blocks";
 
 /** Find a block by id anywhere in the tree, descending into slot attrs. */
 export function findBlock(
@@ -15,6 +15,28 @@ export function findBlock(
     }
   }
   return undefined;
+}
+
+/**
+ * The id of the block whose slot directly holds `id`, or null when `id` is a
+ * top-level block or absent. Unlike the layers outline, this descends every
+ * slot (not just the first) so select-parent resolves correctly inside
+ * multi-slot blocks.
+ */
+export function findParentId(
+  nodes: readonly BlockNode[],
+  id: string,
+  parent: string | null = null,
+): string | null {
+  for (const node of nodes) {
+    if (node.id === id) return parent;
+    for (const value of Object.values(node.attrs ?? {})) {
+      if (!isBlockNodeArray(value)) continue;
+      const hit = findParentId(value, id, node.id);
+      if (hit !== null) return hit;
+    }
+  }
+  return null;
 }
 
 export interface FlatNode {
@@ -154,6 +176,106 @@ export function moveBlock(
   return insertNode(removeNode(tree, sourceId), source, target);
 }
 
+/**
+ * Remove every block in `ids` from the tree at once, immutably. Descends all
+ * slots and returns the same reference when nothing matched, so untouched
+ * branches stay referentially stable for React.
+ */
+export function removeBlocks(
+  nodes: readonly BlockNode[],
+  ids: ReadonlySet<string>,
+): readonly BlockNode[] {
+  if (ids.size === 0) return nodes;
+  const kept = nodes.filter((node) => !ids.has(node.id));
+  let changed = kept.length !== nodes.length;
+  const mapped = kept.map((node) => {
+    const attrs = node.attrs;
+    if (!attrs) return node;
+    let nextAttrs: Record<string, unknown> | undefined;
+    for (const [key, value] of Object.entries(attrs)) {
+      if (!isBlockNodeArray(value)) continue;
+      const pruned = removeBlocks(value, ids);
+      if (pruned !== value) (nextAttrs ??= { ...attrs })[key] = pruned;
+    }
+    if (!nextAttrs) return node;
+    changed = true;
+    return { ...node, attrs: nextAttrs };
+  });
+  return changed ? mapped : nodes;
+}
+
+/**
+ * Insert a fresh-id clone of `id` immediately after it within its own parent
+ * slot. Ids are rewritten through the whole subtree so the duplicate is fully
+ * independent. Returns the same tree and a null id when the source is absent.
+ */
+export function duplicateBlock(
+  tree: readonly BlockNode[],
+  id: string,
+): { readonly tree: readonly BlockNode[]; readonly newId: string | null } {
+  const source = findBlock(tree, id);
+  if (!source) return { tree, newId: null };
+  const [clone] = rewriteBlockNodeIds([source]);
+  if (!clone) return { tree, newId: null };
+  const parentId = findParentId(tree, id);
+  const index = siblingsOf(tree, parentId).findIndex((n) => n.id === id) + 1;
+  return {
+    tree: insertNode(tree, clone, { parentId, index }),
+    newId: clone.id,
+  };
+}
+
+/**
+ * Reduce a selection to its roots: ids that have no selected ancestor. Used by
+ * bulk duplicate so a block isn't cloned twice when both it and its container
+ * are selected (the container's clone already carries a copy of the child).
+ */
+export function selectionRoots(
+  tree: readonly BlockNode[],
+  ids: ReadonlySet<string>,
+): string[] {
+  return [...ids].filter((id) => {
+    let parent = findParentId(tree, id);
+    while (parent !== null) {
+      if (ids.has(parent)) return false;
+      parent = findParentId(tree, parent);
+    }
+    return true;
+  });
+}
+
+/**
+ * Move `id` by `delta` positions among its siblings (negative = up). A no-op
+ * (same tree reference) at the ends or when the block is absent.
+ */
+export function moveBlockBy(
+  tree: readonly BlockNode[],
+  id: string,
+  delta: number,
+): readonly BlockNode[] {
+  const parentId = findParentId(tree, id);
+  const siblings = siblingsOf(tree, parentId);
+  const from = siblings.findIndex((n) => n.id === id);
+  if (from === -1) return tree;
+  const to = from + delta;
+  if (to < 0 || to >= siblings.length) return tree;
+  return moveBlock(tree, id, { parentId, index: to });
+}
+
+// The blocks sharing `id`'s level: the top level when parentId is null, else
+// the parent's first slot (the one the tree ops address).
+function siblingsOf(
+  tree: readonly BlockNode[],
+  parentId: string | null,
+): readonly BlockNode[] {
+  if (parentId === null) return tree;
+  const parent = findBlock(tree, parentId);
+  if (!parent) return [];
+  const key = slotKey(parent);
+  const slot = key !== null ? parent.attrs?.[key] : undefined;
+  return isBlockNodeArray(slot) ? slot : [];
+}
+
 // The first attr key holding a child-block array, or null if the block has no
 // slot. The layers tree addresses only this first slot — multi-slot blocks
 // aren't fully reachable from the outline yet (tracked as a #1108 follow-up).
@@ -179,22 +301,7 @@ function removeNode(
   nodes: readonly BlockNode[],
   id: string,
 ): readonly BlockNode[] {
-  const next = nodes.filter((node) => node.id !== id);
-  let changed = next.length !== nodes.length;
-  const mapped = next.map((node) => {
-    const attrs = node.attrs;
-    if (!attrs) return node;
-    let nextAttrs: Record<string, unknown> | undefined;
-    for (const [key, value] of Object.entries(attrs)) {
-      if (!isBlockNodeArray(value)) continue;
-      const pruned = removeNode(value, id);
-      if (pruned !== value) (nextAttrs ??= { ...attrs })[key] = pruned;
-    }
-    if (!nextAttrs) return node;
-    changed = true;
-    return { ...node, attrs: nextAttrs };
-  });
-  return changed ? mapped : nodes;
+  return removeBlocks(nodes, new Set([id]));
 }
 
 function clampIndex(index: number, length: number): number {

--- a/packages/admin-editor/src/canvas-frame.test.tsx
+++ b/packages/admin-editor/src/canvas-frame.test.tsx
@@ -91,6 +91,58 @@ describe("CanvasFrame", () => {
     expect(queryByTestId("plumix-overlay-selected")).not.toBeNull();
   });
 
+  test("outlines every selected block, marking the active one apart", () => {
+    const { queryByTestId } = render(
+      <Wrapper>
+        <CanvasFrame
+          previewUrl="about:blank"
+          origin={ORIGIN}
+          registry={registry}
+          capabilities={NO_CAPS}
+        />
+      </Wrapper>,
+    );
+
+    fromCanvas({ type: "canvas:select", id: "h1" });
+    fromCanvas({ type: "canvas:select", id: "h2", additive: true });
+    fromCanvas({
+      type: "canvas:geometry",
+      rects: [
+        { id: "h1", x: 10, y: 20, width: 100, height: 40 },
+        { id: "h2", x: 10, y: 80, width: 100, height: 40 },
+      ],
+    });
+
+    // h2 is the active block (strong outline); h1 is a non-active member.
+    expect(queryByTestId("plumix-overlay-selected")).not.toBeNull();
+    expect(queryByTestId("plumix-overlay-member-h1")).not.toBeNull();
+    expect(queryByTestId("plumix-overlay-member-h2")).toBeNull();
+  });
+
+  test("floats the selection toolbar over the active block", () => {
+    const { queryByTestId } = render(
+      <Wrapper>
+        <CanvasFrame
+          previewUrl="about:blank"
+          origin={ORIGIN}
+          registry={registry}
+          capabilities={NO_CAPS}
+        />
+      </Wrapper>,
+    );
+
+    // No active block yet — no toolbar.
+    expect(queryByTestId("plumix-selection-toolbar")).toBeNull();
+
+    fromCanvas({ type: "canvas:select", id: "h1" });
+    fromCanvas({
+      type: "canvas:geometry",
+      rects: [{ id: "h1", x: 10, y: 20, width: 100, height: 40 }],
+    });
+
+    expect(queryByTestId("plumix-selection-toolbar")).not.toBeNull();
+  });
+
   test("empty-state affordance inserts the first catalog block", () => {
     const { getByTestId, queryByTestId } = render(
       <Wrapper>

--- a/packages/admin-editor/src/canvas-frame.tsx
+++ b/packages/admin-editor/src/canvas-frame.tsx
@@ -11,6 +11,7 @@ import { connectCanvas } from "./connect-canvas.js";
 import { dropPlacement } from "./drop-index.js";
 import { overlayBox } from "./overlay.js";
 import { useEditorStore, useEditorStoreApi } from "./provider.js";
+import { SelectionToolbar } from "./selection-toolbar.js";
 import { DEVICE_WIDTH } from "./store.js";
 
 interface CanvasFrameProps {
@@ -25,6 +26,7 @@ interface CanvasFrameProps {
 }
 
 const SELECTED_OUTLINE = "#2563eb";
+const MEMBER_OUTLINE = "rgba(37,99,235,0.5)";
 const HOVER_OUTLINE = "rgba(37,99,235,0.4)";
 const CANVAS_HEIGHT = 800;
 
@@ -49,6 +51,7 @@ export function CanvasFrame({
   const device = useEditorStore((s) => s.device);
   const zoom = useEditorStore((s) => s.zoom);
   const activeId = useEditorStore((s) => s.activeId);
+  const selectedIds = useEditorStore((s) => s.selectedIds);
   const hoverId = useEditorStore((s) => s.hoverId);
   const dragSpec = useEditorStore((s) => s.dragSpec);
   const isEmpty = useEditorStore((s) => s.tree.length === 0);
@@ -148,6 +151,12 @@ export function CanvasFrame({
     if (spec) store.getState().insertBlock(createBlockFromSpec(spec), 0);
   }, [registry, capabilities, store]);
 
+  const activeRect = activeId ? geometry.rects.get(activeId) : undefined;
+  const activeBox =
+    activeRect && geometry.frame
+      ? overlayBox(activeRect, geometry.frame, zoom)
+      : null;
+
   const overlay = (
     id: string | null,
     color: string,
@@ -159,6 +168,7 @@ export function CanvasFrame({
     const box = overlayBox(rect, geometry.frame, zoom);
     return (
       <div
+        key={testId}
         data-testid={testId}
         style={{
           position: "fixed",
@@ -192,7 +202,13 @@ export function CanvasFrame({
         }}
       />
       {overlay(hoverId, HOVER_OUTLINE, "plumix-overlay-hover")}
+      {[...selectedIds]
+        .filter((id) => id !== activeId)
+        .map((id) =>
+          overlay(id, MEMBER_OUTLINE, `plumix-overlay-member-${id}`),
+        )}
       {overlay(activeId, SELECTED_OUTLINE, "plumix-overlay-selected")}
+      {activeBox && <SelectionToolbar box={activeBox} />}
       {dropY !== null && geometry.frame && (
         <div
           data-testid="plumix-drop-indicator"

--- a/packages/admin-editor/src/connect-canvas.test.ts
+++ b/packages/admin-editor/src/connect-canvas.test.ts
@@ -56,6 +56,19 @@ describe("connectCanvas", () => {
     conn.dispose();
   });
 
+  test("an additive canvas:select extends the selection set", () => {
+    const store = createEditorStore();
+    const { win } = fakeFrame();
+    const conn = connectCanvas({ store, frameWindow: win, origin: ORIGIN });
+
+    fromCanvas({ type: "canvas:select", id: "x" });
+    fromCanvas({ type: "canvas:select", id: "y", additive: true });
+
+    expect([...store.getState().selectedIds].sort()).toEqual(["x", "y"]);
+    expect(store.getState().activeId).toBe("y");
+    conn.dispose();
+  });
+
   test("re-pushes the tree when the store tree changes after ready", () => {
     const store = createEditorStore();
     const { win, posted } = fakeFrame();

--- a/packages/admin-editor/src/connect-canvas.ts
+++ b/packages/admin-editor/src/connect-canvas.ts
@@ -73,7 +73,7 @@ export function connectCanvas({
         pushTree();
         break;
       case "canvas:select":
-        store.getState().select(canvas.id);
+        store.getState().select(canvas.id, { additive: canvas.additive });
         break;
       case "canvas:hover":
         store.getState().setHover(canvas.id);

--- a/packages/admin-editor/src/connect-runtime.ts
+++ b/packages/admin-editor/src/connect-runtime.ts
@@ -13,7 +13,7 @@ import {
 } from "@plumix/blocks/renderer";
 
 export interface RuntimeConnection {
-  readonly reportSelect: (id: string) => void;
+  readonly reportSelect: (id: string, additive?: boolean) => void;
   readonly reportHover: (id: string | null) => void;
   readonly reportGeometry: (rects: readonly BlockRect[]) => void;
   readonly dispose: () => void;
@@ -71,8 +71,12 @@ export function connectRuntime({
   announce();
 
   return {
-    reportSelect: (id) =>
-      post({ type: "canvas:select", id } satisfies CanvasMessage),
+    reportSelect: (id, additive) =>
+      post({
+        type: "canvas:select",
+        id,
+        ...(additive ? { additive: true } : {}),
+      } satisfies CanvasMessage),
     reportHover: (id) =>
       post({ type: "canvas:hover", id } satisfies CanvasMessage),
     reportGeometry: (rects) =>

--- a/packages/admin-editor/src/editor-canvas.test.tsx
+++ b/packages/admin-editor/src/editor-canvas.test.tsx
@@ -59,6 +59,32 @@ describe("EditorCanvas", () => {
     spy.mockRestore();
   });
 
+  test("shift-clicking a block reports an additive canvas:select", () => {
+    const posted: unknown[] = [];
+    const spy = vi
+      .spyOn(window.parent, "postMessage")
+      .mockImplementation((data) => posted.push(data));
+
+    const { container } = render(
+      <EditorCanvas registry={registry} origin={ORIGIN} />,
+    );
+    pushTree([{ id: "h1", name: "core/heading", attrs: { text: "Hi" } }]);
+
+    const block = container.querySelector('[data-plumix-id="h1"]');
+    expect(block).not.toBeNull();
+    if (block) fireEvent.click(block, { shiftKey: true });
+
+    const select = posted
+      .map((p) => (p as { message?: { type?: string } }).message)
+      .find((m) => m?.type === "canvas:select");
+    expect(select).toEqual({
+      type: "canvas:select",
+      id: "h1",
+      additive: true,
+    });
+    spy.mockRestore();
+  });
+
   test("renders an initial tree immediately, before any host push", () => {
     const { container } = render(
       <EditorCanvas

--- a/packages/admin-editor/src/editor-canvas.tsx
+++ b/packages/admin-editor/src/editor-canvas.tsx
@@ -77,7 +77,10 @@ export function EditorCanvas({
 
   const handleClick = (event: MouseEvent<HTMLDivElement>): void => {
     const id = blockIdAt(event);
-    if (id) connectionRef.current?.reportSelect(id);
+    if (!id) return;
+    // Shift / cmd / ctrl extend the selection rather than replacing it.
+    const additive = event.shiftKey || event.metaKey || event.ctrlKey;
+    connectionRef.current?.reportSelect(id, additive);
   };
 
   const handleMouseOver = (event: MouseEvent<HTMLDivElement>): void => {

--- a/packages/admin-editor/src/selection-toolbar.test.tsx
+++ b/packages/admin-editor/src/selection-toolbar.test.tsx
@@ -1,0 +1,157 @@
+import { useEffect } from "react";
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, test } from "vitest";
+
+import type { BlockNode } from "@plumix/blocks";
+
+import { EditorProvider, useEditorStoreApi } from "./provider.js";
+import { SelectionToolbar } from "./selection-toolbar.js";
+
+const BOX = { left: 10, top: 20, width: 100, height: 40 };
+
+beforeAll(() => {
+  i18n.loadAndActivate({ locale: "en", messages: {} });
+});
+
+afterEach(cleanup);
+
+let storeApi: ReturnType<typeof useEditorStoreApi> | undefined;
+function Capture(): null {
+  const api = useEditorStoreApi();
+  useEffect(() => {
+    storeApi = api;
+  }, [api]);
+  return null;
+}
+
+function renderToolbar(tree: readonly BlockNode[]): ReturnType<typeof render> {
+  return render(
+    <I18nProvider i18n={i18n}>
+      <EditorProvider initialTree={tree}>
+        <SelectionToolbar box={BOX} />
+        <Capture />
+      </EditorProvider>
+    </I18nProvider>,
+  );
+}
+
+const button = (el: HTMLElement): HTMLButtonElement => el as HTMLButtonElement;
+
+describe("SelectionToolbar", () => {
+  test("renders nothing until a block is active", () => {
+    const { queryByTestId } = renderToolbar([{ id: "a", name: "core/x" }]);
+    expect(queryByTestId("plumix-selection-toolbar")).toBeNull();
+  });
+
+  test("deletes every selected block", () => {
+    const { getByTestId } = renderToolbar([
+      { id: "a", name: "core/x" },
+      { id: "b", name: "core/x" },
+      { id: "c", name: "core/x" },
+    ]);
+    act(() => {
+      storeApi?.getState().select("a");
+      storeApi?.getState().select("c", { additive: true });
+    });
+
+    fireEvent.click(getByTestId("selection-toolbar-delete"));
+
+    expect(storeApi?.getState().tree.map((n) => n.id)).toEqual(["b"]);
+  });
+
+  test("duplicates the active block", () => {
+    const { getByTestId } = renderToolbar([{ id: "a", name: "core/x" }]);
+    act(() => storeApi?.getState().select("a"));
+
+    fireEvent.click(getByTestId("selection-toolbar-duplicate"));
+
+    expect(storeApi?.getState().tree).toHaveLength(2);
+  });
+
+  test("moves the active block up and down", () => {
+    const { getByTestId } = renderToolbar([
+      { id: "a", name: "core/x" },
+      { id: "b", name: "core/x" },
+    ]);
+    act(() => storeApi?.getState().select("a"));
+
+    fireEvent.click(getByTestId("selection-toolbar-move-down"));
+    expect(storeApi?.getState().tree.map((n) => n.id)).toEqual(["b", "a"]);
+
+    fireEvent.click(getByTestId("selection-toolbar-move-up"));
+    expect(storeApi?.getState().tree.map((n) => n.id)).toEqual(["a", "b"]);
+  });
+
+  test("selects the container, disabled for a top-level block", () => {
+    const { getByTestId } = renderToolbar([
+      {
+        id: "g",
+        name: "core/group",
+        attrs: { content: [{ id: "child", name: "core/x" }] },
+      },
+    ]);
+
+    // Top-level block: select-parent is disabled.
+    act(() => storeApi?.getState().select("g"));
+    expect(
+      button(getByTestId("selection-toolbar-select-parent")).disabled,
+    ).toBe(true);
+
+    // Nested block: select-parent walks up to the group.
+    act(() => storeApi?.getState().select("child"));
+    fireEvent.click(getByTestId("selection-toolbar-select-parent"));
+    expect(storeApi?.getState().activeId).toBe("g");
+  });
+
+  test("shows a count when several blocks are selected", () => {
+    const { getByTestId, queryByTestId } = renderToolbar([
+      { id: "a", name: "core/x" },
+      { id: "b", name: "core/x" },
+    ]);
+
+    act(() => storeApi?.getState().select("a"));
+    expect(queryByTestId("selection-toolbar-count")).toBeNull();
+
+    act(() => storeApi?.getState().select("b", { additive: true }));
+    expect(getByTestId("selection-toolbar-count").textContent).toContain("2");
+  });
+
+  test("disables single-target actions while several blocks are selected", () => {
+    const { getByTestId } = renderToolbar([
+      {
+        id: "g",
+        name: "core/group",
+        attrs: {
+          content: [
+            { id: "a", name: "core/x" },
+            { id: "b", name: "core/x" },
+          ],
+        },
+      },
+    ]);
+    act(() => {
+      storeApi?.getState().select("a");
+      storeApi?.getState().select("b", { additive: true });
+    });
+
+    // Move + select-parent are ambiguous across a multi-selection → disabled;
+    // bulk delete/duplicate stay enabled.
+    expect(button(getByTestId("selection-toolbar-move-up")).disabled).toBe(
+      true,
+    );
+    expect(button(getByTestId("selection-toolbar-move-down")).disabled).toBe(
+      true,
+    );
+    expect(
+      button(getByTestId("selection-toolbar-select-parent")).disabled,
+    ).toBe(true);
+    expect(button(getByTestId("selection-toolbar-delete")).disabled).toBe(
+      false,
+    );
+    expect(button(getByTestId("selection-toolbar-duplicate")).disabled).toBe(
+      false,
+    );
+  });
+});

--- a/packages/admin-editor/src/selection-toolbar.tsx
+++ b/packages/admin-editor/src/selection-toolbar.tsx
@@ -1,0 +1,118 @@
+import type { ReactElement } from "react";
+import { Trans } from "@lingui/react";
+
+import { Button } from "@plumix/admin-ui/button";
+
+import { findParentId } from "./block-tree-ops.js";
+import { useEditorStore, useEditorStoreApi } from "./provider.js";
+
+/** Where to float the toolbar — the active block's box in shell coordinates. */
+interface ToolbarBox {
+  readonly left: number;
+  readonly top: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+const TOOLBAR_GAP = 4;
+
+/**
+ * Floating actions for the active block: select its container, reorder it among
+ * its siblings, duplicate or delete it. Bulk actions (delete/duplicate) act on
+ * the whole selection; reorder + select-parent act on the active block. Renders
+ * nothing until a block is active.
+ */
+export function SelectionToolbar({
+  box,
+}: {
+  readonly box: ToolbarBox;
+}): ReactElement | null {
+  const store = useEditorStoreApi();
+  const activeId = useEditorStore((s) => s.activeId);
+  const selectedCount = useEditorStore((s) => s.selectedIds.size);
+  const hasParent = useEditorStore((s) =>
+    s.activeId ? findParentId(s.tree, s.activeId) !== null : false,
+  );
+  if (!activeId) return null;
+
+  const act = (run: () => void) => (): void => run();
+  const state = store.getState();
+  // Move + select-parent act on the single active block, so they're ambiguous
+  // (and disabled) while several blocks are selected; bulk delete/duplicate
+  // stay enabled.
+  const multi = selectedCount > 1;
+
+  return (
+    <div
+      data-testid="plumix-selection-toolbar"
+      className="bg-background flex items-center gap-0.5 rounded-md border p-0.5 shadow-sm"
+      style={{
+        position: "fixed",
+        left: box.left,
+        top: Math.max(0, box.top - 36 - TOOLBAR_GAP),
+        zIndex: 30,
+      }}
+    >
+      {selectedCount > 1 ? (
+        <span
+          data-testid="selection-toolbar-count"
+          className="text-muted-foreground px-1.5 text-xs tabular-nums"
+        >
+          <Trans
+            id="editor.selection.count"
+            message="{count} selected"
+            values={{ count: selectedCount }}
+          />
+        </span>
+      ) : null}
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        data-testid="selection-toolbar-select-parent"
+        disabled={!hasParent || multi}
+        onClick={act(() => state.selectParent())}
+      >
+        <Trans id="editor.selection.selectParent" message="Select parent" />
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        data-testid="selection-toolbar-move-up"
+        disabled={multi}
+        onClick={act(() => state.moveSelectedBy(-1))}
+      >
+        <Trans id="editor.selection.moveUp" message="Move up" />
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        data-testid="selection-toolbar-move-down"
+        disabled={multi}
+        onClick={act(() => state.moveSelectedBy(1))}
+      >
+        <Trans id="editor.selection.moveDown" message="Move down" />
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        data-testid="selection-toolbar-duplicate"
+        onClick={act(() => state.duplicateSelected())}
+      >
+        <Trans id="editor.selection.duplicate" message="Duplicate" />
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        data-testid="selection-toolbar-delete"
+        onClick={act(() => state.removeSelected())}
+      >
+        <Trans id="editor.selection.delete" message="Delete" />
+      </Button>
+    </div>
+  );
+}

--- a/packages/admin-editor/src/store.test.ts
+++ b/packages/admin-editor/src/store.test.ts
@@ -27,6 +27,18 @@ describe("editor store", () => {
     expect(store.getState().activeId).toBe("b");
   });
 
+  test("additive select toggles a block off and repoints the active block", () => {
+    const store = createEditorStore();
+
+    store.getState().select("a");
+    store.getState().select("b", { additive: true });
+    // Toggle the active block (b) back off — a remains and becomes active.
+    store.getState().select("b", { additive: true });
+
+    expect([...store.getState().selectedIds]).toEqual(["a"]);
+    expect(store.getState().activeId).toBe("a");
+  });
+
   test("clearSelection empties the set and the active block", () => {
     const store = createEditorStore();
     store.getState().select("a");
@@ -192,6 +204,158 @@ describe("undo / redo", () => {
     store.getState().redo();
     // Redo was cleared by the post-undo edit; the tree stays at [b].
     expect(store.getState().tree.map((n) => n.id)).toEqual(["b"]);
+  });
+});
+
+describe("removeSelected", () => {
+  test("removes every selected block and clears the selection", () => {
+    const store = createEditorStore({
+      tree: [
+        { id: "a", name: "core/x" },
+        { id: "b", name: "core/x" },
+        { id: "c", name: "core/x" },
+      ],
+    });
+    store.getState().select("a");
+    store.getState().select("c", { additive: true });
+
+    store.getState().removeSelected();
+
+    expect(store.getState().tree.map((n) => n.id)).toEqual(["b"]);
+    expect(store.getState().selectedIds.size).toBe(0);
+    expect(store.getState().activeId).toBeNull();
+  });
+
+  test("is a no-op when nothing is selected", () => {
+    const tree: readonly BlockNode[] = [{ id: "a", name: "core/x" }];
+    const store = createEditorStore({ tree });
+
+    store.getState().removeSelected();
+
+    expect(store.getState().tree).toBe(tree);
+  });
+
+  test("a removal is undoable", () => {
+    const store = createEditorStore({ tree: [{ id: "a", name: "core/x" }] });
+    store.getState().select("a");
+
+    store.getState().removeSelected();
+    expect(store.getState().tree).toHaveLength(0);
+
+    store.getState().undo();
+    expect(store.getState().tree.map((n) => n.id)).toEqual(["a"]);
+  });
+});
+
+describe("duplicateSelected", () => {
+  test("clones each selected block and selects the clones", () => {
+    const store = createEditorStore({
+      tree: [
+        { id: "a", name: "core/x" },
+        { id: "b", name: "core/x" },
+      ],
+    });
+    store.getState().select("a");
+
+    store.getState().duplicateSelected();
+
+    const ids = store.getState().tree.map((n) => n.id);
+    expect(ids).toHaveLength(3);
+    expect(ids.slice(0, 2)).toEqual(["a", store.getState().activeId]);
+    // The clone, not the original, is now selected.
+    expect([...store.getState().selectedIds]).toEqual([
+      store.getState().activeId,
+    ]);
+  });
+
+  test("is a no-op when nothing is selected", () => {
+    const tree: readonly BlockNode[] = [{ id: "a", name: "core/x" }];
+    const store = createEditorStore({ tree });
+
+    store.getState().duplicateSelected();
+
+    expect(store.getState().tree).toBe(tree);
+  });
+
+  test("clones a container once when it and its child are both selected", () => {
+    const store = createEditorStore({
+      tree: [
+        {
+          id: "g",
+          name: "core/group",
+          attrs: { content: [{ id: "child", name: "core/x" }] },
+        },
+      ],
+    });
+    store.getState().select("g");
+    store.getState().select("child", { additive: true });
+
+    store.getState().duplicateSelected();
+
+    // Two groups total (original + one clone) — the child isn't cloned again on
+    // its own, so the clone's slot holds exactly one child.
+    expect(store.getState().tree).toHaveLength(2);
+    const cloneId = store.getState().activeId ?? "";
+    const clone = store.getState().tree.find((n) => n.id === cloneId);
+    expect((clone?.attrs?.content as readonly BlockNode[]).length).toBe(1);
+  });
+});
+
+describe("selectParent", () => {
+  test("selects the active block's container", () => {
+    const store = createEditorStore({
+      tree: [
+        {
+          id: "g",
+          name: "core/group",
+          attrs: { content: [{ id: "child", name: "core/x" }] },
+        },
+      ],
+    });
+    store.getState().select("child");
+
+    store.getState().selectParent();
+
+    expect(store.getState().activeId).toBe("g");
+    expect([...store.getState().selectedIds]).toEqual(["g"]);
+  });
+
+  test("is a no-op for a top-level active block", () => {
+    const store = createEditorStore({ tree: [{ id: "a", name: "core/x" }] });
+    store.getState().select("a");
+
+    store.getState().selectParent();
+
+    expect(store.getState().activeId).toBe("a");
+  });
+});
+
+describe("moveSelectedBy", () => {
+  test("moves the active block down among its siblings", () => {
+    const store = createEditorStore({
+      tree: [
+        { id: "a", name: "core/x" },
+        { id: "b", name: "core/x" },
+      ],
+    });
+    store.getState().select("a");
+
+    store.getState().moveSelectedBy(1);
+
+    expect(store.getState().tree.map((n) => n.id)).toEqual(["b", "a"]);
+  });
+
+  test("is a no-op at the boundary", () => {
+    const tree: readonly BlockNode[] = [
+      { id: "a", name: "core/x" },
+      { id: "b", name: "core/x" },
+    ];
+    const store = createEditorStore({ tree });
+    store.getState().select("a");
+
+    store.getState().moveSelectedBy(-1);
+
+    expect(store.getState().tree).toBe(tree);
   });
 });
 

--- a/packages/admin-editor/src/store.ts
+++ b/packages/admin-editor/src/store.ts
@@ -5,7 +5,14 @@ import { isBlockNodeArray } from "@plumix/blocks";
 
 import type { MoveTarget } from "./block-tree-ops.js";
 import type { History } from "./history.js";
-import { moveBlock as moveBlockOp } from "./block-tree-ops.js";
+import {
+  duplicateBlock,
+  findParentId,
+  moveBlockBy,
+  moveBlock as moveBlockOp,
+  removeBlocks,
+  selectionRoots,
+} from "./block-tree-ops.js";
 import { initHistory, recordHistory, redo, undo } from "./history.js";
 
 type TreeHistory = History<readonly BlockNode[]>;
@@ -51,6 +58,14 @@ export interface EditorActions {
   ) => void;
   select: (id: string, options?: { readonly additive?: boolean }) => void;
   clearSelection: () => void;
+  /** Delete every selected block (bulk) and clear the selection. */
+  removeSelected: () => void;
+  /** Clone every selected block after itself and select the clones (bulk). */
+  duplicateSelected: () => void;
+  /** Select the active block's container, walking one level up. */
+  selectParent: () => void;
+  /** Move the active block by `delta` positions among its siblings. */
+  moveSelectedBy: (delta: number) => void;
   setHover: (id: string | null) => void;
   setDevice: (device: EditorDevice) => void;
   setZoom: (zoom: number) => void;
@@ -146,13 +161,68 @@ export function createEditorStore(
         return { tree, history: recordHistory(state.history, tree, key) };
       }),
     select: (id, options) =>
-      set((state) => ({
-        selectedIds: options?.additive
-          ? new Set(state.selectedIds).add(id)
-          : new Set([id]),
-        activeId: id,
-      })),
+      set((state) => {
+        if (!options?.additive) {
+          return { selectedIds: new Set([id]), activeId: id };
+        }
+        // Additive: toggle membership. Removing the active block repoints
+        // active to another remaining member (or null when the set empties).
+        const selectedIds = new Set(state.selectedIds);
+        if (selectedIds.delete(id)) {
+          const activeId =
+            state.activeId === id
+              ? ([...selectedIds].at(-1) ?? null)
+              : state.activeId;
+          return { selectedIds, activeId };
+        }
+        selectedIds.add(id);
+        return { selectedIds, activeId: id };
+      }),
     clearSelection: () => set({ selectedIds: new Set(), activeId: null }),
+    removeSelected: () =>
+      set((state) => {
+        const tree = removeBlocks(state.tree, state.selectedIds);
+        if (tree === state.tree) return {};
+        return {
+          tree,
+          selectedIds: new Set(),
+          activeId: null,
+          history: recordHistory(state.history, tree, null),
+        };
+      }),
+    duplicateSelected: () =>
+      set((state) => {
+        let tree = state.tree;
+        const newIds: string[] = [];
+        // Only clone selection roots; a nested block whose container is also
+        // selected is already copied inside that container's clone.
+        for (const id of selectionRoots(tree, state.selectedIds)) {
+          const result = duplicateBlock(tree, id);
+          tree = result.tree;
+          if (result.newId) newIds.push(result.newId);
+        }
+        if (tree === state.tree) return {};
+        return {
+          tree,
+          selectedIds: new Set(newIds),
+          activeId: newIds.at(-1) ?? null,
+          history: recordHistory(state.history, tree, null),
+        };
+      }),
+    selectParent: () =>
+      set((state) => {
+        if (!state.activeId) return {};
+        const parentId = findParentId(state.tree, state.activeId);
+        if (!parentId) return {};
+        return { selectedIds: new Set([parentId]), activeId: parentId };
+      }),
+    moveSelectedBy: (delta) =>
+      set((state) => {
+        if (!state.activeId) return {};
+        const tree = moveBlockBy(state.tree, state.activeId, delta);
+        if (tree === state.tree) return {};
+        return { tree, history: recordHistory(state.history, tree, null) };
+      }),
     setHover: (hoverId) => set({ hoverId }),
     setDevice: (device) => set({ device }),
     setZoom: (zoom) =>

--- a/packages/blocks/src/renderer/editor-protocol.ts
+++ b/packages/blocks/src/renderer/editor-protocol.ts
@@ -25,7 +25,12 @@ export interface HostMessage {
 /** Canvas (iframe) → parent (admin shell). */
 export type CanvasMessage =
   | { readonly type: "canvas:ready" }
-  | { readonly type: "canvas:select"; readonly id: string }
+  | {
+      readonly type: "canvas:select";
+      readonly id: string;
+      /** Add to the current selection instead of replacing it (shift/cmd-click). */
+      readonly additive?: boolean;
+    }
   | { readonly type: "canvas:hover"; readonly id: string | null }
   | { readonly type: "canvas:geometry"; readonly rects: readonly BlockRect[] };
 


### PR DESCRIPTION
Selecting a block in the bespoke editor canvas now floats a toolbar over it with
select-parent, move up/down, duplicate, and delete. Shift / cmd / ctrl-click
extends the selection (and toggles a block back off); the canvas outlines every
selected block while marking the active one apart, and bulk delete/duplicate act
on the whole selection. Move and select-parent stay scoped to the active block
and are disabled while several blocks are selected, where acting on one of many
would be ambiguous.

The selection logic lives in pure, immutable tree primitives in
`block-tree-ops.ts` — `removeBlocks` prunes a whole id set in one pass,
`duplicateBlock` clones a subtree with fresh ids beside its original,
`findParentId`/`moveBlockBy` resolve a block's container and reorder it among its
siblings, and `selectionRoots` drops a nested block whose container is also
selected so bulk duplicate never copies it twice. The `canvas:select` bridge
message gained an optional `additive` flag so modifier-clicks inside the iframe
reach the host as additive selections. Worth a careful look:
`selectionRoots`/`duplicateSelected` (the double-copy guard) and the
additive-toggle path in the store's `select`.

The mock e2e harness can't run the real public route the canvas iframe loads, so
the toolbar's geometry-dependent positioning isn't exercised there; its behavior
is covered by the package unit tests (store, `selection-toolbar`, `canvas-frame`,
and the bridge specs). The Layers panel still highlights/selects a single block
and is left to a fast-follow.

Closes #1117