### PR TITLE
feat: drag existing canvas blocks to reorder and nest

### DIFF
--- a/packages/admin-editor/e2e/editor-visual.spec.ts
+++ b/packages/admin-editor/e2e/editor-visual.spec.ts
@@ -77,12 +77,19 @@ test.describe("editor playground", () => {
     const canvas = page.frameLocator(CANVAS_FRAME);
 
     await canvas.locator('[data-plumix-id="heading-1"]').click();
-    await canvas
-      .locator('[data-plumix-id="intro"]')
-      .click({ modifiers: ["Shift"] });
-
-    // intro is now active (strong outline); heading-1 is a non-active member.
+    // Wait for the first selection (and its floating toolbar) to settle before
+    // the additive click.
     await expect(page.getByTestId("plumix-overlay-selected")).toBeVisible();
+
+    // Additive-select a block well clear of heading-1's floating toolbar (which
+    // sits over the top of the canvas) so the shift-click can't land on the
+    // toolbar instead of the block. Hold Shift at the page level for a robust
+    // modifier across the iframe boundary.
+    await page.keyboard.down("Shift");
+    await canvas.locator('[data-plumix-id="col-left"]').click();
+    await page.keyboard.up("Shift");
+
+    // col-left is now active; heading-1 is a non-active member.
     await expect(
       page.getByTestId("plumix-overlay-member-heading-1"),
     ).toBeVisible();
@@ -152,6 +159,102 @@ test.describe("editor playground", () => {
         '[data-plumix-slot-parent="columns-1"][data-plumix-slot-key="left"]',
       ),
     ).toBeAttached();
+  });
+
+  test("dragging the toolbar handle nests a block into a container slot", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const canvas = page.frameLocator(CANVAS_FRAME);
+
+    // heading-1 starts at the top level, outside the group.
+    await expect(
+      canvas.locator(
+        '[data-plumix-slot-parent="group-1"] [data-plumix-id="heading-1"]',
+      ),
+    ).toHaveCount(0);
+
+    await canvas.locator('[data-plumix-id="heading-1"]').click();
+    await expect(page.getByTestId("selection-toolbar-drag")).toBeVisible();
+    const handle = await page
+      .getByTestId("selection-toolbar-drag")
+      .boundingBox();
+    const target = await canvas
+      .locator('[data-plumix-id="group-heading"]')
+      .boundingBox();
+    if (!handle || !target) throw new Error("expected handle + target boxes");
+
+    // Drag the handle (host-side) into the group's slot and release.
+    await page.mouse.move(
+      handle.x + handle.width / 2,
+      handle.y + handle.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      target.x + target.width / 2,
+      target.y + target.height / 2,
+      { steps: 10 },
+    );
+    await page.mouse.up();
+
+    // heading-1 now lives inside the group's content slot.
+    await expect(
+      canvas.locator(
+        '[data-plumix-slot-parent="group-1"] [data-plumix-id="heading-1"]',
+      ),
+    ).toBeAttached();
+  });
+
+  test("dragging the toolbar handle reorders a top-level block", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const canvas = page.frameLocator(CANVAS_FRAME);
+
+    const headingBefore = await canvas
+      .locator('[data-plumix-id="heading-1"]')
+      .boundingBox();
+    const introBefore = await canvas
+      .locator('[data-plumix-id="intro"]')
+      .boundingBox();
+    if (!headingBefore || !introBefore) throw new Error("expected boxes");
+    // heading-1 starts above intro.
+    expect(headingBefore.y).toBeLessThan(introBefore.y);
+
+    await canvas.locator('[data-plumix-id="heading-1"]').click();
+    await expect(page.getByTestId("selection-toolbar-drag")).toBeVisible();
+    const handle = await page
+      .getByTestId("selection-toolbar-drag")
+      .boundingBox();
+    if (!handle) throw new Error("expected handle box");
+
+    // Drag the handle to intro's lower half — a top-level drop after intro,
+    // clear of any container slot.
+    await page.mouse.move(
+      handle.x + handle.width / 2,
+      handle.y + handle.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      introBefore.x + introBefore.width / 2,
+      introBefore.y + introBefore.height * 0.75,
+      { steps: 10 },
+    );
+    await page.mouse.up();
+
+    // heading-1 now sits below intro — and exactly after it (the off-by-one
+    // would drop it further down the tree).
+    await expect
+      .poll(async () => {
+        const h = await canvas
+          .locator('[data-plumix-id="heading-1"]')
+          .boundingBox();
+        const i = await canvas
+          .locator('[data-plumix-id="intro"]')
+          .boundingBox();
+        return h && i ? h.y > i.y : false;
+      })
+      .toBe(true);
   });
 
   test("the Layers tab outlines the nested structure", async ({ page }) => {

--- a/packages/admin-editor/src/canvas-frame.test.tsx
+++ b/packages/admin-editor/src/canvas-frame.test.tsx
@@ -264,4 +264,57 @@ describe("CanvasFrame nested drop", () => {
       | undefined;
     expect(items).toEqual([]);
   });
+
+  // Moving an existing block over a slot, started via the toolbar handle's
+  // startMove (the drag origin is host-side, so jsdom can drive it). Top-level
+  // reorder needs a real iframe rect for the over-gate; that's e2e-covered.
+  const moveInto = (
+    movingId: string,
+    parentId: string,
+    slotKey: string,
+  ): void => {
+    fromCanvas({
+      type: "canvas:geometry",
+      rects: [{ id: parentId, x: 0, y: 0, width: 500, height: 500 }],
+      slots: [{ parentId, slotKey, x: 0, y: 0, width: 500, height: 500 }],
+    });
+    act(() => storeApi?.getState().startMove(movingId));
+    act(() => {
+      window.dispatchEvent(
+        new MouseEvent("pointermove", { clientX: 50, clientY: 50 }),
+      );
+      window.dispatchEvent(
+        new MouseEvent("pointerup", { clientX: 50, clientY: 50 }),
+      );
+    });
+  };
+
+  test("dragging an existing block into a slot nests it there", () => {
+    renderWith([
+      { id: "h", name: "core/heading" },
+      { id: "g", name: "core/group", attrs: { content: [] } },
+    ]);
+
+    moveInto("h", "g", "content");
+
+    const tree = storeApi?.getState().tree ?? [];
+    // h left the top level and now lives in the group's content slot.
+    expect(tree.map((n) => n.id)).toEqual(["g"]);
+    expect(
+      (tree[0]?.attrs?.content as readonly BlockNode[]).map((n) => n.name),
+    ).toEqual(["core/heading"]);
+  });
+
+  test("a move into a disallowed slot is rejected", () => {
+    renderWith([
+      { id: "h", name: "core/heading" },
+      { id: "b1", name: "core/buttons", attrs: { items: [] } },
+    ]);
+
+    moveInto("h", "b1", "items");
+
+    const tree = storeApi?.getState().tree ?? [];
+    expect(tree.map((n) => n.id)).toEqual(["h", "b1"]);
+    expect(tree[1]?.attrs?.items).toEqual([]);
+  });
 });

