### PR TITLE
feat: full nested editing — slot-aware tree ops, drop zones, allowedBlocks

### DIFF
--- a/packages/admin-editor/e2e/editor-visual.spec.ts
+++ b/packages/admin-editor/e2e/editor-visual.spec.ts
@@ -136,6 +136,24 @@ test.describe("editor playground", () => {
       .toBeGreaterThan(before.width);
   });
 
+  test("selects a nested block and exposes slot drop zones", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const canvas = page.frameLocator(CANVAS_FRAME);
+
+    // A block nested inside the columns' left slot is selectable at depth.
+    await canvas.locator('[data-plumix-id="col-left"]').click();
+    await expect(page.getByTestId("plumix-overlay-selected")).toBeVisible();
+
+    // The edit seam tags container slots so the canvas can target nested drops.
+    await expect(
+      canvas.locator(
+        '[data-plumix-slot-parent="columns-1"][data-plumix-slot-key="left"]',
+      ),
+    ).toBeAttached();
+  });
+
   test("the Layers tab outlines the nested structure", async ({ page }) => {
     await page.goto("/");
 

--- a/packages/admin-editor/src/block-catalog.test.ts
+++ b/packages/admin-editor/src/block-catalog.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, test } from "vitest";
 import type { BlockSpec } from "@plumix/blocks";
 import { createBlockRegistry } from "@plumix/blocks";
 
-import { createBlockFromSpec, groupBlocksByCategory } from "./block-catalog.js";
+import {
+  createBlockFromSpec,
+  groupBlocksByCategory,
+  slotAllowedBlocks,
+} from "./block-catalog.js";
 
 const spec = (over: Partial<BlockSpec> & { name: string }): BlockSpec => ({
   render: () => null,
@@ -11,6 +15,43 @@ const spec = (over: Partial<BlockSpec> & { name: string }): BlockSpec => ({
 });
 
 const NO_CAPS: ReadonlySet<string> = new Set();
+
+describe("slotAllowedBlocks", () => {
+  const registry = createBlockRegistry([
+    spec({
+      name: "core/buttons",
+      inputs: [
+        {
+          name: "items",
+          type: "slot",
+          label: "Buttons",
+          allowedBlocks: ["core/button"],
+        },
+      ],
+    }),
+    spec({
+      name: "core/group",
+      inputs: [{ name: "content", type: "slot", label: "Content" }],
+    }),
+  ]);
+
+  test("returns a slot's allowedBlocks list", () => {
+    expect(slotAllowedBlocks(registry, "core/buttons", "items")).toEqual([
+      "core/button",
+    ]);
+  });
+
+  test("returns undefined for an unrestricted slot", () => {
+    expect(
+      slotAllowedBlocks(registry, "core/group", "content"),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined for an unknown parent or slot", () => {
+    expect(slotAllowedBlocks(registry, "core/nope", "items")).toBeUndefined();
+    expect(slotAllowedBlocks(registry, "core/buttons", "nope")).toBeUndefined();
+  });
+});
 
 describe("groupBlocksByCategory", () => {
   test("groups eligible blocks by category in first-seen order", () => {

--- a/packages/admin-editor/src/block-catalog.ts
+++ b/packages/admin-editor/src/block-catalog.ts
@@ -2,6 +2,23 @@ import type { BlockNode, BlockRegistry, BlockSpec } from "@plumix/blocks";
 import { rewriteBlockNodeIds } from "@plumix/blocks";
 import { labelSourceText } from "@plumix/core/i18n";
 
+/**
+ * A slot's `allowedBlocks` list (the block names it accepts), or undefined when
+ * the slot is unrestricted or the parent/slot is unknown. Resolved from the
+ * parent block's slot input in the registry — the policy the canvas drop and
+ * the inserter enforce.
+ */
+export function slotAllowedBlocks(
+  registry: BlockRegistry,
+  parentName: string,
+  slotKey: string,
+): readonly string[] | undefined {
+  const input = registry
+    .get(parentName)
+    ?.inputs?.find((i) => i.type === "slot" && i.name === slotKey);
+  return input?.allowedBlocks;
+}
+
 interface CatalogGroup {
   readonly category: string;
   readonly blocks: readonly BlockSpec[];

--- a/packages/admin-editor/src/block-tree-ops.test.ts
+++ b/packages/admin-editor/src/block-tree-ops.test.ts
@@ -7,6 +7,7 @@ import {
   findBlock,
   findParentId,
   flattenTree,
+  insertBlockAt,
   moveBlock,
   moveBlockBy,
   projectMove,
@@ -321,15 +322,15 @@ describe("moveBlockBy", () => {
 
 describe("slotKeys", () => {
   test("lists every slot key in declaration order", () => {
-    expect(slotKeys(columns([{ id: "l", name: "x" }], [{ id: "r", name: "x" }]))).toEqual(
-      ["left", "right"],
-    );
+    expect(
+      slotKeys(columns([{ id: "l", name: "x" }], [{ id: "r", name: "x" }])),
+    ).toEqual(["left", "right"]);
   });
 
   test("returns an empty list for a slotless block", () => {
-    expect(slotKeys({ id: "h", name: "core/heading", attrs: { text: "hi" } })).toEqual(
-      [],
-    );
+    expect(
+      slotKeys({ id: "h", name: "core/heading", attrs: { text: "hi" } }),
+    ).toEqual([]);
   });
 });
 
@@ -387,6 +388,55 @@ describe("moveBlock allowedBlocks enforcement", () => {
   test("an undefined allowed list permits any block", () => {
     const moved = moveBlock(tree, "btn", { parentId: "g", index: 0 });
     expect(content(moved).map((n) => n.id)).toEqual(["btn"]);
+  });
+});
+
+describe("insertBlockAt", () => {
+  const tree: readonly BlockNode[] = [
+    columns([{ id: "l", name: "x" }], [{ id: "r", name: "x" }]),
+  ];
+
+  test("inserts a new block into a named slot at an index", () => {
+    const next = insertBlockAt(
+      tree,
+      { id: "n", name: "core/heading" },
+      { parentId: "cols", slotKey: "right", index: 0 },
+    );
+    expect(
+      (findBlock(next, "cols")?.attrs?.right as readonly BlockNode[]).map(
+        (n) => n.id,
+      ),
+    ).toEqual(["n", "r"]);
+  });
+
+  test("inserts at the top level when parentId is null", () => {
+    const next = insertBlockAt(
+      [{ id: "a", name: "x" }],
+      { id: "n", name: "y" },
+      { parentId: null, index: 0 },
+    );
+    expect(next.map((node) => node.id)).toEqual(["n", "a"]);
+  });
+
+  test("refuses a block not in the slot's allowed list", () => {
+    expect(
+      insertBlockAt(
+        tree,
+        { id: "n", name: "core/button" },
+        { parentId: "cols", slotKey: "right", index: 0 },
+        ["core/heading"],
+      ),
+    ).toBe(tree);
+  });
+
+  test("is a no-op when the target slot is absent", () => {
+    expect(
+      insertBlockAt(
+        tree,
+        { id: "n", name: "x" },
+        { parentId: "cols", slotKey: "missing", index: 0 },
+      ),
+    ).toBe(tree);
   });
 });
 

--- a/packages/admin-editor/src/block-tree-ops.test.ts
+++ b/packages/admin-editor/src/block-tree-ops.test.ts
@@ -12,7 +12,17 @@ import {
   projectMove,
   removeBlocks,
   selectionRoots,
+  slotKeys,
 } from "./block-tree-ops.js";
+
+const columns = (
+  left: readonly BlockNode[],
+  right: readonly BlockNode[],
+): BlockNode => ({
+  id: "cols",
+  name: "core/columns",
+  attrs: { left, right },
+});
 
 const ids = (tree: readonly BlockNode[]): string[] =>
   flattenTree(tree).map((n) => `${n.parentId ?? "-"}/${n.id}`);
@@ -306,6 +316,77 @@ describe("moveBlockBy", () => {
 
   test("is a no-op when the block is absent", () => {
     expect(moveBlockBy(tree, "zzz", 1)).toBe(tree);
+  });
+});
+
+describe("slotKeys", () => {
+  test("lists every slot key in declaration order", () => {
+    expect(slotKeys(columns([{ id: "l", name: "x" }], [{ id: "r", name: "x" }]))).toEqual(
+      ["left", "right"],
+    );
+  });
+
+  test("returns an empty list for a slotless block", () => {
+    expect(slotKeys({ id: "h", name: "core/heading", attrs: { text: "hi" } })).toEqual(
+      [],
+    );
+  });
+});
+
+describe("moveBlock into a named slot", () => {
+  const tree: readonly BlockNode[] = [
+    { id: "a", name: "core/heading" },
+    columns([{ id: "l", name: "x" }], [{ id: "r", name: "x" }]),
+  ];
+  const slot = (t: readonly BlockNode[], key: string): readonly BlockNode[] =>
+    findBlock(t, "cols")?.attrs?.[key] as readonly BlockNode[];
+
+  test("nests into the named (non-first) slot, leaving the others untouched", () => {
+    const moved = moveBlock(tree, "a", {
+      parentId: "cols",
+      slotKey: "right",
+      index: 0,
+    });
+    expect(slot(moved, "right").map((n) => n.id)).toEqual(["a", "r"]);
+    expect(slot(moved, "left").map((n) => n.id)).toEqual(["l"]);
+  });
+
+  test("defaults to the first slot when slotKey is omitted", () => {
+    const moved = moveBlock(tree, "a", { parentId: "cols", index: 0 });
+    expect(slot(moved, "left").map((n) => n.id)).toEqual(["a", "l"]);
+  });
+
+  test("is a no-op for a slot the parent does not have", () => {
+    expect(
+      moveBlock(tree, "a", { parentId: "cols", slotKey: "missing", index: 0 }),
+    ).toBe(tree);
+  });
+});
+
+describe("moveBlock allowedBlocks enforcement", () => {
+  const tree: readonly BlockNode[] = [
+    { id: "btn", name: "core/button" },
+    { id: "g", name: "core/group", attrs: { content: [] } },
+  ];
+  const content = (t: readonly BlockNode[]): readonly BlockNode[] =>
+    findBlock(t, "g")?.attrs?.content as readonly BlockNode[];
+
+  test("refuses a block whose name is not in the slot's allowed list", () => {
+    expect(
+      moveBlock(tree, "btn", { parentId: "g", index: 0 }, ["core/heading"]),
+    ).toBe(tree);
+  });
+
+  test("permits a block whose name is in the allowed list", () => {
+    const moved = moveBlock(tree, "btn", { parentId: "g", index: 0 }, [
+      "core/button",
+    ]);
+    expect(content(moved).map((n) => n.id)).toEqual(["btn"]);
+  });
+
+  test("an undefined allowed list permits any block", () => {
+    const moved = moveBlock(tree, "btn", { parentId: "g", index: 0 });
+    expect(content(moved).map((n) => n.id)).toEqual(["btn"]);
   });
 });
 

--- a/packages/admin-editor/src/block-tree-ops.ts
+++ b/packages/admin-editor/src/block-tree-ops.ts
@@ -149,28 +149,36 @@ function projectedParentId(
 export interface MoveTarget {
   /** The new parent's id, or null to move to the top level. */
   readonly parentId: string | null;
-  /** Insertion index among the target parent's children. */
+  /** Which of the parent's slots to drop into; defaults to its first slot. */
+  readonly slotKey?: string;
+  /** Insertion index among the target slot's children. */
   readonly index: number;
 }
 
 /**
- * Move a block to a new parent + index, immutably. Handles reorder (same
- * parent), nest (into a parent's slot) and un-nest (to the top level). Returns
- * the same tree reference when the move is invalid — source missing, dropping
- * into itself or its own descendant, or a target parent with no slot to hold
- * children — so a bad drag is a safe no-op rather than a lost subtree.
+ * Move a block to a new parent + slot + index, immutably. Handles reorder (same
+ * parent), nest (into a named slot) and un-nest (to the top level). Returns the
+ * same tree reference when the move is invalid — source missing, dropping into
+ * itself or its own descendant, the target slot absent, or `allowed` given and
+ * the source's name not in it — so a bad drag is a safe no-op, never a lost
+ * subtree. `allowed` is the slot's `allowedBlocks` list (the caller resolves it
+ * from the registry); undefined permits any block.
  */
 export function moveBlock(
   tree: readonly BlockNode[],
   sourceId: string,
   target: MoveTarget,
+  allowed?: readonly string[],
 ): readonly BlockNode[] {
   if (target.parentId === sourceId) return tree;
   const source = findBlock(tree, sourceId);
   if (!source) return tree;
+  if (allowed && !allowed.includes(source.name)) return tree;
   if (target.parentId !== null) {
     const parent = findBlock(tree, target.parentId);
-    if (!parent || slotKey(parent) === null) return tree;
+    if (!parent) return tree;
+    const key = target.slotKey ?? slotKey(parent);
+    if (key === null || !isBlockNodeArray(parent.attrs?.[key])) return tree;
     if (containsBlock(source, target.parentId)) return tree;
   }
   return insertNode(removeNode(tree, sourceId), source, target);
@@ -286,6 +294,16 @@ function slotKey(node: BlockNode): string | null {
   return null;
 }
 
+/** Every attr key holding a child-block array, in declaration order — the
+ *  block's slots. Empty for a slotless (leaf) block. */
+export function slotKeys(node: BlockNode): string[] {
+  const keys: string[] = [];
+  for (const [key, value] of Object.entries(node.attrs ?? {})) {
+    if (isBlockNodeArray(value)) keys.push(key);
+  }
+  return keys;
+}
+
 /** Whether `id` is `node` itself or anywhere in its subtree. */
 function containsBlock(node: BlockNode, id: string): boolean {
   if (node.id === id) return true;
@@ -319,10 +337,11 @@ function insertNode(
   }
   return nodes.map((current) => {
     if (current.id === target.parentId) {
-      const key = slotKey(current);
+      const key = target.slotKey ?? slotKey(current);
       if (key === null) return current;
       const slot = current.attrs?.[key];
-      const children = isBlockNodeArray(slot) ? slot : [];
+      if (!isBlockNodeArray(slot)) return current;
+      const children = slot;
       const at = clampIndex(target.index, children.length);
       return {
         ...current,

--- a/packages/admin-editor/src/block-tree-ops.ts
+++ b/packages/admin-editor/src/block-tree-ops.ts
@@ -174,14 +174,41 @@ export function moveBlock(
   const source = findBlock(tree, sourceId);
   if (!source) return tree;
   if (allowed && !allowed.includes(source.name)) return tree;
-  if (target.parentId !== null) {
-    const parent = findBlock(tree, target.parentId);
-    if (!parent) return tree;
-    const key = target.slotKey ?? slotKey(parent);
-    if (key === null || !isBlockNodeArray(parent.attrs?.[key])) return tree;
-    if (containsBlock(source, target.parentId)) return tree;
+  if (!slotTargetExists(tree, target)) return tree;
+  if (target.parentId !== null && containsBlock(source, target.parentId)) {
+    return tree;
   }
   return insertNode(removeNode(tree, sourceId), source, target);
+}
+
+// Whether `target` names a real slot on a real parent. The top level always
+// exists; a nested target needs the parent present with that slot as an array.
+function slotTargetExists(
+  tree: readonly BlockNode[],
+  target: MoveTarget,
+): boolean {
+  if (target.parentId === null) return true;
+  const parent = findBlock(tree, target.parentId);
+  if (!parent) return false;
+  const key = target.slotKey ?? slotKey(parent);
+  return key !== null && isBlockNodeArray(parent.attrs?.[key]);
+}
+
+/**
+ * Insert a (new) block at a parent + slot + index, immutably. Mirrors
+ * moveBlock's validation for an insert rather than a relocation: a no-op (same
+ * tree) when the target slot is absent, or `allowed` is given and the block's
+ * name isn't in it. `parentId: null` inserts at the top level.
+ */
+export function insertBlockAt(
+  tree: readonly BlockNode[],
+  node: BlockNode,
+  target: MoveTarget,
+  allowed?: readonly string[],
+): readonly BlockNode[] {
+  if (allowed && !allowed.includes(node.name)) return tree;
+  if (!slotTargetExists(tree, target)) return tree;
+  return insertNode(tree, node, target);
 }
 
 /**

--- a/packages/admin-editor/src/canvas-frame.test.tsx
+++ b/packages/admin-editor/src/canvas-frame.test.tsx
@@ -1,14 +1,20 @@
 import type { ReactElement, ReactNode } from "react";
+import { useEffect } from "react";
 import { i18n } from "@lingui/core";
 import { I18nProvider } from "@lingui/react";
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, beforeAll, describe, expect, test } from "vitest";
 
+import type { BlockNode, BlockSpec } from "@plumix/blocks";
 import { createBlockRegistry } from "@plumix/blocks";
 import { EDITOR_BRIDGE_CHANNEL, encode } from "@plumix/blocks/renderer";
 
 import { CanvasFrame } from "./canvas-frame.js";
-import { EditorProvider, useEditorStore } from "./provider.js";
+import {
+  EditorProvider,
+  useEditorStore,
+  useEditorStoreApi,
+} from "./provider.js";
 
 const ORIGIN = "http://localhost:3000";
 
@@ -161,5 +167,101 @@ describe("CanvasFrame", () => {
     expect(getByTestId("tree-probe").textContent).toBe("core/heading");
     // Affordance disappears once the canvas is no longer empty.
     expect(queryByTestId("plumix-empty-add")).toBeNull();
+  });
+});
+
+describe("CanvasFrame nested drop", () => {
+  const headingSpec: BlockSpec = {
+    name: "core/heading",
+    render: () => null,
+    title: "Heading",
+    category: "text",
+  };
+  const nestRegistry = createBlockRegistry([
+    headingSpec,
+    {
+      name: "core/group",
+      render: () => null,
+      inputs: [{ name: "content", type: "slot", label: "Content" }],
+    },
+    {
+      name: "core/buttons",
+      render: () => null,
+      inputs: [
+        {
+          name: "items",
+          type: "slot",
+          label: "Buttons",
+          allowedBlocks: ["core/button"],
+        },
+      ],
+    },
+  ]);
+
+  let storeApi: ReturnType<typeof useEditorStoreApi> | undefined;
+  function Capture(): null {
+    const api = useEditorStoreApi();
+    useEffect(() => {
+      storeApi = api;
+    }, [api]);
+    return null;
+  }
+
+  function renderWith(tree: readonly BlockNode[]): void {
+    render(
+      <I18nProvider i18n={i18n}>
+        <EditorProvider initialTree={tree}>
+          <CanvasFrame
+            previewUrl="about:blank"
+            origin={ORIGIN}
+            registry={nestRegistry}
+            capabilities={NO_CAPS}
+          />
+          <Capture />
+        </EditorProvider>
+      </I18nProvider>,
+    );
+  }
+
+  // Drives the catalog-drag pointer sequence over a reported slot region. jsdom
+  // gives the iframe a zero origin, so a slot rect at (0,0,500,500) maps 1:1 to
+  // screen and a pointer at (50,50) lands inside it.
+  const dragInto = (parentId: string, slotKey: string): void => {
+    fromCanvas({
+      type: "canvas:geometry",
+      rects: [{ id: parentId, x: 0, y: 0, width: 500, height: 500 }],
+      slots: [{ parentId, slotKey, x: 0, y: 0, width: 500, height: 500 }],
+    });
+    act(() => storeApi?.getState().startBlockDrag(headingSpec));
+    act(() => {
+      window.dispatchEvent(
+        new MouseEvent("pointermove", { clientX: 50, clientY: 50 }),
+      );
+      window.dispatchEvent(
+        new MouseEvent("pointerup", { clientX: 50, clientY: 50 }),
+      );
+    });
+  };
+
+  test("dropping a dragged block into a slot region nests it there", () => {
+    renderWith([{ id: "g1", name: "core/group", attrs: { content: [] } }]);
+
+    dragInto("g1", "content");
+
+    const content = storeApi?.getState().tree[0]?.attrs?.content as
+      | readonly BlockNode[]
+      | undefined;
+    expect(content?.map((n) => n.name)).toEqual(["core/heading"]);
+  });
+
+  test("a slot rejects a block its allowedBlocks does not permit", () => {
+    renderWith([{ id: "b1", name: "core/buttons", attrs: { items: [] } }]);
+
+    dragInto("b1", "items");
+
+    const items = storeApi?.getState().tree[0]?.attrs?.items as
+      | readonly BlockNode[]
+      | undefined;
+    expect(items).toEqual([]);
   });
 });

--- a/packages/admin-editor/src/canvas-frame.tsx
+++ b/packages/admin-editor/src/canvas-frame.tsx
@@ -3,10 +3,15 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Trans } from "@lingui/react";
 
 import type { BlockRegistry } from "@plumix/blocks";
-import type { BlockRect } from "@plumix/blocks/renderer";
+import type { BlockRect, SlotRect } from "@plumix/blocks/renderer";
 
 import type { FrameOffset, OverlayBox } from "./overlay.js";
-import { createBlockFromSpec, groupBlocksByCategory } from "./block-catalog.js";
+import {
+  createBlockFromSpec,
+  groupBlocksByCategory,
+  slotAllowedBlocks,
+} from "./block-catalog.js";
+import { findBlock } from "./block-tree-ops.js";
 import { connectCanvas } from "./connect-canvas.js";
 import { dropPlacement } from "./drop-index.js";
 import { overlayBox } from "./overlay.js";
@@ -32,11 +37,20 @@ const CANVAS_HEIGHT = 800;
 
 interface Geometry {
   readonly rects: ReadonlyMap<string, BlockRect>;
+  /** Container slot regions (iframe coords), for resolving nested drops. */
+  readonly slots: readonly SlotRect[];
   /** The iframe's on-screen offset, for mapping block rects to overlay boxes. */
   readonly frame: FrameOffset | null;
   /** The canvas viewport's on-screen box — overlays clip to this so they never
    *  spill over the side rails (the iframe renders wider than the column). */
   readonly container: OverlayBox | null;
+}
+
+/** A resolved nested-drop target: which slot, and its on-screen box. */
+interface SlotDrop {
+  readonly parentId: string;
+  readonly slotKey: string;
+  readonly box: OverlayBox;
 }
 
 /**
@@ -63,6 +77,7 @@ export function CanvasFrame({
   const containerRef = useRef<HTMLDivElement>(null);
   const [geometry, setGeometry] = useState<Geometry>({
     rects: new Map(),
+    slots: [],
     frame: null,
     container: null,
   });
@@ -70,6 +85,7 @@ export function CanvasFrame({
   // re-subscribing the window listeners on every geometry report.
   const geometryRef = useRef<Geometry>(geometry);
   const [dropY, setDropY] = useState<number | null>(null);
+  const [dropSlot, setDropSlot] = useState<SlotDrop | null>(null);
 
   // The iframe's on-screen offset and the canvas viewport box, read live from
   // the DOM. These move on scroll, window resize, and rail collapse — none of
@@ -93,9 +109,10 @@ export function CanvasFrame({
       store,
       frameWindow,
       origin,
-      onGeometry: (reported) => {
+      onGeometry: (reported, slots) => {
         const next: Geometry = {
           rects: new Map(reported.map((r) => [r.id, r])),
+          slots,
           ...measureHost(),
         };
         geometryRef.current = next;
@@ -156,15 +173,71 @@ export function CanvasFrame({
       return dropPlacement(spans, clientY);
     };
 
+    // The innermost slot under the pointer that accepts the dragged block — a
+    // nested drop target. Innermost (smallest box) wins so a slot inside a slot
+    // is reachable; allowedBlocks gates which slots even light up.
+    const slotTargetAt = (
+      clientX: number,
+      clientY: number,
+    ): SlotDrop | null => {
+      const rect = iframe.getBoundingClientRect();
+      const frame: FrameOffset = { left: rect.left, top: rect.top };
+      const { tree, zoom: z } = store.getState();
+      let best: SlotDrop | null = null;
+      let bestArea = Infinity;
+      for (const slot of geometryRef.current.slots) {
+        const box = overlayBox(slot, frame, z);
+        if (
+          clientX < box.left ||
+          clientX > box.left + box.width ||
+          clientY < box.top ||
+          clientY > box.top + box.height
+        ) {
+          continue;
+        }
+        const parent = findBlock(tree, slot.parentId);
+        if (!parent) continue;
+        const allowed = slotAllowedBlocks(registry, parent.name, slot.slotKey);
+        if (allowed && !allowed.includes(dragSpec.name)) continue;
+        const area = box.width * box.height;
+        if (area < bestArea) {
+          bestArea = area;
+          best = { parentId: slot.parentId, slotKey: slot.slotKey, box };
+        }
+      }
+      return best;
+    };
+
     const onMove = (e: PointerEvent): void => {
-      setDropY(placementAt(e.clientX, e.clientY)?.indicatorY ?? null);
+      const slot = slotTargetAt(e.clientX, e.clientY);
+      setDropSlot(slot);
+      // A nested slot target supersedes the top-level line indicator.
+      setDropY(
+        slot ? null : (placementAt(e.clientX, e.clientY)?.indicatorY ?? null),
+      );
     };
     const onUp = (e: PointerEvent): void => {
-      const placement = placementAt(e.clientX, e.clientY);
-      if (placement) {
-        store
-          .getState()
-          .insertBlock(createBlockFromSpec(dragSpec), placement.index);
+      const node = createBlockFromSpec(dragSpec);
+      const slot = slotTargetAt(e.clientX, e.clientY);
+      if (slot) {
+        const parent = findBlock(store.getState().tree, slot.parentId);
+        const allowed = parent
+          ? slotAllowedBlocks(registry, parent.name, slot.slotKey)
+          : undefined;
+        // Nested drops append to the slot; insertNode clamps the index to the
+        // slot length, so a sentinel lands it at the end without a re-lookup.
+        store.getState().insertBlockInto(
+          node,
+          {
+            parentId: slot.parentId,
+            slotKey: slot.slotKey,
+            index: Number.MAX_SAFE_INTEGER,
+          },
+          allowed,
+        );
+      } else {
+        const placement = placementAt(e.clientX, e.clientY);
+        if (placement) store.getState().insertBlock(node, placement.index);
       }
       store.getState().endBlockDrag();
     };
@@ -186,8 +259,9 @@ export function CanvasFrame({
       window.removeEventListener("keydown", onKey);
       iframe.style.pointerEvents = "";
       setDropY(null);
+      setDropSlot(null);
     };
-  }, [dragSpec, store]);
+  }, [dragSpec, store, registry]);
 
   const addFirstBlock = useCallback((): void => {
     const [group] = groupBlocksByCategory(registry, { capabilities });
@@ -275,6 +349,22 @@ export function CanvasFrame({
             )}
           {overlay(activeId, SELECTED_OUTLINE, "plumix-overlay-selected")}
           {activeBox && <SelectionToolbar box={activeBox} />}
+          {dropSlot && (
+            <div
+              data-testid="plumix-slot-drop-indicator"
+              style={{
+                position: "absolute",
+                left: dropSlot.box.left - container.left,
+                top: dropSlot.box.top - container.top,
+                width: dropSlot.box.width,
+                height: dropSlot.box.height,
+                outline: `2px dashed ${SELECTED_OUTLINE}`,
+                background: "rgba(37,99,235,0.08)",
+                pointerEvents: "none",
+                zIndex: 20,
+              }}
+            />
+          )}
           {dropY !== null && geometry.frame && (
             <div
               data-testid="plumix-drop-indicator"

--- a/packages/admin-editor/src/connect-canvas.ts
+++ b/packages/admin-editor/src/connect-canvas.ts
@@ -2,6 +2,7 @@ import type {
   BlockRect,
   CanvasMessage,
   HostMessage,
+  SlotRect,
 } from "@plumix/blocks/renderer";
 import {
   createHandshake,
@@ -25,8 +26,11 @@ interface ConnectCanvasOptions {
   readonly frameWindow: Window;
   /** Expected origin of the canvas iframe; messages from elsewhere are dropped. */
   readonly origin: string;
-  /** Latest block geometry, for the shell to draw selection/hover overlays. */
-  readonly onGeometry?: (rects: readonly BlockRect[]) => void;
+  /** Latest block + slot geometry, for overlays and nested drop targeting. */
+  readonly onGeometry?: (
+    rects: readonly BlockRect[],
+    slots: readonly SlotRect[],
+  ) => void;
 }
 
 // The iframe runtime usually boots after the parent mounts, so a single hello
@@ -79,7 +83,7 @@ export function connectCanvas({
         store.getState().setHover(canvas.id);
         break;
       case "canvas:geometry":
-        onGeometry?.(canvas.rects);
+        onGeometry?.(canvas.rects, canvas.slots ?? []);
         break;
     }
   };

--- a/packages/admin-editor/src/connect-runtime.ts
+++ b/packages/admin-editor/src/connect-runtime.ts
@@ -3,6 +3,7 @@ import type {
   BlockRect,
   CanvasMessage,
   HostMessage,
+  SlotRect,
 } from "@plumix/blocks/renderer";
 import {
   createHandshake,
@@ -15,7 +16,10 @@ import {
 export interface RuntimeConnection {
   readonly reportSelect: (id: string, additive?: boolean) => void;
   readonly reportHover: (id: string | null) => void;
-  readonly reportGeometry: (rects: readonly BlockRect[]) => void;
+  readonly reportGeometry: (
+    rects: readonly BlockRect[],
+    slots?: readonly SlotRect[],
+  ) => void;
   readonly dispose: () => void;
 }
 
@@ -79,8 +83,8 @@ export function connectRuntime({
       } satisfies CanvasMessage),
     reportHover: (id) =>
       post({ type: "canvas:hover", id } satisfies CanvasMessage),
-    reportGeometry: (rects) =>
-      post({ type: "canvas:geometry", rects } satisfies CanvasMessage),
+    reportGeometry: (rects, slots) =>
+      post({ type: "canvas:geometry", rects, slots } satisfies CanvasMessage),
     dispose: () => window.removeEventListener("message", onMessage),
   };
 }

--- a/packages/admin-editor/src/editor-canvas.test.tsx
+++ b/packages/admin-editor/src/editor-canvas.test.tsx
@@ -85,6 +85,36 @@ describe("EditorCanvas", () => {
     spy.mockRestore();
   });
 
+  test("reports container slot regions for nested drop targeting", () => {
+    const posted: unknown[] = [];
+    const spy = vi
+      .spyOn(window.parent, "postMessage")
+      .mockImplementation((data) => posted.push(data));
+
+    render(<EditorCanvas registry={registry} origin={ORIGIN} />);
+    pushTree([
+      {
+        id: "g1",
+        name: "core/group",
+        attrs: {
+          content: [{ id: "h1", name: "core/heading", attrs: { text: "Hi" } }],
+        },
+      },
+    ]);
+
+    const geometry = posted
+      .map((p) => (p as { message?: { type?: string } }).message)
+      .find((m) => m?.type === "canvas:geometry") as
+      | { slots?: { parentId: string; slotKey: string }[] }
+      | undefined;
+    expect(
+      geometry?.slots?.some(
+        (s) => s.parentId === "g1" && s.slotKey === "content",
+      ),
+    ).toBe(true);
+    spy.mockRestore();
+  });
+
   test("renders an initial tree immediately, before any host push", () => {
     const { container } = render(
       <EditorCanvas

--- a/packages/admin-editor/src/editor-canvas.tsx
+++ b/packages/admin-editor/src/editor-canvas.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 
 import type { BlockNode, BlockRegistry } from "@plumix/blocks";
-import type { BlockRect } from "@plumix/blocks/renderer";
+import type { BlockRect, SlotRect } from "@plumix/blocks/renderer";
 import { renderBlockTree } from "@plumix/blocks";
 import { PlumixProvider } from "@plumix/blocks/renderer";
 
@@ -63,7 +63,22 @@ export function EditorCanvas({
       const r = el.getBoundingClientRect();
       rects.push({ id, x: r.left, y: r.top, width: r.width, height: r.height });
     });
-    connection.reportGeometry(rects);
+    // Slot markers are display:contents (no box of their own), so a slot's drop
+    // region is the union of its direct children's rects — block rows for a
+    // filled slot, the min-height placeholder for an empty one.
+    const slots: SlotRect[] = [];
+    root
+      .querySelectorAll<HTMLElement>("[data-plumix-slot-parent]")
+      .forEach((el) => {
+        const parentId = el.dataset.plumixSlotParent;
+        const slotKey = el.dataset.plumixSlotKey;
+        if (!parentId || slotKey === undefined) return;
+        const region = unionRect(
+          [...el.children].map((c) => c.getBoundingClientRect()),
+        );
+        if (region) slots.push({ parentId, slotKey, ...region });
+      });
+    connection.reportGeometry(rects, slots);
   }, []);
 
   useLayoutEffect(() => {
@@ -107,4 +122,22 @@ export function EditorCanvas({
       </div>
     </PlumixProvider>
   );
+}
+
+// Bounding box covering all rects, or null when there are none.
+function unionRect(
+  rects: readonly DOMRect[],
+): { x: number; y: number; width: number; height: number } | null {
+  if (rects.length === 0) return null;
+  let left = Infinity;
+  let top = Infinity;
+  let right = -Infinity;
+  let bottom = -Infinity;
+  for (const r of rects) {
+    left = Math.min(left, r.left);
+    top = Math.min(top, r.top);
+    right = Math.max(right, r.right);
+    bottom = Math.max(bottom, r.bottom);
+  }
+  return { x: left, y: top, width: right - left, height: bottom - top };
 }

--- a/packages/admin-editor/src/overlay.test.ts
+++ b/packages/admin-editor/src/overlay.test.ts
@@ -6,7 +6,7 @@ describe("overlayBox", () => {
   // Pins the iframe→screen transform — the old Puck zoom-overlay bug lived here.
   test("maps an iframe rect to screen coords by offset and zoom", () => {
     const box = overlayBox(
-      { id: "a", x: 10, y: 20, width: 100, height: 40 },
+      { x: 10, y: 20, width: 100, height: 40 },
       { left: 5, top: 8 },
       0.5,
     );
@@ -16,7 +16,7 @@ describe("overlayBox", () => {
 
   test("at 100% zoom it is the rect shifted by the iframe offset", () => {
     const box = overlayBox(
-      { id: "a", x: 0, y: 0, width: 200, height: 100 },
+      { x: 0, y: 0, width: 200, height: 100 },
       { left: 30, top: 40 },
       1,
     );

--- a/packages/admin-editor/src/overlay.ts
+++ b/packages/admin-editor/src/overlay.ts
@@ -1,5 +1,3 @@
-import type { BlockRect } from "@plumix/blocks/renderer";
-
 export interface FrameOffset {
   readonly left: number;
   readonly top: number;
@@ -13,14 +11,22 @@ export interface OverlayBox {
   readonly height: number;
 }
 
+/** The positional fields shared by a block rect and a slot rect. */
+interface PositionedRect {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+
 /**
- * Map a block rect (iframe's unscaled coordinate space) to a screen-space
+ * Map an iframe-space rect (a block or a slot, unscaled) to a screen-space
  * overlay box, accounting for the iframe's on-screen offset and CSS zoom.
  * Computing in the iframe's own space and scaling here is what keeps the
  * overlay aligned at <100% zoom (the Puck overlay bug computed it scaled).
  */
 export function overlayBox(
-  rect: BlockRect,
+  rect: PositionedRect,
   frame: FrameOffset,
   zoom: number,
 ): OverlayBox {

--- a/packages/admin-editor/src/store.test.ts
+++ b/packages/admin-editor/src/store.test.ts
@@ -207,6 +207,54 @@ describe("undo / redo", () => {
   });
 });
 
+describe("insertBlockInto", () => {
+  const withColumns = (): ReturnType<typeof createEditorStore> =>
+    createEditorStore({
+      tree: [
+        {
+          id: "cols",
+          name: "core/columns",
+          attrs: { left: [{ id: "l", name: "core/x" }], right: [] },
+        },
+      ],
+    });
+
+  test("inserts a new block into a named slot and selects it", () => {
+    const store = withColumns();
+    store.getState().insertBlockInto(
+      { id: "n", name: "core/heading" },
+      {
+        parentId: "cols",
+        slotKey: "right",
+        index: 0,
+      },
+    );
+
+    const right = (store.getState().tree[0]?.attrs?.right as BlockNode[]).map(
+      (n) => n.id,
+    );
+    expect(right).toEqual(["n"]);
+    expect(store.getState().activeId).toBe("n");
+  });
+
+  test("rejects a block the slot does not allow (no-op)", () => {
+    const store = withColumns();
+    const before = store.getState().tree;
+
+    store.getState().insertBlockInto(
+      { id: "n", name: "core/button" },
+      {
+        parentId: "cols",
+        slotKey: "right",
+        index: 0,
+      },
+      ["core/heading"],
+    );
+
+    expect(store.getState().tree).toBe(before);
+  });
+});
+
 describe("removeSelected", () => {
   test("removes every selected block and clears the selection", () => {
     const store = createEditorStore({

--- a/packages/admin-editor/src/store.ts
+++ b/packages/admin-editor/src/store.ts
@@ -8,6 +8,7 @@ import type { History } from "./history.js";
 import {
   duplicateBlock,
   findParentId,
+  insertBlockAt,
   moveBlockBy,
   moveBlock as moveBlockOp,
   removeBlocks,
@@ -49,6 +50,13 @@ export interface EditorActions {
   setTree: (tree: readonly BlockNode[]) => void;
   /** Insert a block at a top-level index (clamped) and select it. */
   insertBlock: (node: BlockNode, index: number) => void;
+  /** Insert a block into a parent's slot (nested), gated by `allowed`, and
+   *  select it. A no-op when the slot is absent or the block isn't allowed. */
+  insertBlockInto: (
+    node: BlockNode,
+    target: MoveTarget,
+    allowed?: readonly string[],
+  ) => void;
   /** Move a block to a new parent + index (reorder / nest / un-nest). */
   moveBlock: (sourceId: string, target: MoveTarget) => void;
   /** Merge a partial attrs patch into one block, anywhere in the tree. */
@@ -139,6 +147,17 @@ export function createEditorStore(
           node,
           ...state.tree.slice(at),
         ];
+        return {
+          tree,
+          activeId: node.id,
+          selectedIds: new Set([node.id]),
+          history: recordHistory(state.history, tree, null),
+        };
+      }),
+    insertBlockInto: (node, target, allowed) =>
+      set((state) => {
+        const tree = insertBlockAt(state.tree, node, target, allowed);
+        if (tree === state.tree) return {};
         return {
           tree,
           activeId: node.id,

--- a/packages/blocks/src/render-block-tree.edit.test.tsx
+++ b/packages/blocks/src/render-block-tree.edit.test.tsx
@@ -3,12 +3,23 @@ import { describe, expect, test } from "vitest";
 
 import type { BlockNode } from "./render-block-tree.js";
 import { createBlockRegistry } from "./block-registry.js";
+import { groupBlock } from "./group/index.js";
 import { headingBlock } from "./heading/index.js";
 import { renderBlockTree } from "./render-block-tree.js";
 
-const registry = createBlockRegistry([headingBlock]);
+const registry = createBlockRegistry([headingBlock, groupBlock]);
 const tree: readonly BlockNode[] = [
   { id: "abc", name: "core/heading", attrs: { text: "Hi", level: 2 } },
+];
+
+const nested: readonly BlockNode[] = [
+  {
+    id: "g1",
+    name: "core/group",
+    attrs: {
+      content: [{ id: "h1", name: "core/heading", attrs: { text: "x" } }],
+    },
+  },
 ];
 
 describe("renderBlockTree edit-aware seam", () => {
@@ -24,5 +35,33 @@ describe("renderBlockTree edit-aware seam", () => {
     const html = renderToStaticMarkup(renderBlockTree(tree, registry));
 
     expect(html).not.toContain("data-plumix-id");
+  });
+
+  test("editing marks each container slot so the canvas can target nested drops", () => {
+    const html = renderToStaticMarkup(
+      renderBlockTree(nested, registry, { editing: true }),
+    );
+
+    expect(html).toContain('data-plumix-slot="g1:content"');
+    // The marker is layout-neutral (display:contents) — the child still renders.
+    expect(html).toContain('data-plumix-id="h1"');
+  });
+
+  test("editing gives an empty slot a droppable placeholder", () => {
+    const empty: readonly BlockNode[] = [
+      { id: "g2", name: "core/group", attrs: { content: [] } },
+    ];
+    const html = renderToStaticMarkup(
+      renderBlockTree(empty, registry, { editing: true }),
+    );
+
+    expect(html).toContain('data-plumix-slot="g2:content"');
+    expect(html).toContain('data-plumix-slot-empty="g2:content"');
+  });
+
+  test("the normal render carries no slot markers", () => {
+    const html = renderToStaticMarkup(renderBlockTree(nested, registry));
+
+    expect(html).not.toContain("data-plumix-slot");
   });
 });

--- a/packages/blocks/src/render-block-tree.edit.test.tsx
+++ b/packages/blocks/src/render-block-tree.edit.test.tsx
@@ -42,7 +42,8 @@ describe("renderBlockTree edit-aware seam", () => {
       renderBlockTree(nested, registry, { editing: true }),
     );
 
-    expect(html).toContain('data-plumix-slot="g1:content"');
+    expect(html).toContain('data-plumix-slot-parent="g1"');
+    expect(html).toContain('data-plumix-slot-key="content"');
     // The marker is layout-neutral (display:contents) — the child still renders.
     expect(html).toContain('data-plumix-id="h1"');
   });
@@ -55,8 +56,8 @@ describe("renderBlockTree edit-aware seam", () => {
       renderBlockTree(empty, registry, { editing: true }),
     );
 
-    expect(html).toContain('data-plumix-slot="g2:content"');
-    expect(html).toContain('data-plumix-slot-empty="g2:content"');
+    expect(html).toContain('data-plumix-slot-parent="g2"');
+    expect(html).toContain("data-plumix-slot-empty");
   });
 
   test("the normal render carries no slot markers", () => {

--- a/packages/blocks/src/render-block-tree.ts
+++ b/packages/blocks/src/render-block-tree.ts
@@ -143,16 +143,36 @@ export function isBlockNodeArray(
 }
 
 function materializeSlots(
-  attrs: Readonly<Record<string, unknown>>,
+  node: BlockNode,
   env: WalkerEnv,
   childContext: BlockContext,
 ): Readonly<Record<string, unknown>> {
+  const attrs = node.attrs ?? {};
   let materialized: Record<string, unknown> | undefined;
   for (const [key, value] of Object.entries(attrs)) {
     if (isBlockNodeArray(value)) {
       materialized ??= { ...attrs };
+      const children = value;
       materialized[key] = function SlotComponent() {
-        return renderNodes(value, env, childContext);
+        const rendered = renderNodes(children, env, childContext);
+        if (!env.editing) return rendered;
+        // Tag the slot so the canvas can resolve a nested drop to it. The
+        // wrapper is display:contents — zero layout impact, the children flow
+        // as if it weren't there. An empty slot gets a min-height placeholder
+        // so it stays a measurable drop target.
+        return createElement(
+          "div",
+          {
+            "data-plumix-slot": `${node.id}:${key}`,
+            style: { display: "contents" },
+          },
+          children.length > 0
+            ? rendered
+            : createElement("div", {
+                "data-plumix-slot-empty": `${node.id}:${key}`,
+                style: { minHeight: "2rem" },
+              }),
+        );
       };
     }
   }
@@ -204,7 +224,7 @@ function renderNode(
     parent: node.name,
     depth: context.depth + 1,
   };
-  const attrs = materializeSlots(node.attrs ?? {}, env, childContext);
+  const attrs = materializeSlots(node, env, childContext);
   const data = loaderData?.get(node.id);
   let rendered: ReactNode;
   if (data && data.error !== null) {

--- a/packages/blocks/src/render-block-tree.ts
+++ b/packages/blocks/src/render-block-tree.ts
@@ -158,18 +158,20 @@ function materializeSlots(
         if (!env.editing) return rendered;
         // Tag the slot so the canvas can resolve a nested drop to it. The
         // wrapper is display:contents — zero layout impact, the children flow
-        // as if it weren't there. An empty slot gets a min-height placeholder
-        // so it stays a measurable drop target.
+        // as if it weren't there. Parent id + slot key are separate attrs (not
+        // one delimited string) so an id never needs charset-escaping. An empty
+        // slot gets a min-height placeholder so it stays a measurable target.
         return createElement(
           "div",
           {
-            "data-plumix-slot": `${node.id}:${key}`,
+            "data-plumix-slot-parent": node.id,
+            "data-plumix-slot-key": key,
             style: { display: "contents" },
           },
           children.length > 0
             ? rendered
             : createElement("div", {
-                "data-plumix-slot-empty": `${node.id}:${key}`,
+                "data-plumix-slot-empty": "",
                 style: { minHeight: "2rem" },
               }),
         );

--- a/packages/blocks/src/renderer/editor-protocol.ts
+++ b/packages/blocks/src/renderer/editor-protocol.ts
@@ -16,6 +16,17 @@ export interface BlockRect {
   readonly height: number;
 }
 
+/** Geometry of one container slot — the drop region for nested inserts, in the
+ *  iframe's unscaled coordinate space. */
+export interface SlotRect {
+  readonly parentId: string;
+  readonly slotKey: string;
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+
 /** Parent (admin shell) → canvas (iframe). */
 export interface HostMessage {
   readonly type: "host:tree";
@@ -32,6 +43,11 @@ export type CanvasMessage =
       readonly additive?: boolean;
     }
   | { readonly type: "canvas:hover"; readonly id: string | null }
-  | { readonly type: "canvas:geometry"; readonly rects: readonly BlockRect[] };
+  | {
+      readonly type: "canvas:geometry";
+      readonly rects: readonly BlockRect[];
+      /** Container slot regions, for resolving a drag to a nested drop target. */
+      readonly slots?: readonly SlotRect[];
+    };
 
 export type EditorBridgeMessage = HostMessage | CanvasMessage;

--- a/packages/blocks/src/renderer/index.tsx
+++ b/packages/blocks/src/renderer/index.tsx
@@ -171,4 +171,5 @@ export type {
   CanvasMessage,
   EditorBridgeMessage,
   HostMessage,
+  SlotRect,
 } from "./editor-protocol.js";


### PR DESCRIPTION
Closes #1112 (PRD #1104).

Brings nested editing to the bespoke editor: blocks at any depth are selectable
(already true via depth-tagged ids), container slots are drop targets, and slot
`allowedBlocks` is enforced.

**Slot-aware pure ops** (`block-tree-ops.ts`): `slotKeys` lists every slot;
`MoveTarget` gains an optional `slotKey` (addresses a named slot, defaults to the
first for back-compat); `moveBlock` and the new `insertBlockAt` take an optional
`allowed` list and no-op a disallowed placement. A shared `slotTargetExists`
guard backs both.

**Edit-seam slot tagging** (`render-block-tree.ts`): in editing mode each slot is
wrapped in a `display:contents` marker carrying `data-plumix-slot-parent` +
`data-plumix-slot-key` (separate attrs, no delimiter to escape), and an empty
slot gets a min-height placeholder so it stays a measurable drop target.
`display:contents` means **non-editing SSR output is byte-for-byte unchanged**.

**Nested drop** (bridge + `editor-canvas` + `canvas-frame`): a `SlotRect` rides
an extended `canvas:geometry`; the iframe reports each slot's region (union of its
children's rects, or the placeholder's). The host resolves a catalog drag to the
innermost slot under the pointer that *accepts* the dragged block — slots whose
`allowedBlocks` rejects it don't light up — draws a slot-scoped indicator, and
nests via the store's `insertBlockInto`. `slotAllowedBlocks` resolves the policy
from the registry.

Worth a look: the slot-region union for nested slots and the innermost-by-area
drop resolution in `canvas-frame.tsx`. The pure ops are unit-tested in isolation
(insert/move/nest/remove/find + allowedBlocks, adversarial cases); the
geometry-dependent drop is covered deterministically by jsdom canvas-frame tests
and by the playground visual e2e (nested selection + slot markers in a real
browser). senpai + code-simplifier reviewed; their two follow-ups (Layers-drag
allowedBlocks parity, within-slot drop index) are filed as separate tasks.