### PR TITLE
fix(admin-editor): clip canvas overlays and adopt shadcn sidebar rails

### DIFF
--- a/packages/admin-editor/e2e/editor-visual.spec.ts
+++ b/packages/admin-editor/e2e/editor-visual.spec.ts
@@ -41,6 +41,35 @@ test.describe("editor playground", () => {
     await expect(page.getByTestId("selection-toolbar-duplicate")).toBeVisible();
   });
 
+  test("overlays and toolbar stay clipped to the canvas, not over the rails", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const canvas = page.frameLocator(CANVAS_FRAME);
+
+    // Select a full-width block whose outline would otherwise span the whole
+    // 1280px canvas — far wider than the column.
+    await canvas.locator('[data-plumix-id="heading-1"]').click();
+
+    // Overlays live inside a clip layer that exactly covers the canvas column
+    // and hides overflow, so nothing they draw can reach the side rails.
+    // (boundingBox can't see CSS clipping, so assert the clip region instead.)
+    const frameBox = await page
+      .getByTestId("plumix-canvas-frame")
+      .boundingBox();
+    const clip = page.getByTestId("plumix-overlay-clip");
+    const clipBox = await clip.boundingBox();
+    if (!frameBox || !clipBox) {
+      throw new Error("expected canvas + clip boxes");
+    }
+    expect(clipBox.x).toBeGreaterThanOrEqual(frameBox.x - 1);
+    expect(clipBox.x + clipBox.width).toBeLessThanOrEqual(
+      frameBox.x + frameBox.width + 1,
+    );
+    const overflow = await clip.evaluate((el) => getComputedStyle(el).overflow);
+    expect(overflow).toBe("hidden");
+  });
+
   test("shift-click multi-selects, outlining members and showing a count", async ({
     page,
   }) => {
@@ -80,6 +109,31 @@ test.describe("editor playground", () => {
     // Duplicate selects the clone; deleting it returns to the original count.
     await page.getByTestId("selection-toolbar-delete").click();
     await expect(blocks).toHaveCount(before);
+  });
+
+  test("collapsing the rails re-measures the canvas clip region", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page
+      .frameLocator(CANVAS_FRAME)
+      .locator('[data-plumix-id="heading-1"]')
+      .waitFor();
+
+    const before = await page.getByTestId("plumix-overlay-clip").boundingBox();
+    if (!before) throw new Error("expected clip box");
+
+    // Collapsing both rails widens the canvas column; the clip layer must track
+    // it (the rail toggle fires no block-geometry report, so this exercises the
+    // scroll/resize/collapse re-measure path, not the tree-keyed one).
+    await page.getByTestId("plumix-rails-toggle").click();
+    await expect
+      .poll(
+        async () =>
+          (await page.getByTestId("plumix-overlay-clip").boundingBox())
+            ?.width ?? 0,
+      )
+      .toBeGreaterThan(before.width);
   });
 
   test("the Layers tab outlines the nested structure", async ({ page }) => {

--- a/packages/admin-editor/playground/playground.css
+++ b/packages/admin-editor/playground/playground.css
@@ -30,6 +30,14 @@
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
 }
 
 @theme inline {

--- a/packages/admin-editor/src/canvas-frame.tsx
+++ b/packages/admin-editor/src/canvas-frame.tsx
@@ -5,7 +5,7 @@ import { Trans } from "@lingui/react";
 import type { BlockRegistry } from "@plumix/blocks";
 import type { BlockRect } from "@plumix/blocks/renderer";
 
-import type { FrameOffset } from "./overlay.js";
+import type { FrameOffset, OverlayBox } from "./overlay.js";
 import { createBlockFromSpec, groupBlocksByCategory } from "./block-catalog.js";
 import { connectCanvas } from "./connect-canvas.js";
 import { dropPlacement } from "./drop-index.js";
@@ -32,7 +32,11 @@ const CANVAS_HEIGHT = 800;
 
 interface Geometry {
   readonly rects: ReadonlyMap<string, BlockRect>;
+  /** The iframe's on-screen offset, for mapping block rects to overlay boxes. */
   readonly frame: FrameOffset | null;
+  /** The canvas viewport's on-screen box — overlays clip to this so they never
+   *  spill over the side rails (the iframe renders wider than the column). */
+  readonly container: OverlayBox | null;
 }
 
 /**
@@ -56,14 +60,31 @@ export function CanvasFrame({
   const dragSpec = useEditorStore((s) => s.dragSpec);
   const isEmpty = useEditorStore((s) => s.tree.length === 0);
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const [geometry, setGeometry] = useState<Geometry>({
     rects: new Map(),
     frame: null,
+    container: null,
   });
   // Mirror geometry for the drag handler so it reads fresh rects without
   // re-subscribing the window listeners on every geometry report.
   const geometryRef = useRef<Geometry>(geometry);
   const [dropY, setDropY] = useState<number | null>(null);
+
+  // The iframe's on-screen offset and the canvas viewport box, read live from
+  // the DOM. These move on scroll, window resize, and rail collapse — none of
+  // which re-fire the iframe's tree-keyed geometry report — so they're measured
+  // here and refreshed by the observer effect below, not just on block reports.
+  const measureHost = useCallback((): Pick<Geometry, "frame" | "container"> => {
+    const rect = iframeRef.current?.getBoundingClientRect();
+    const box = containerRef.current?.getBoundingClientRect();
+    return {
+      frame: rect ? { left: rect.left, top: rect.top } : null,
+      container: box
+        ? { left: box.left, top: box.top, width: box.width, height: box.height }
+        : null,
+    };
+  }, []);
 
   useEffect(() => {
     const frameWindow = iframeRef.current?.contentWindow;
@@ -73,17 +94,40 @@ export function CanvasFrame({
       frameWindow,
       origin,
       onGeometry: (reported) => {
-        const rect = iframeRef.current?.getBoundingClientRect();
         const next: Geometry = {
           rects: new Map(reported.map((r) => [r.id, r])),
-          frame: rect ? { left: rect.left, top: rect.top } : null,
+          ...measureHost(),
         };
         geometryRef.current = next;
         setGeometry(next);
       },
     });
     return () => connection.dispose();
-  }, [store, origin]);
+  }, [store, origin, measureHost]);
+
+  // Keep frame/container fresh when the canvas moves without a block report:
+  // column scroll, window resize, and rail collapse (which resizes the inset).
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const refresh = (): void => {
+      const next = { ...geometryRef.current, ...measureHost() };
+      geometryRef.current = next;
+      setGeometry(next);
+    };
+    el.addEventListener("scroll", refresh, { passive: true });
+    window.addEventListener("resize", refresh);
+    const observer =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(refresh);
+    observer?.observe(el);
+    return () => {
+      el.removeEventListener("scroll", refresh);
+      window.removeEventListener("resize", refresh);
+      observer?.disconnect();
+    };
+  }, [measureHost]);
 
   // Catalog drag → top-level insert. While dragging, the iframe ignores pointer
   // events so the host keeps receiving them over the canvas; the placement is
@@ -151,10 +195,14 @@ export function CanvasFrame({
     if (spec) store.getState().insertBlock(createBlockFromSpec(spec), 0);
   }, [registry, capabilities, store]);
 
+  // Overlays live in a clip layer pinned over the canvas viewport, so their
+  // boxes are expressed relative to that layer's top-left (the container's
+  // on-screen origin) rather than the whole window.
+  const container = geometry.container;
   const activeRect = activeId ? geometry.rects.get(activeId) : undefined;
   const activeBox =
-    activeRect && geometry.frame
-      ? overlayBox(activeRect, geometry.frame, zoom)
+    activeRect && geometry.frame && container
+      ? clipRelative(overlayBox(activeRect, geometry.frame, zoom), container)
       : null;
 
   const overlay = (
@@ -162,16 +210,16 @@ export function CanvasFrame({
     color: string,
     testId: string,
   ): ReactElement | null => {
-    if (!id || !geometry.frame) return null;
+    if (!id || !geometry.frame || !container) return null;
     const rect = geometry.rects.get(id);
     if (!rect) return null;
-    const box = overlayBox(rect, geometry.frame, zoom);
+    const box = clipRelative(overlayBox(rect, geometry.frame, zoom), container);
     return (
       <div
         key={testId}
         data-testid={testId}
         style={{
-          position: "fixed",
+          position: "absolute",
           left: box.left,
           top: box.top,
           width: box.width,
@@ -186,6 +234,7 @@ export function CanvasFrame({
 
   return (
     <div
+      ref={containerRef}
       data-testid="plumix-canvas-frame"
       style={{ position: "relative", flex: 1, overflow: "auto" }}
     >
@@ -201,28 +250,47 @@ export function CanvasFrame({
           transformOrigin: "top left",
         }}
       />
-      {overlay(hoverId, HOVER_OUTLINE, "plumix-overlay-hover")}
-      {[...selectedIds]
-        .filter((id) => id !== activeId)
-        .map((id) =>
-          overlay(id, MEMBER_OUTLINE, `plumix-overlay-member-${id}`),
-        )}
-      {overlay(activeId, SELECTED_OUTLINE, "plumix-overlay-selected")}
-      {activeBox && <SelectionToolbar box={activeBox} />}
-      {dropY !== null && geometry.frame && (
+      {/* Clip layer pinned over the visible canvas column. Its overflow:hidden
+          keeps the absolutely-positioned overlays + toolbar from spilling onto
+          the side rails when the iframe renders wider than the column. */}
+      {container && (
         <div
-          data-testid="plumix-drop-indicator"
+          data-testid="plumix-overlay-clip"
           style={{
             position: "fixed",
-            left: geometry.frame.left,
-            top: dropY,
-            width: DEVICE_WIDTH[device] * zoom,
-            height: 2,
-            background: SELECTED_OUTLINE,
+            left: container.left,
+            top: container.top,
+            width: container.width,
+            height: container.height,
+            overflow: "hidden",
             pointerEvents: "none",
-            zIndex: 20,
+            zIndex: 10,
           }}
-        />
+        >
+          {overlay(hoverId, HOVER_OUTLINE, "plumix-overlay-hover")}
+          {[...selectedIds]
+            .filter((id) => id !== activeId)
+            .map((id) =>
+              overlay(id, MEMBER_OUTLINE, `plumix-overlay-member-${id}`),
+            )}
+          {overlay(activeId, SELECTED_OUTLINE, "plumix-overlay-selected")}
+          {activeBox && <SelectionToolbar box={activeBox} />}
+          {dropY !== null && geometry.frame && (
+            <div
+              data-testid="plumix-drop-indicator"
+              style={{
+                position: "absolute",
+                left: geometry.frame.left - container.left,
+                top: dropY - container.top,
+                width: DEVICE_WIDTH[device] * zoom,
+                height: 2,
+                background: SELECTED_OUTLINE,
+                pointerEvents: "none",
+                zIndex: 20,
+              }}
+            />
+          )}
+        </div>
       )}
       {/* Stays visible during a drag so an empty canvas still shows a drop
           target (no block geometry exists to draw an indicator against). */}
@@ -238,4 +306,13 @@ export function CanvasFrame({
       )}
     </div>
   );
+}
+
+// Shift a window-space overlay box into the clip layer's local space.
+function clipRelative(box: OverlayBox, container: OverlayBox): OverlayBox {
+  return {
+    ...box,
+    left: box.left - container.left,
+    top: box.top - container.top,
+  };
 }