--- a/packages/admin-editor/src/canvas-frame.tsx
+++ b/packages/admin-editor/src/canvas-frame.tsx
@@ -72,6 +72,7 @@ export function CanvasFrame({
   const selectedIds = useEditorStore((s) => s.selectedIds);
   const hoverId = useEditorStore((s) => s.hoverId);
   const dragSpec = useEditorStore((s) => s.dragSpec);
+  const movingId = useEditorStore((s) => s.movingId);
   const isEmpty = useEditorStore((s) => s.tree.length === 0);
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -146,13 +147,29 @@ export function CanvasFrame({
     };
   }, [measureHost]);
 
-  // Catalog drag → top-level insert. While dragging, the iframe ignores pointer
-  // events so the host keeps receiving them over the canvas; the placement is
-  // computed from the reported block geometry mapped into screen space.
+  // Canvas drag, shared by two sources: a catalog block being inserted
+  // (dragSpec) and an existing block being moved (movingId). While dragging, the
+  // iframe ignores pointer events so the host keeps receiving them; the target
+  // is computed from the reported block + slot geometry mapped into screen space.
   useEffect(() => {
     const iframe = iframeRef.current;
-    if (!dragSpec || !iframe) return;
+    if (!iframe) return;
+    const draggingName =
+      dragSpec?.name ??
+      (movingId ? findBlock(store.getState().tree, movingId)?.name : undefined);
+    if (!draggingName) return;
     iframe.style.pointerEvents = "none";
+
+    const endDrag = (): void => {
+      if (dragSpec) store.getState().endBlockDrag();
+      else store.getState().endMove();
+    };
+    const allowedForSlot = (slot: SlotDrop): readonly string[] | undefined => {
+      const parent = findBlock(store.getState().tree, slot.parentId);
+      return parent
+        ? slotAllowedBlocks(registry, parent.name, slot.slotKey)
+        : undefined;
+    };
 
     const placementAt = (clientX: number, clientY: number) => {
       const rect = iframe.getBoundingClientRect();
@@ -198,7 +215,7 @@ export function CanvasFrame({
         const parent = findBlock(tree, slot.parentId);
         if (!parent) continue;
         const allowed = slotAllowedBlocks(registry, parent.name, slot.slotKey);
-        if (allowed && !allowed.includes(dragSpec.name)) continue;
+        if (allowed && !allowed.includes(draggingName)) continue;
         const area = box.width * box.height;
         if (area < bestArea) {
           bestArea = area;
@@ -217,36 +234,52 @@ export function CanvasFrame({
       );
     };
     const onUp = (e: PointerEvent): void => {
-      const node = createBlockFromSpec(dragSpec);
       const slot = slotTargetAt(e.clientX, e.clientY);
       if (slot) {
-        const parent = findBlock(store.getState().tree, slot.parentId);
-        const allowed = parent
-          ? slotAllowedBlocks(registry, parent.name, slot.slotKey)
-          : undefined;
-        // Nested drops append to the slot; insertNode clamps the index to the
-        // slot length, so a sentinel lands it at the end without a re-lookup.
-        store.getState().insertBlockInto(
-          node,
-          {
-            parentId: slot.parentId,
-            slotKey: slot.slotKey,
-            index: Number.MAX_SAFE_INTEGER,
-          },
-          allowed,
-        );
+        // Nested drops append (a sentinel index that insertNode/moveBlock clamp
+        // to the slot length).
+        const target = {
+          parentId: slot.parentId,
+          slotKey: slot.slotKey,
+          index: Number.MAX_SAFE_INTEGER,
+        };
+        const allowed = allowedForSlot(slot);
+        if (dragSpec) {
+          store
+            .getState()
+            .insertBlockInto(createBlockFromSpec(dragSpec), target, allowed);
+        } else if (movingId) {
+          store.getState().moveBlock(movingId, target, allowed);
+        }
       } else {
         const placement = placementAt(e.clientX, e.clientY);
-        if (placement) store.getState().insertBlock(node, placement.index);
+        if (placement) {
+          if (dragSpec) {
+            store
+              .getState()
+              .insertBlock(createBlockFromSpec(dragSpec), placement.index);
+          } else if (movingId) {
+            // placement.index counts the pre-removal top level; moveBlock
+            // removes the source first, so shift down by one when the source
+            // currently sits before the drop point (a downward reorder).
+            const top = store.getState().tree;
+            const from = top.findIndex((n) => n.id === movingId);
+            const index =
+              from !== -1 && from < placement.index
+                ? placement.index - 1
+                : placement.index;
+            store.getState().moveBlock(movingId, { parentId: null, index });
+          }
+        }
       }
-      store.getState().endBlockDrag();
+      endDrag();
     };
     // Without this, a pointercancel (touch interruption, context menu, drag
-    // into a native element) or Escape would skip onUp, stranding dragSpec set
+    // into a native element) or Escape would skip onUp, stranding the drag set
     // and the iframe permanently non-interactive (pointerEvents: none).
-    const onCancel = (): void => store.getState().endBlockDrag();
+    const onCancel = (): void => endDrag();
     const onKey = (e: KeyboardEvent): void => {
-      if (e.key === "Escape") store.getState().endBlockDrag();
+      if (e.key === "Escape") endDrag();
     };
     window.addEventListener("pointermove", onMove);
     window.addEventListener("pointerup", onUp);
@@ -261,7 +294,7 @@ export function CanvasFrame({
       setDropY(null);
       setDropSlot(null);
     };
-  }, [dragSpec, store, registry]);
+  }, [dragSpec, movingId, store, registry]);
 
   const addFirstBlock = useCallback((): void => {
     const [group] = groupBlocksByCategory(registry, { capabilities });

--- a/packages/admin-editor/src/selection-toolbar.test.tsx
+++ b/packages/admin-editor/src/selection-toolbar.test.tsx
@@ -105,6 +105,23 @@ describe("SelectionToolbar", () => {
     expect(storeApi?.getState().activeId).toBe("g");
   });
 
+  test("the drag handle begins moving the active block", () => {
+    const { getByTestId } = renderToolbar([
+      { id: "a", name: "core/x" },
+      { id: "b", name: "core/x" },
+    ]);
+    act(() => storeApi?.getState().select("a"));
+
+    // jsdom lacks a PointerEvent ctor; dispatch a typed MouseEvent the React
+    // onPointerDown listener still fires on.
+    fireEvent(
+      getByTestId("selection-toolbar-drag"),
+      new MouseEvent("pointerdown", { bubbles: true }),
+    );
+
+    expect(storeApi?.getState().movingId).toBe("a");
+  });
+
   test("shows a count when several blocks are selected", () => {
     const { getByTestId, queryByTestId } = renderToolbar([
       { id: "a", name: "core/x" },

--- a/packages/admin-editor/src/selection-toolbar.tsx
+++ b/packages/admin-editor/src/selection-toolbar.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from "react";
 import { Trans } from "@lingui/react";
 
 import { Button } from "@plumix/admin-ui/button";
+import { GripVertical } from "@plumix/admin-ui/icons";
 
 import type { OverlayBox } from "./overlay.js";
 import { findParentId } from "./block-tree-ops.js";
@@ -51,6 +52,23 @@ export function SelectionToolbar({
         zIndex: 30,
       }}
     >
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        data-testid="selection-toolbar-drag"
+        aria-label="Drag to move"
+        disabled={multi}
+        // Pointerdown (not click) starts the move; preventDefault stops the
+        // browser's text-selection drag from hijacking it.
+        onPointerDown={(e) => {
+          e.preventDefault();
+          state.startMove(activeId);
+        }}
+        className="cursor-grab active:cursor-grabbing"
+      >
+        <GripVertical className="size-4" />
+      </Button>
       {selectedCount > 1 ? (
         <span
           data-testid="selection-toolbar-count"

--- a/packages/admin-editor/src/store.test.ts
+++ b/packages/admin-editor/src/store.test.ts
@@ -420,4 +420,30 @@ describe("moveBlock action", () => {
 
     expect(store.getState().tree.map((n) => n.id)).toEqual(["b", "a"]);
   });
+
+  test("honors an allowedBlocks list, rejecting a disallowed nest", () => {
+    const tree: readonly BlockNode[] = [
+      { id: "btn", name: "core/button" },
+      { id: "g", name: "core/group", attrs: { content: [] } },
+    ];
+    const store = createEditorStore({ tree });
+
+    store
+      .getState()
+      .moveBlock("btn", { parentId: "g", index: 0 }, ["core/heading"]);
+
+    expect(store.getState().tree).toBe(tree);
+  });
+});
+
+describe("move drag", () => {
+  test("startMove marks the moving block; endMove clears it", () => {
+    const store = createEditorStore();
+
+    store.getState().startMove("a");
+    expect(store.getState().movingId).toBe("a");
+
+    store.getState().endMove();
+    expect(store.getState().movingId).toBeNull();
+  });
 });

--- a/packages/admin-editor/src/store.ts
+++ b/packages/admin-editor/src/store.ts
@@ -42,6 +42,8 @@ export interface EditorState {
   readonly zoom: number;
   /** The catalog block currently being dragged toward the canvas, if any. */
   readonly dragSpec: BlockSpec | null;
+  /** The existing block being dragged to a new position on the canvas, if any. */
+  readonly movingId: string | null;
   /** Snapshot history of the tree, driving undo/redo. */
   readonly history: TreeHistory;
 }
@@ -57,8 +59,13 @@ export interface EditorActions {
     target: MoveTarget,
     allowed?: readonly string[],
   ) => void;
-  /** Move a block to a new parent + index (reorder / nest / un-nest). */
-  moveBlock: (sourceId: string, target: MoveTarget) => void;
+  /** Move a block to a new parent + slot + index (reorder / nest / un-nest),
+   *  gated by an optional `allowed` (the target slot's allowedBlocks). */
+  moveBlock: (
+    sourceId: string,
+    target: MoveTarget,
+    allowed?: readonly string[],
+  ) => void;
   /** Merge a partial attrs patch into one block, anywhere in the tree. */
   updateBlockAttrs: (
     id: string,
@@ -79,6 +86,9 @@ export interface EditorActions {
   setZoom: (zoom: number) => void;
   startBlockDrag: (spec: BlockSpec) => void;
   endBlockDrag: () => void;
+  /** Begin / end dragging an existing block to a new canvas position. */
+  startMove: (id: string) => void;
+  endMove: () => void;
   /** Restore the previous / next tree snapshot. */
   undo: () => void;
   redo: () => void;
@@ -134,6 +144,7 @@ export function createEditorStore(
     device: initial?.device ?? "desktop",
     zoom: initial?.zoom ?? 1,
     dragSpec: null,
+    movingId: null,
     history: initHistory(initial?.tree ?? []),
 
     // Raw seed/programmatic setter — intentionally does not record history
@@ -165,9 +176,9 @@ export function createEditorStore(
           history: recordHistory(state.history, tree, null),
         };
       }),
-    moveBlock: (sourceId, target) =>
+    moveBlock: (sourceId, target, allowed) =>
       set((state) => {
-        const tree = moveBlockOp(state.tree, sourceId, target);
+        const tree = moveBlockOp(state.tree, sourceId, target, allowed);
         if (tree === state.tree) return {};
         return { tree, history: recordHistory(state.history, tree, null) };
       }),
@@ -248,6 +259,8 @@ export function createEditorStore(
       set({ zoom: Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoom)) }),
     startBlockDrag: (dragSpec) => set({ dragSpec }),
     endBlockDrag: () => set({ dragSpec: null }),
+    startMove: (movingId) => set({ movingId }),
+    endMove: () => set({ movingId: null }),
     undo: () =>
       set((state) => {
         const history = undo(state.history);


### PR DESCRIPTION
Closes #1118 (PRD #1104).

Lets authors drag an existing block on the canvas to reorder it among its
siblings or nest it into a container slot — building on #1112's slot resolution.

A drag handle on the floating selection toolbar starts the move (`startMove` →
`movingId`); the drag originates host-side (the toolbar is a host overlay), so
there's no fragile cross-iframe pointer handoff. The canvas drag effect — already
driving catalog inserts — is generalized: the same `placementAt` / `slotTargetAt`
resolution feeds either an insert (catalog `dragSpec`) or a move (`moveBlock`,
now taking the slot's `allowedBlocks`). Disallowed slots don't light up; moving a
block into its own descendant is rejected by `moveBlock`'s existing guard; moves
persist through the same `onChange` path as every other edit.

Note the top-level reorder index fix: `moveBlock` removes the source before
inserting, so a downward top-level drop's pre-removal index is shifted down by
one at the call site (the op's post-removal convention is what `moveBlockBy`
relies on, so the fix lives in the canvas, not the op).

Coverage: store + toolbar-handle unit tests; jsdom canvas-frame tests for the
nest + allowedBlocks-reject paths; playground visual e2e drives a real mouse drag
of the handle for both nesting and top-level reorder (the latter guards the
off-by-one). senpai + code-simplifier reviewed.