### PR TITLE
refactor: source admin icons from a shared @plumix/admin-ui/icons export

### DIFF
--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -68,6 +68,10 @@
       "types": "./dist/form.d.ts",
       "default": "./dist/form.js"
     },
+    "./icons": {
+      "types": "./dist/icons.d.ts",
+      "default": "./dist/icons.js"
+    },
     "./input": {
       "types": "./dist/input.d.ts",
       "default": "./dist/input.js"

--- a/packages/admin-ui/src/icons.ts
+++ b/packages/admin-ui/src/icons.ts
@@ -1,0 +1,6 @@
+// The shared icon set. Re-exports lucide-react so every consumer (admin,
+// admin-editor, themes) pulls icons from one place at one catalog-pinned
+// version, instead of each depending on lucide directly and drifting. lucide
+// ships per-icon ESM modules, so `export *` stays tree-shakeable — bundlers
+// keep only the icons a consumer actually imports.
+export * from "lucide-react";

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -34,7 +34,6 @@
     "@tiptap/core": "catalog:",
     "cmdk": "catalog:",
     "jsondiffpatch": "^0.7.6",
-    "lucide-react": "catalog:",
     "radix-ui": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",

--- a/packages/admin/src/components/data-table/list-pagination.tsx
+++ b/packages/admin/src/components/data-table/list-pagination.tsx
@@ -3,9 +3,9 @@ import type { ReactNode } from "react";
 import { useLabel } from "@/lib/use-label.js";
 import { defineMessage } from "@lingui/core/macro";
 import { Trans } from "@lingui/react";
-import { ChevronLeft, ChevronRight } from "lucide-react";
 
 import { Button } from "@plumix/admin-ui/button";
+import { ChevronLeft, ChevronRight } from "@plumix/admin-ui/icons";
 import {
   Pagination,
   PaginationContent,

--- a/packages/admin/src/components/error-boundary-fallback.tsx
+++ b/packages/admin/src/components/error-boundary-fallback.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { Trans } from "@lingui/react";
-import { TriangleAlert } from "lucide-react";
 
 import { Button } from "@plumix/admin-ui/button";
 import {
@@ -11,6 +10,7 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@plumix/admin-ui/empty";
+import { TriangleAlert } from "@plumix/admin-ui/icons";
 
 interface ErrorBoundaryFallbackProps {
   readonly error: Error;

--- a/packages/admin/src/components/error-placeholder.tsx
+++ b/packages/admin/src/components/error-placeholder.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from "react";
-import { TriangleAlert } from "lucide-react";
 
 import {
   Empty,
@@ -8,6 +7,7 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@plumix/admin-ui/empty";
+import { TriangleAlert } from "@plumix/admin-ui/icons";
 
 interface ErrorPlaceholderProps {
   readonly title: ReactNode;

--- a/packages/admin/src/components/form/multi-select.tsx
+++ b/packages/admin/src/components/form/multi-select.tsx
@@ -5,7 +5,6 @@ import { useLabel } from "@/lib/use-label.js";
 import { cn } from "@/lib/utils.js";
 import { defineMessage } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react";
-import { Check, ChevronsUpDown } from "lucide-react";
 
 import { Badge } from "@plumix/admin-ui/badge";
 import { Button } from "@plumix/admin-ui/button";
@@ -17,6 +16,7 @@ import {
   CommandItem,
   CommandList,
 } from "@plumix/admin-ui/command";
+import { Check, ChevronsUpDown } from "@plumix/admin-ui/icons";
 import {
   Popover,
   PopoverContent,

--- a/packages/admin/src/components/form/search-input.tsx
+++ b/packages/admin/src/components/form/search-input.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
-import { Search } from "lucide-react";
 
+import { Search } from "@plumix/admin-ui/icons";
 import { Input } from "@plumix/admin-ui/input";
 
 const SEARCH_DEBOUNCE_MS = 250;

--- a/packages/admin/src/components/meta-box/repeater-field.tsx
+++ b/packages/admin/src/components/meta-box/repeater-field.tsx
@@ -2,10 +2,10 @@ import type { ReactNode } from "react";
 import type { ControllerRenderProps, FieldValues } from "react-hook-form";
 import { useId } from "react";
 import { Trans } from "@lingui/react";
-import { PlusIcon } from "lucide-react";
 
 import type { MetaBoxFieldManifestEntry } from "@plumix/core/manifest";
 import { Button } from "@plumix/admin-ui/button";
+import { PlusIcon } from "@plumix/admin-ui/icons";
 import { SortableList } from "@plumix/admin-ui/sortable";
 
 import { MetaBoxField } from "./meta-box-field.js";

--- a/packages/admin/src/components/profile/api-tokens-card.tsx
+++ b/packages/admin/src/components/profile/api-tokens-card.tsx
@@ -11,7 +11,6 @@ import { valibotResolver } from "@hookform/resolvers/valibot";
 import { defineMessage } from "@lingui/core/macro";
 import { Trans } from "@lingui/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Check, Copy, Plus } from "lucide-react";
 import { useForm, useWatch } from "react-hook-form";
 import * as v from "valibot";
 
@@ -50,6 +49,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@plumix/admin-ui/form";
+import { Check, Copy, Plus } from "@plumix/admin-ui/icons";
 import { Input } from "@plumix/admin-ui/input";
 import { Label as UILabel } from "@plumix/admin-ui/label";
 import { RadioGroup, RadioGroupItem } from "@plumix/admin-ui/radio-group";

--- a/packages/admin/src/components/shell/core-icon.tsx
+++ b/packages/admin/src/components/shell/core-icon.tsx
@@ -1,5 +1,7 @@
-import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
+
+import type { LucideIcon } from "@plumix/admin-ui/icons";
+import type { CoreIconName } from "@plumix/core/manifest";
 import {
   Calendar,
   FileText,
@@ -13,9 +15,7 @@ import {
   Settings,
   Tag,
   Users,
-} from "lucide-react";
-
-import type { CoreIconName } from "@plumix/core/manifest";
+} from "@plumix/admin-ui/icons";
 
 const CORE_ICON: Record<CoreIconName, LucideIcon> = {
   dashboard: LayoutDashboard,

--- a/packages/admin/src/components/shell/user-menu.tsx
+++ b/packages/admin/src/components/shell/user-menu.tsx
@@ -4,7 +4,6 @@ import { SESSION_QUERY_KEY } from "@/lib/session.js";
 import { Trans } from "@lingui/react";
 import { useMutation } from "@tanstack/react-query";
 import { Link, useRouter } from "@tanstack/react-router";
-import { ChevronsUpDown, LogOut, Settings, User } from "lucide-react";
 
 import type { AuthSessionUser } from "@plumix/core";
 import { Avatar, AvatarFallback } from "@plumix/admin-ui/avatar";
@@ -17,6 +16,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@plumix/admin-ui/dropdown-menu";
+import { ChevronsUpDown, LogOut, Settings, User } from "@plumix/admin-ui/icons";
 import { SidebarMenuButton, useSidebar } from "@plumix/admin-ui/sidebar";
 
 // Only the identity fields are rendered — a narrow slice of the session

--- a/packages/admin/src/editor/BlockIcon.tsx
+++ b/packages/admin/src/editor/BlockIcon.tsx
@@ -1,4 +1,5 @@
 import type { ComponentType, SVGProps } from "react";
+
 import {
   AlignLeft,
   ChevronDown,
@@ -17,7 +18,7 @@ import {
   Square,
   Table,
   Type,
-} from "lucide-react";
+} from "@plumix/admin-ui/icons";
 
 type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
 

--- a/packages/admin/src/editor/EditorLayout.tsx
+++ b/packages/admin/src/editor/EditorLayout.tsx
@@ -22,7 +22,6 @@ import { defineMessage } from "@lingui/core/macro";
 import { Trans } from "@lingui/react";
 import { Drawer, Puck, useGetPuck } from "@puckeditor/core";
 import { Link } from "@tanstack/react-router";
-import { Minus, Monitor, Plus, Smartphone, Tablet } from "lucide-react";
 
 import type {
   BlockRegistry,
@@ -42,6 +41,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@plumix/admin-ui/dialog";
+import {
+  Minus,
+  Monitor,
+  Plus,
+  Smartphone,
+  Tablet,
+} from "@plumix/admin-ui/icons";
 import {
   Tabs,
   TabsContent,

--- a/packages/admin/src/editor/PatternRefPreview.tsx
+++ b/packages/admin/src/editor/PatternRefPreview.tsx
@@ -11,9 +11,9 @@ import { copyText } from "@/lib/clipboard.js";
 import { useLabel } from "@/lib/use-label.js";
 import { Trans } from "@lingui/react";
 import { registerOverlayPortal, useGetPuck } from "@puckeditor/core";
-import { Link, Unlink } from "lucide-react";
 
 import type { BlockRegistry, PatternRegistry } from "@plumix/blocks";
+import { Link, Unlink } from "@plumix/admin-ui/icons";
 import { renderBlockTree } from "@plumix/blocks";
 
 import { detachPatternRef } from "./detach-pattern-ref.js";

--- a/packages/admin/src/editor/PreviewButton.tsx
+++ b/packages/admin/src/editor/PreviewButton.tsx
@@ -5,7 +5,6 @@ import { copyText } from "@/lib/clipboard.js";
 import { toastError, toastSuccess } from "@/lib/toast.js";
 import { useLabel } from "@/lib/use-label.js";
 import { defineMessage } from "@lingui/core/macro";
-import { ChevronDownIcon, EyeIcon, Link2Icon } from "lucide-react";
 
 import { Button } from "@plumix/admin-ui/button";
 import {
@@ -14,6 +13,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@plumix/admin-ui/dropdown-menu";
+import { ChevronDownIcon, EyeIcon, Link2Icon } from "@plumix/admin-ui/icons";
 import {
   Tooltip,
   TooltipContent,

--- a/packages/admin/src/editor/revisions/RevisionsSheet.tsx
+++ b/packages/admin/src/editor/revisions/RevisionsSheet.tsx
@@ -5,9 +5,9 @@ import { useLabel } from "@/lib/use-label.js";
 import { defineMessage } from "@lingui/core/macro";
 import { Trans } from "@lingui/react";
 import { useInfiniteQuery } from "@tanstack/react-query";
-import { MessageCircle, MessageCircleMore } from "lucide-react";
 
 import { Button } from "@plumix/admin-ui/button";
+import { MessageCircle, MessageCircleMore } from "@plumix/admin-ui/icons";
 import { Input } from "@plumix/admin-ui/input";
 import {
   Sheet,

--- a/packages/admin/src/lib/plugin-error-boundary.tsx
+++ b/packages/admin/src/lib/plugin-error-boundary.tsx
@@ -3,9 +3,9 @@ import type { ReactNode } from "react";
 import { Component } from "react";
 import { i18n } from "@lingui/core";
 import { defineMessage } from "@lingui/core/macro";
-import { AlertTriangle } from "lucide-react";
 
 import { Alert, AlertDescription } from "@plumix/admin-ui/alert";
+import { AlertTriangle } from "@plumix/admin-ui/icons";
 
 type Kind = "page" | "widget" | "icon" | "block" | "field";
 

--- a/packages/admin/src/lib/user-agent.ts
+++ b/packages/admin/src/lib/user-agent.ts
@@ -1,6 +1,14 @@
-import type { LucideIcon } from "lucide-react";
-import { Globe, Monitor, Smartphone, Tablet, Tv, Watch } from "lucide-react";
 import { UAParser } from "ua-parser-js";
+
+import type { LucideIcon } from "@plumix/admin-ui/icons";
+import {
+  Globe,
+  Monitor,
+  Smartphone,
+  Tablet,
+  Tv,
+  Watch,
+} from "@plumix/admin-ui/icons";
 
 // Pretty-prints a `User-Agent` string into something humans can scan in
 // a session list ("Chrome on macOS", "Safari on iPhone"), and picks an

--- a/packages/admin/src/routes/_authenticated/allowed-domains/index.tsx
+++ b/packages/admin/src/routes/_authenticated/allowed-domains/index.tsx
@@ -10,7 +10,6 @@ import { defineMessage } from "@lingui/core/macro";
 import { Trans, useLingui } from "@lingui/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, redirect } from "@tanstack/react-router";
-import { Trash2 } from "lucide-react";
 import { useForm } from "react-hook-form";
 import * as v from "valibot";
 
@@ -33,6 +32,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@plumix/admin-ui/form";
+import { Trash2 } from "@plumix/admin-ui/icons";
 import { Input } from "@plumix/admin-ui/input";
 import {
   Select,

--- a/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
+++ b/packages/admin/src/routes/_authenticated/entries/$slug/index.tsx
@@ -20,7 +20,6 @@ import { defineMessage } from "@lingui/core/macro";
 import { Trans, useLingui } from "@lingui/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
-import { ArrowDown, ArrowUp, ArrowUpDown, Plus } from "lucide-react";
 import * as v from "valibot";
 
 import type { EntryTypeManifestEntry } from "@plumix/core/manifest";
@@ -46,6 +45,7 @@ import {
   EmptyHeader,
   EmptyTitle,
 } from "@plumix/admin-ui/empty";
+import { ArrowDown, ArrowUp, ArrowUpDown, Plus } from "@plumix/admin-ui/icons";
 import {
   Select,
   SelectContent,

--- a/packages/admin/src/routes/_authenticated/index.tsx
+++ b/packages/admin/src/routes/_authenticated/index.tsx
@@ -11,7 +11,6 @@ import { defineMessage } from "@lingui/core/macro";
 import { Trans, useLingui } from "@lingui/react";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { ArrowRight, FileText, Puzzle } from "lucide-react";
 
 import { Button } from "@plumix/admin-ui/button";
 import {
@@ -28,6 +27,7 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@plumix/admin-ui/empty";
+import { ArrowRight, FileText, Puzzle } from "@plumix/admin-ui/icons";
 
 import { DashboardWidgets } from "./-dashboard-widgets.js";
 

--- a/packages/admin/src/routes/_authenticated/settings/index.tsx
+++ b/packages/admin/src/routes/_authenticated/settings/index.tsx
@@ -4,7 +4,6 @@ import { visibleSettingsPages } from "@/lib/manifest.js";
 import { useLabel } from "@/lib/use-label.js";
 import { Trans } from "@lingui/react";
 import { createFileRoute, Link, redirect } from "@tanstack/react-router";
-import { Settings as SettingsIcon } from "lucide-react";
 
 import {
   Card,
@@ -20,6 +19,7 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@plumix/admin-ui/empty";
+import { Settings as SettingsIcon } from "@plumix/admin-ui/icons";
 
 export const Route = createFileRoute("/_authenticated/settings/")({
   // The settings surface is admin-only at the floor — `settings:manage`

--- a/packages/admin/src/routes/_authenticated/terms/$name/$id/edit.tsx
+++ b/packages/admin/src/routes/_authenticated/terms/$name/$id/edit.tsx
@@ -30,7 +30,6 @@ import {
   notFound,
   useNavigate,
 } from "@tanstack/react-router";
-import { ArrowLeft } from "lucide-react";
 import * as v from "valibot";
 
 import type { TermTaxonomyManifestEntry } from "@plumix/core/manifest";
@@ -53,6 +52,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@plumix/admin-ui/card";
+import { ArrowLeft } from "@plumix/admin-ui/icons";
 import { seedFromMetaBoxes } from "@plumix/core/manifest";
 import { idPathParam } from "@plumix/core/validation";
 

--- a/packages/admin/src/routes/_authenticated/terms/$name/create.tsx
+++ b/packages/admin/src/routes/_authenticated/terms/$name/create.tsx
@@ -17,7 +17,6 @@ import {
   redirect,
   useNavigate,
 } from "@tanstack/react-router";
-import { ArrowLeft } from "lucide-react";
 
 import type { TermTaxonomyManifestEntry } from "@plumix/core/manifest";
 import {
@@ -27,6 +26,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@plumix/admin-ui/card";
+import { ArrowLeft } from "@plumix/admin-ui/icons";
 import { slugify } from "@plumix/core/slugify";
 
 import { TAXONOMY_LIST_DEFAULT_SEARCH } from "./-constants.js";

--- a/packages/admin/src/routes/_authenticated/terms/$name/index.tsx
+++ b/packages/admin/src/routes/_authenticated/terms/$name/index.tsx
@@ -15,7 +15,6 @@ import { defineMessage } from "@lingui/core/macro";
 import { Trans } from "@lingui/react";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
-import { Plus } from "lucide-react";
 import * as v from "valibot";
 
 import type { TermTaxonomyManifestEntry } from "@plumix/core/manifest";
@@ -29,6 +28,7 @@ import {
   EmptyHeader,
   EmptyTitle,
 } from "@plumix/admin-ui/empty";
+import { Plus } from "@plumix/admin-ui/icons";
 
 const M = {
   columnName: defineMessage({

--- a/packages/admin/src/routes/_authenticated/users/$id/edit.tsx
+++ b/packages/admin/src/routes/_authenticated/users/$id/edit.tsx
@@ -34,7 +34,6 @@ import {
   redirect,
   useNavigate,
 } from "@tanstack/react-router";
-import { ArrowLeft } from "lucide-react";
 import { useForm } from "react-hook-form";
 import * as v from "valibot";
 
@@ -58,6 +57,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@plumix/admin-ui/form";
+import { ArrowLeft } from "@plumix/admin-ui/icons";
 import { Input } from "@plumix/admin-ui/input";
 import { Label as UILabel } from "@plumix/admin-ui/label";
 import { seedFromMetaBoxes } from "@plumix/core/manifest";

--- a/packages/admin/src/routes/_authenticated/users/create.tsx
+++ b/packages/admin/src/routes/_authenticated/users/create.tsx
@@ -17,7 +17,6 @@ import {
   redirect,
   useNavigate,
 } from "@tanstack/react-router";
-import { ArrowLeft, Check, Copy } from "lucide-react";
 import { useForm } from "react-hook-form";
 import * as v from "valibot";
 
@@ -40,6 +39,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@plumix/admin-ui/form";
+import { ArrowLeft, Check, Copy } from "@plumix/admin-ui/icons";
 import { Input } from "@plumix/admin-ui/input";
 import { Label as UILabel } from "@plumix/admin-ui/label";
 import { vMessage } from "@plumix/core/validation";

--- a/packages/admin/src/routes/_authenticated/users/index.tsx
+++ b/packages/admin/src/routes/_authenticated/users/index.tsx
@@ -15,7 +15,6 @@ import { defineMessage } from "@lingui/core/macro";
 import { Trans } from "@lingui/react";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, redirect } from "@tanstack/react-router";
-import { Plus, UserPlus } from "lucide-react";
 import * as v from "valibot";
 
 import type { Label } from "@plumix/core/i18n";
@@ -30,6 +29,7 @@ import {
   EmptyHeader,
   EmptyTitle,
 } from "@plumix/admin-ui/empty";
+import { Plus, UserPlus } from "@plumix/admin-ui/icons";
 import {
   Select,
   SelectContent,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,9 +325,6 @@ importers:
       jsondiffpatch:
         specifier: ^0.7.6
         version: 0.7.6
-      lucide-react:
-        specifier: 'catalog:'
-        version: 1.16.0(react@19.2.7)
       radix-ui:
         specifier: 'catalog:'
         version: 1.6.0(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
Adds a single icon surface — `@plumix/admin-ui/icons` re-exporting `lucide-react`
— so every first-party consumer (admin, admin-editor, themes) pulls icons from
one place at the one catalog-pinned version, instead of each package depending on
lucide directly and drifting. lucide ships per-icon ESM modules, so `export *`
stays tree-shakeable — bundlers keep only the icons actually imported.

Admin's 26 files move from `lucide-react` to `@plumix/admin-ui/icons`, and
admin's now-unused direct `lucide-react` dependency is dropped (it resolves
transitively through admin-ui, which keeps it as a direct dep).

The export is a **subpath only** — deliberately kept out of the admin-ui root
barrel and the `plumix/admin/ui` shim. Unlike React / orpc, the icon set is
open-ended and not a singleton the admin can pre-bundle, so plugins should depend
on `lucide-react: catalog:` directly rather than route icons through the plugin
chunk seam. (No plugin imports lucide today; this is the convention going
forward.)

No behavior change — same icons, same version, just one import path.