--- a/packages/admin-editor/src/editor-toolbar.test.tsx
+++ b/packages/admin-editor/src/editor-toolbar.test.tsx
@@ -4,6 +4,8 @@ import { I18nProvider } from "@lingui/react";
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
 
+import { SidebarProvider } from "@plumix/admin-ui/sidebar";
+
 import { EditorShortcuts, EditorToolbar } from "./editor-toolbar.js";
 import { EditorProvider, useEditorStoreApi } from "./provider.js";
 
@@ -29,7 +31,9 @@ function renderToolbar(
   return render(
     <I18nProvider i18n={i18n}>
       <EditorProvider initialTree={[]}>
-        <EditorToolbar publish={publish} />
+        <SidebarProvider>
+          <EditorToolbar publish={publish} />
+        </SidebarProvider>
         <EditorShortcuts />
         <Capture />
       </EditorProvider>

--- a/packages/admin-editor/src/editor-toolbar.tsx
+++ b/packages/admin-editor/src/editor-toolbar.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 import { Trans } from "@lingui/react";
 
 import { Button } from "@plumix/admin-ui/button";
+import { SidebarTrigger } from "@plumix/admin-ui/sidebar";
 
 import { canRedo, canUndo } from "./history.js";
 import { useEditorStore, useEditorStoreApi } from "./provider.js";
@@ -45,6 +46,8 @@ export function EditorToolbar({
       className="bg-background flex items-center gap-1 border-b p-2"
       data-testid="plumix-editor-toolbar"
     >
+      {/* Collapses both rails for a focused canvas (also Cmd/Ctrl+B). */}
+      <SidebarTrigger data-testid="plumix-rails-toggle" />
       <Button
         type="button"
         variant="ghost"

--- a/packages/admin-editor/src/overlay.ts
+++ b/packages/admin-editor/src/overlay.ts
@@ -5,6 +5,14 @@ export interface FrameOffset {
   readonly top: number;
 }
 
+/** A positioned box (overlay outline, toolbar anchor, clip region). */
+export interface OverlayBox {
+  readonly left: number;
+  readonly top: number;
+  readonly width: number;
+  readonly height: number;
+}
+
 /**
  * Map a block rect (iframe's unscaled coordinate space) to a screen-space
  * overlay box, accounting for the iframe's on-screen offset and CSS zoom.
@@ -15,7 +23,7 @@ export function overlayBox(
   rect: BlockRect,
   frame: FrameOffset,
   zoom: number,
-): { left: number; top: number; width: number; height: number } {
+): OverlayBox {
   return {
     left: frame.left + rect.x * zoom,
     top: frame.top + rect.y * zoom,

--- a/packages/admin-editor/src/plumix-editor.tsx
+++ b/packages/admin-editor/src/plumix-editor.tsx
@@ -1,8 +1,15 @@
-import type { ReactElement, ReactNode } from "react";
+import type { CSSProperties, ReactElement, ReactNode } from "react";
 import { useEffect, useRef } from "react";
 import { Trans } from "@lingui/react";
 
 import type { BlockRegistry, EntryContent } from "@plumix/blocks";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarHeader,
+  SidebarInset,
+  SidebarProvider,
+} from "@plumix/admin-ui/sidebar";
 import {
   Tabs,
   TabsContent,
@@ -63,15 +70,19 @@ export function PlumixEditor({
 }: PlumixEditorProps): ReactElement {
   return (
     <EditorProvider initialTree={defaultValue?.blocks}>
-      <div className="flex h-full flex-col" data-testid="plumix-editor-layout">
-        <EditorToolbar publish={publish} />
-        <div className="flex min-h-0 flex-1">
-          <aside
-            className="bg-background w-72 shrink-0 overflow-auto border-e"
-            data-testid="plumix-editor-left"
-          >
-            <Tabs defaultValue="blocks">
-              <TabsList className="m-2">
+      <SidebarProvider
+        className="h-full min-h-0"
+        style={{ "--sidebar-width": "18rem" } as CSSProperties}
+        data-testid="plumix-editor-layout"
+      >
+        <Sidebar
+          side="left"
+          collapsible="offcanvas"
+          data-testid="plumix-editor-left"
+        >
+          <Tabs defaultValue="blocks" className="flex h-full min-h-0 flex-col">
+            <SidebarHeader>
+              <TabsList>
                 <TabsTrigger value="blocks" data-testid="plumix-tab-blocks">
                   <Trans id="editor.tab.blocks" message="Blocks" />
                 </TabsTrigger>
@@ -79,26 +90,34 @@ export function PlumixEditor({
                   <Trans id="editor.tab.layers" message="Layers" />
                 </TabsTrigger>
               </TabsList>
+            </SidebarHeader>
+            <SidebarContent>
               <TabsContent value="blocks">
                 <BlockCatalog registry={registry} capabilities={capabilities} />
               </TabsContent>
               <TabsContent value="layers">
                 <LayersTab registry={registry} />
               </TabsContent>
-            </Tabs>
-          </aside>
+            </SidebarContent>
+          </Tabs>
+        </Sidebar>
+        <SidebarInset className="min-w-0">
+          <EditorToolbar publish={publish} />
           <CanvasFrame
             previewUrl={previewUrl}
             origin={origin}
             registry={registry}
             capabilities={capabilities}
           />
-          <aside
-            className="bg-background w-80 shrink-0 overflow-auto border-s"
-            data-testid="plumix-editor-right"
-          >
-            <Tabs defaultValue="block">
-              <TabsList className="m-2">
+        </SidebarInset>
+        <Sidebar
+          side="right"
+          collapsible="offcanvas"
+          data-testid="plumix-editor-right"
+        >
+          <Tabs defaultValue="block" className="flex h-full min-h-0 flex-col">
+            <SidebarHeader>
+              <TabsList>
                 <TabsTrigger value="block" data-testid="plumix-tab-block">
                   <Trans id="editor.tab.block" message="Block" />
                 </TabsTrigger>
@@ -109,6 +128,8 @@ export function PlumixEditor({
                   <Trans id="editor.tab.json" message="JSON" />
                 </TabsTrigger>
               </TabsList>
+            </SidebarHeader>
+            <SidebarContent>
               <TabsContent value="block">
                 <BlockInspector registry={registry} />
               </TabsContent>
@@ -125,10 +146,10 @@ export function PlumixEditor({
               <TabsContent value="json">
                 <JsonInspector />
               </TabsContent>
-            </Tabs>
-          </aside>
-        </div>
-      </div>
+            </SidebarContent>
+          </Tabs>
+        </Sidebar>
+      </SidebarProvider>
       <EditorShortcuts />
       {overlay}
       {onChange ? <TreeChangeEmitter onChange={onChange} /> : null}

--- a/packages/admin-editor/src/selection-toolbar.tsx
+++ b/packages/admin-editor/src/selection-toolbar.tsx
@@ -3,16 +3,9 @@ import { Trans } from "@lingui/react";
 
 import { Button } from "@plumix/admin-ui/button";
 
+import type { OverlayBox } from "./overlay.js";
 import { findParentId } from "./block-tree-ops.js";
 import { useEditorStore, useEditorStoreApi } from "./provider.js";
-
-/** Where to float the toolbar — the active block's box in shell coordinates. */
-interface ToolbarBox {
-  readonly left: number;
-  readonly top: number;
-  readonly width: number;
-  readonly height: number;
-}
 
 const TOOLBAR_GAP = 4;
 
@@ -25,7 +18,9 @@ const TOOLBAR_GAP = 4;
 export function SelectionToolbar({
   box,
 }: {
-  readonly box: ToolbarBox;
+  /** The active block's box in the canvas clip layer's local coordinates, so
+   *  the toolbar clips to the canvas with the overlays. */
+  readonly box: OverlayBox;
 }): ReactElement | null {
   const store = useEditorStoreApi();
   const activeId = useEditorStore((s) => s.activeId);
@@ -47,9 +42,12 @@ export function SelectionToolbar({
       data-testid="plumix-selection-toolbar"
       className="bg-background flex items-center gap-0.5 rounded-md border p-0.5 shadow-sm"
       style={{
-        position: "fixed",
-        left: box.left,
+        position: "absolute",
+        left: Math.max(0, box.left),
         top: Math.max(0, box.top - 36 - TOOLBAR_GAP),
+        // The enclosing clip layer is pointer-events:none (so overlays don't
+        // eat canvas clicks); the toolbar opts back in so its buttons work.
+        pointerEvents: "auto",
         zIndex: 30,
       }}
     >

--- a/packages/admin-editor/tsconfig.json
+++ b/packages/admin-editor/tsconfig.json
@@ -21,6 +21,8 @@
     "playground",
     "e2e",
     "vite.config.ts",
+    "vitest.config.ts",
+    "vitest.setup.ts",
     "playwright.config.ts"
   ],
   "exclude": ["dist", "playground/dist", "node_modules"]

--- a/packages/admin-editor/vitest.config.ts
+++ b/packages/admin-editor/vitest.config.ts
@@ -7,6 +7,7 @@ export default mergeConfig(
   defineConfig({
     test: {
       environment: "jsdom",
+      setupFiles: ["./vitest.setup.ts"],
     },
   }),
 );

--- a/packages/admin-editor/vitest.setup.ts
+++ b/packages/admin-editor/vitest.setup.ts
@@ -1,0 +1,16 @@
+import { vi } from "vitest";
+
+// jsdom has no matchMedia, but the shadcn Sidebar's useIsMobile hook calls it.
+// Stub a desktop-width result so the editor's rails render their desktop branch
+// under test. (TS types matchMedia as always present, so assign unconditionally
+// rather than guard — jsdom never provides one.)
+window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+}));


### PR DESCRIPTION
Two editor-layout fixes that the new playground made visible.

**Overlays no longer spill over the side rails.** The selection / hover /
multi-select overlays, the floating block toolbar, and the drag drop-indicator
were positioned in window coordinates (`position: fixed`), so they bled across
the side rails whenever the canvas iframe rendered wider than its column. They
now render inside an `overflow: hidden` clip layer pinned to the canvas viewport
box and positioned relative to it, so nothing they draw can reach the rails (the
toolbar opts back into `pointer-events: auto` so its buttons still work). The
canvas box and iframe offset are re-measured on column scroll, window resize, and
rail collapse — none of which re-fire the iframe's tree-keyed geometry report —
so overlays stay aligned, not just on block edits.

**Rails use the shadcn Sidebar.** The two hand-rolled `<aside>` rails are
replaced with `SidebarProvider` + `Sidebar` (tab strips in `SidebarHeader`,
panels in `SidebarContent`), the canvas + toolbar in a `SidebarInset`, and a
toolbar trigger (or Cmd/Ctrl+B) to collapse the rails. A vitest setup stubs
`matchMedia` for the Sidebar's `useIsMobile` hook under jsdom.

Worth a look: the clip coordinate math + the re-measure observer in
`canvas-frame.tsx`, and the single-`SidebarProvider` choice (both rails currently
share one collapse state — independent collapse and a toolbar right-edge clamp
are filed as follow-ups). The geometry-dependent behavior is covered by the
playground visual e2e, including a test that collapses the rails and asserts the
clip region re-measures to the wider canvas.

No `src/` consumer API changed; the published library dist is unaffected.