### PR TITLE
feat: surface patterns and variations in the editor inserter

### DIFF
--- a/packages/admin-editor/e2e/editor-visual.spec.ts
+++ b/packages/admin-editor/e2e/editor-visual.spec.ts
@@ -257,6 +257,42 @@ test.describe("editor playground", () => {
       .toBe(true);
   });
 
+  test("the Blocks tab lists variations and a patterns section", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    // The augmented core/group surfaces its inserter variation in place of the
+    // bare block; the seeded pattern shows under the patterns group.
+    await expect(
+      page.getByTestId("block-catalog-item-core/group/group/two-column"),
+    ).toBeVisible();
+    await expect(page.getByTestId("block-catalog-patterns")).toBeVisible();
+    await expect(
+      page.getByTestId("block-catalog-pattern-starter/hero"),
+    ).toBeVisible();
+  });
+
+  test("the + Add Block popover opens the same catalog and inserts a pattern", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const canvas = page.frameLocator(CANVAS_FRAME);
+    const blocks = canvas.locator("[data-plumix-id]");
+    const before = await blocks.count();
+
+    // AC4: the toolbar's inline inserter opens the catalog in a popover.
+    await page.getByTestId("plumix-add-block").click();
+    const popover = page.getByTestId("plumix-add-block-popover");
+    await expect(popover.getByTestId("block-catalog")).toBeVisible();
+
+    // Inserting the hero pattern splices its whole two-block composition in one
+    // step and closes the popover.
+    await popover.getByTestId("block-catalog-pattern-starter/hero").click();
+    await expect(blocks).toHaveCount(before + 2);
+    await expect(popover).toBeHidden();
+  });
+
   test("the Layers tab outlines the nested structure", async ({ page }) => {
     await page.goto("/");
 

--- a/packages/admin-editor/locales/ar.po
+++ b/packages/admin-editor/locales/ar.po
@@ -24,6 +24,11 @@ msgid "editor.canvas.addBlock"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/block-inserter.tsx
+msgid "editor.toolbar.addBlock"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/json-inspector.tsx
 msgid "editor.json.block"
 msgstr ""
@@ -96,6 +101,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.page"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/block-catalog-tab.tsx
+msgid "editor.catalog.patterns"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/de.po
+++ b/packages/admin-editor/locales/de.po
@@ -24,6 +24,11 @@ msgid "editor.canvas.addBlock"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/block-inserter.tsx
+msgid "editor.toolbar.addBlock"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/json-inspector.tsx
 msgid "editor.json.block"
 msgstr ""
@@ -96,6 +101,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.page"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/block-catalog-tab.tsx
+msgid "editor.catalog.patterns"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/en.po
+++ b/packages/admin-editor/locales/en.po
@@ -24,6 +24,11 @@ msgid "editor.canvas.addBlock"
 msgstr "Add a block"
 
 #. js-lingui-explicit-id
+#: src/block-inserter.tsx
+msgid "editor.toolbar.addBlock"
+msgstr "Add Block"
+
+#. js-lingui-explicit-id
 #: src/json-inspector.tsx
 msgid "editor.json.block"
 msgstr "Block"
@@ -97,6 +102,11 @@ msgstr "Page"
 #: src/plumix-editor.tsx
 msgid "editor.tab.page"
 msgstr "Page"
+
+#. js-lingui-explicit-id
+#: src/block-catalog-tab.tsx
+msgid "editor.catalog.patterns"
+msgstr "Patterns"
 
 #. js-lingui-explicit-id
 #: src/editor-toolbar.tsx

--- a/packages/admin-editor/locales/uk.po
+++ b/packages/admin-editor/locales/uk.po
@@ -24,6 +24,11 @@ msgid "editor.canvas.addBlock"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/block-inserter.tsx
+msgid "editor.toolbar.addBlock"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/json-inspector.tsx
 msgid "editor.json.block"
 msgstr ""
@@ -96,6 +101,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.page"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/block-catalog-tab.tsx
+msgid "editor.catalog.patterns"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/zh-CN.po
+++ b/packages/admin-editor/locales/zh-CN.po
@@ -24,6 +24,11 @@ msgid "editor.canvas.addBlock"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/block-inserter.tsx
+msgid "editor.toolbar.addBlock"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/json-inspector.tsx
 msgid "editor.json.block"
 msgstr ""
@@ -96,6 +101,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.page"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/block-catalog-tab.tsx
+msgid "editor.catalog.patterns"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/playground/host.tsx
+++ b/packages/admin-editor/playground/host.tsx
@@ -5,6 +5,7 @@ import { i18n } from "@lingui/core";
 import { I18nProvider } from "@lingui/react";
 import { createRoot } from "react-dom/client";
 
+import type { BlockSpec } from "@plumix/blocks";
 import {
   coreBlocks,
   createBlockRegistry,
@@ -12,7 +13,7 @@ import {
 } from "@plumix/blocks";
 
 import { PlumixEditor } from "../src/plumix-editor.js";
-import { SEED_BLOCKS } from "./seed.js";
+import { SEED_BLOCKS, SEED_PATTERNS } from "./seed.js";
 
 import "./playground.css";
 
@@ -27,7 +28,25 @@ const CATALOGS = import.meta.glob<{ messages: Messages }>("../locales/*.mjs", {
 i18n.load("en", CATALOGS["../locales/en.mjs"]?.messages ?? {});
 i18n.activate("en");
 
-const registry = createBlockRegistry(coreBlocks);
+// Core blocks ship no variations, so augment core/group with an inserter
+// variation here — the harness needs one to exercise the catalog's
+// blocks-plus-variations rendering.
+const withVariations = coreBlocks.map(
+  (spec): BlockSpec =>
+    spec.name === "core/group"
+      ? {
+          ...spec,
+          variations: [
+            {
+              slug: "group/two-column",
+              title: "Two-column group",
+              attrs: { layout: "row" },
+            },
+          ],
+        }
+      : spec,
+);
+const registry = createBlockRegistry(withVariations);
 
 function DocumentPanelStub(): ReactElement {
   return (
@@ -54,6 +73,7 @@ if (root) {
           registry={registry}
           defaultValue={defineEntryContent(SEED_BLOCKS)}
           capabilities={new Set()}
+          patterns={SEED_PATTERNS}
           documentPanel={<DocumentPanelStub />}
           publish={{
             onPublish: () => console.info("[playground] publish"),

--- a/packages/admin-editor/playground/seed.ts
+++ b/packages/admin-editor/playground/seed.ts
@@ -1,5 +1,7 @@
 import type { BlockNode } from "@plumix/blocks";
 
+import type { InserterPattern } from "../src/block-catalog.js";
+
 /**
  * A representative tree for the playground: top-level blocks plus nested and
  * multi-slot containers (group, columns, buttons) so selection, the floating
@@ -70,5 +72,30 @@ export const SEED_BLOCKS: readonly BlockNode[] = [
         },
       ],
     },
+  },
+];
+
+/**
+ * Inserter patterns for the harness — a multi-block "Hero" composition the
+ * catalog can splice in one click, so the patterns section (and its top-level
+ * insert) has something real to exercise without a manifest.
+ */
+export const SEED_PATTERNS: readonly InserterPattern[] = [
+  {
+    name: "starter/hero",
+    title: "Hero section",
+    keywords: ["banner", "intro"],
+    content: [
+      {
+        id: "hero-heading",
+        name: "core/heading",
+        attrs: { level: 1, text: "Build anything" },
+      },
+      {
+        id: "hero-text",
+        name: "core/rich-text",
+        attrs: { body: "<p>A two-block hero, inserted as one pattern.</p>" },
+      },
+    ],
   },
 ];

--- a/packages/admin-editor/src/block-catalog-tab.test.tsx
+++ b/packages/admin-editor/src/block-catalog-tab.test.tsx
@@ -2,8 +2,9 @@ import type { ReactElement } from "react";
 import { i18n } from "@lingui/core";
 import { I18nProvider } from "@lingui/react";
 import { cleanup, fireEvent, render } from "@testing-library/react";
-import { afterEach, beforeAll, describe, expect, test } from "vitest";
+import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
 
+import type { BlockPattern } from "@plumix/blocks";
 import { createBlockRegistry } from "@plumix/blocks";
 
 import { BlockCatalog } from "./block-catalog-tab.js";
@@ -24,6 +25,15 @@ const registry = createBlockRegistry([
   },
   { name: "core/quote", render: () => null, category: "text", title: "Quote" },
   { name: "core/image", render: () => null, category: "media", title: "Image" },
+  {
+    name: "core/group",
+    render: () => null,
+    category: "layout",
+    title: "Group",
+    variations: [
+      { slug: "group/two-col", title: "Two columns", attrs: { cols: 2 } },
+    ],
+  },
 ]);
 
 const NO_CAPS: ReadonlySet<string> = new Set();
@@ -33,11 +43,19 @@ function TreeProbe(): ReactElement {
   return <output data-testid="tree-probe">{ids}</output>;
 }
 
-function renderCatalog(): ReturnType<typeof render> {
+function renderCatalog(
+  patterns?: readonly BlockPattern[],
+  onInsert?: () => void,
+): ReturnType<typeof render> {
   return render(
     <I18nProvider i18n={i18n}>
       <EditorProvider initialTree={[]}>
-        <BlockCatalog registry={registry} capabilities={NO_CAPS} />
+        <BlockCatalog
+          registry={registry}
+          capabilities={NO_CAPS}
+          patterns={patterns}
+          onInsert={onInsert}
+        />
         <TreeProbe />
       </EditorProvider>
     </I18nProvider>,
@@ -80,5 +98,77 @@ describe("BlockCatalog", () => {
     expect(getByTestId("tree-probe").textContent).toBe(
       "core/heading,core/image",
     );
+  });
+
+  test("fires onInsert after a click-insert (block, variation or pattern)", () => {
+    const onInsert = vi.fn();
+    const patterns: readonly BlockPattern[] = [
+      { name: "hero", title: "Hero", content: [] },
+    ];
+    const { getByTestId } = renderCatalog(patterns, onInsert);
+    fireEvent.click(getByTestId("block-catalog-item-core/heading"));
+    fireEvent.click(getByTestId("block-catalog-item-core/group/group/two-col"));
+    fireEvent.click(getByTestId("block-catalog-pattern-hero"));
+    expect(onInsert).toHaveBeenCalledTimes(3);
+  });
+
+  test("lists block variations as their own items, keyed by slug", () => {
+    const { getByTestId, queryByTestId } = renderCatalog();
+    // A block with an inserter variation surfaces the variation in place of
+    // its bare self.
+    expect(
+      getByTestId("block-catalog-item-core/group/group/two-col"),
+    ).toBeDefined();
+    expect(queryByTestId("block-catalog-item-core/group")).toBeNull();
+    expect(getByTestId("block-catalog-group-layout")).toBeDefined();
+  });
+
+  test("clicking a variation appends its parent block", () => {
+    const { getByTestId } = renderCatalog();
+    fireEvent.click(getByTestId("block-catalog-item-core/group/group/two-col"));
+    expect(getByTestId("tree-probe").textContent).toBe("core/group");
+  });
+
+  describe("patterns", () => {
+    const patterns: readonly BlockPattern[] = [
+      {
+        name: "hero",
+        title: "Hero banner",
+        content: [
+          { id: "p1", name: "core/heading" },
+          { id: "p2", name: "core/quote" },
+        ],
+      },
+      { name: "cta", title: "Call to action", content: [] },
+    ];
+
+    test("renders a patterns section listing each pattern", () => {
+      const { getByTestId } = renderCatalog(patterns);
+      expect(getByTestId("block-catalog-patterns")).toBeDefined();
+      expect(getByTestId("block-catalog-pattern-hero")).toBeDefined();
+      expect(getByTestId("block-catalog-pattern-cta")).toBeDefined();
+    });
+
+    test("omits the patterns section when there are none", () => {
+      const { queryByTestId } = renderCatalog();
+      expect(queryByTestId("block-catalog-patterns")).toBeNull();
+    });
+
+    test("clicking a pattern appends its whole composition", () => {
+      const { getByTestId } = renderCatalog(patterns);
+      fireEvent.click(getByTestId("block-catalog-pattern-hero"));
+      expect(getByTestId("tree-probe").textContent).toBe(
+        "core/heading,core/quote",
+      );
+    });
+
+    test("search filters patterns alongside blocks", () => {
+      const { getByTestId, queryByTestId } = renderCatalog(patterns);
+      fireEvent.change(getByTestId("block-catalog-search"), {
+        target: { value: "hero" },
+      });
+      expect(getByTestId("block-catalog-pattern-hero")).toBeDefined();
+      expect(queryByTestId("block-catalog-pattern-cta")).toBeNull();
+    });
   });
 });

--- a/packages/admin-editor/src/block-catalog-tab.tsx
+++ b/packages/admin-editor/src/block-catalog-tab.tsx
@@ -1,91 +1,151 @@
 import type { ReactElement } from "react";
-import { useId, useMemo, useState } from "react";
-import { Trans, useLingui } from "@lingui/react";
+import { useMemo, useState } from "react";
+import { useLingui } from "@lingui/react";
 
-import type { BlockRegistry } from "@plumix/blocks";
-import { Input } from "@plumix/admin-ui/input";
+import type {
+  BlockNode,
+  BlockRegistry,
+  InsertableBlockEntry,
+} from "@plumix/blocks";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@plumix/admin-ui/command";
 import { resolveLabel } from "@plumix/core/i18n";
 
-import { createBlockFromSpec, groupBlocksByCategory } from "./block-catalog.js";
+import type { InserterPattern } from "./block-catalog.js";
+import {
+  createNodeFromEntry,
+  expandPattern,
+  filterPatterns,
+  groupInsertables,
+} from "./block-catalog.js";
 import { useEditorStore } from "./provider.js";
 
 interface BlockCatalogProps {
   readonly registry: BlockRegistry;
   readonly capabilities: ReadonlySet<string>;
+  /** Theme + plugin patterns offered alongside the blocks (click-insert). */
+  readonly patterns?: readonly InserterPattern[];
+  /** Called after any click-insert, so a host popover can close itself. */
+  readonly onInsert?: () => void;
 }
 
 /**
- * Left-rail block inserter: a searchable catalog grouped by category. Clicking
- * a block appends it; pressing on one starts a drag the canvas resolves to a
- * positional drop. Both paths go through the store's insert/drag actions, so
- * the live patch loop renders and persists the result.
+ * Left-rail inserter built on shadcn's Command: a searchable list of blocks
+ * (and their inserter variations) grouped by category, plus a patterns group.
+ * Selecting a block appends it; pressing on one starts a drag the canvas
+ * resolves to a positional drop. Patterns are click-insert only (their whole
+ * composition appends). Filtering is ours (capabilities + variation expansion),
+ * so Command runs with `shouldFilter={false}`.
  */
 export function BlockCatalog({
   registry,
   capabilities,
+  patterns,
+  onInsert,
 }: BlockCatalogProps): ReactElement {
   const { i18n } = useLingui();
-  const searchId = useId();
   const [query, setQuery] = useState("");
   const insertBlock = useEditorStore((s) => s.insertBlock);
+  const insertBlocks = useEditorStore((s) => s.insertBlocks);
   const startBlockDrag = useEditorStore((s) => s.startBlockDrag);
   const treeLength = useEditorStore((s) => s.tree.length);
 
   const groups = useMemo(
-    () => groupBlocksByCategory(registry, { capabilities, query }),
+    () => groupInsertables(registry, { capabilities, query }),
     [registry, capabilities, query],
   );
+  const matchedPatterns = useMemo(
+    () => filterPatterns(patterns ?? [], query),
+    [patterns, query],
+  );
+
+  const insertEntry = (node: BlockNode): void => {
+    insertBlock(node, treeLength);
+    onInsert?.();
+  };
+  const insertPattern = (nodes: readonly BlockNode[]): void => {
+    insertBlocks(nodes, treeLength);
+    onInsert?.();
+  };
 
   return (
-    <div className="flex flex-col gap-3 p-3" data-testid="block-catalog">
-      <label htmlFor={searchId} className="sr-only">
-        <Trans id="editor.catalog.searchLabel" message="Search blocks" />
-      </label>
-      <Input
-        id={searchId}
-        type="search"
+    <Command
+      shouldFilter={false}
+      className="bg-transparent"
+      data-testid="block-catalog"
+    >
+      <CommandInput
         value={query}
-        onChange={(e) => setQuery(e.target.value)}
+        onValueChange={setQuery}
+        aria-label={i18n._({
+          id: "editor.catalog.searchLabel",
+          message: "Search blocks",
+        })}
         data-testid="block-catalog-search"
       />
-      {groups.length === 0 ? (
-        <p
-          className="text-muted-foreground text-sm"
-          data-testid="block-catalog-empty"
-        >
-          <Trans
-            id="editor.catalog.noResults"
-            message="No blocks match your search."
-          />
-        </p>
-      ) : (
-        groups.map((group) => (
-          <section
+      <CommandList className="max-h-none">
+        <CommandEmpty data-testid="block-catalog-empty">
+          {i18n._({
+            id: "editor.catalog.noResults",
+            message: "No blocks match your search.",
+          })}
+        </CommandEmpty>
+        {groups.map((group) => (
+          <CommandGroup
             key={group.category}
+            heading={group.category}
             data-testid={`block-catalog-group-${group.category}`}
           >
-            <h3 className="text-muted-foreground mb-1 text-xs font-medium tracking-wide uppercase">
-              {group.category}
-            </h3>
-            <div className="grid grid-cols-2 gap-2">
-              {group.blocks.map((spec) => (
-                <button
-                  key={spec.name}
-                  type="button"
-                  data-testid={`block-catalog-item-${spec.name}`}
-                  className="border-input hover:bg-accent rounded-md border p-2 text-start text-sm"
-                  onPointerDown={() => startBlockDrag(spec)}
-                  onClick={() =>
-                    insertBlock(createBlockFromSpec(spec), treeLength)
-                  }
-                >
-                  {resolveLabel(spec.title ?? spec.name, i18n)}
-                </button>
-              ))}
-            </div>
-          </section>
-        ))
-      )}
-    </div>
+            {group.entries.map((entry) => (
+              <CommandItem
+                key={entryKey(entry)}
+                value={entryKey(entry)}
+                data-testid={`block-catalog-item-${entryKey(entry)}`}
+                onPointerDown={() => startBlockDrag(entry)}
+                onSelect={() =>
+                  insertEntry(createNodeFromEntry(registry, entry))
+                }
+              >
+                {resolveLabel(entry.title, i18n)}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        ))}
+        {matchedPatterns.length > 0 && (
+          <CommandGroup
+            heading={i18n._({
+              id: "editor.catalog.patterns",
+              message: "Patterns",
+            })}
+            data-testid="block-catalog-patterns"
+          >
+            {matchedPatterns.map((pattern) => (
+              <CommandItem
+                key={pattern.name}
+                value={`pattern:${pattern.name}`}
+                data-testid={`block-catalog-pattern-${pattern.name}`}
+                onSelect={() => insertPattern(expandPattern(pattern))}
+              >
+                {resolveLabel(pattern.title, i18n)}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+      </CommandList>
+    </Command>
   );
+}
+
+// A stable, collision-free identity for an inserter entry. Variation slugs are
+// only unique per parent block (two blocks can both declare `default`), so a
+// variation is qualified by its parent name; a bare block (slug === name) keeps
+// its name as-is.
+function entryKey(entry: InsertableBlockEntry): string {
+  return entry.slug === entry.name ? entry.slug : `${entry.name}/${entry.slug}`;
 }

--- a/packages/admin-editor/src/block-catalog.test.ts
+++ b/packages/admin-editor/src/block-catalog.test.ts
@@ -4,11 +4,9 @@ import type { BlockNode, BlockPattern, BlockSpec } from "@plumix/blocks";
 import { createBlockRegistry } from "@plumix/blocks";
 
 import {
-  createBlockFromSpec,
   createNodeFromEntry,
   expandPattern,
   filterPatterns,
-  groupBlocksByCategory,
   groupInsertables,
   slotAllowedBlocks,
 } from "./block-catalog.js";
@@ -57,94 +55,6 @@ describe("slotAllowedBlocks", () => {
   });
 });
 
-describe("groupBlocksByCategory", () => {
-  test("groups eligible blocks by category in first-seen order", () => {
-    const registry = createBlockRegistry([
-      spec({ name: "core/heading", category: "text", title: "Heading" }),
-      spec({ name: "core/image", category: "media", title: "Image" }),
-      spec({ name: "core/quote", category: "text", title: "Quote" }),
-    ]);
-
-    const groups = groupBlocksByCategory(registry, { capabilities: NO_CAPS });
-
-    expect(groups.map((g) => g.category)).toEqual(["text", "media"]);
-    expect(groups[0]?.blocks.map((b) => b.name)).toEqual([
-      "core/heading",
-      "core/quote",
-    ]);
-  });
-
-  test("falls back to 'uncategorized' for specs without a category", () => {
-    const registry = createBlockRegistry([spec({ name: "core/x" })]);
-
-    const groups = groupBlocksByCategory(registry, { capabilities: NO_CAPS });
-
-    expect(groups[0]?.category).toBe("uncategorized");
-  });
-
-  test("excludes blocks with inserter:false", () => {
-    const registry = createBlockRegistry([
-      spec({ name: "core/heading", category: "text" }),
-      spec({ name: "core/internal", category: "text", inserter: false }),
-    ]);
-
-    const groups = groupBlocksByCategory(registry, { capabilities: NO_CAPS });
-
-    expect(groups[0]?.blocks.map((b) => b.name)).toEqual(["core/heading"]);
-  });
-
-  test("excludes capability-gated blocks the viewer lacks", () => {
-    const registry = createBlockRegistry([
-      spec({ name: "core/public", category: "text" }),
-      spec({
-        name: "core/secret",
-        category: "text",
-        capability: "blocks:secret",
-      }),
-    ]);
-
-    const lacking = groupBlocksByCategory(registry, { capabilities: NO_CAPS });
-    expect(lacking[0]?.blocks.map((b) => b.name)).toEqual(["core/public"]);
-
-    const granted = groupBlocksByCategory(registry, {
-      capabilities: new Set(["blocks:secret"]),
-    });
-    expect(granted[0]?.blocks.map((b) => b.name)).toEqual([
-      "core/public",
-      "core/secret",
-    ]);
-  });
-
-  test("filters by query against title, name and keywords; drops empty groups", () => {
-    const registry = createBlockRegistry([
-      spec({ name: "core/heading", category: "text", title: "Heading" }),
-      spec({
-        name: "core/quote",
-        category: "text",
-        title: "Quote",
-        keywords: ["citation"],
-      }),
-      spec({ name: "core/image", category: "media", title: "Image" }),
-    ]);
-
-    // Title match.
-    expect(
-      groupBlocksByCategory(registry, {
-        capabilities: NO_CAPS,
-        query: "head",
-      }).flatMap((g) => g.blocks.map((b) => b.name)),
-    ).toEqual(["core/heading"]);
-
-    // Keyword match — the media group is dropped (no matches).
-    const byKeyword = groupBlocksByCategory(registry, {
-      capabilities: NO_CAPS,
-      query: "citation",
-    });
-    expect(byKeyword.map((g) => g.category)).toEqual(["text"]);
-    expect(byKeyword[0]?.blocks.map((b) => b.name)).toEqual(["core/quote"]);
-  });
-});
-
 describe("groupInsertables", () => {
   test("includes blocks and their inserter variations, grouped by category", () => {
     const registry = createBlockRegistry([
@@ -180,6 +90,24 @@ describe("groupInsertables", () => {
       query: "head",
     }).flatMap((g) => g.entries.map((e) => e.slug));
     expect(slugs).toEqual(["core/heading"]);
+  });
+
+  test("falls back to 'uncategorized' for specs without a category", () => {
+    const registry = createBlockRegistry([spec({ name: "core/x" })]);
+    expect(
+      groupInsertables(registry, { capabilities: NO_CAPS })[0]?.category,
+    ).toBe("uncategorized");
+  });
+
+  test("admits capability-gated blocks once the viewer holds the capability", () => {
+    const registry = createBlockRegistry([
+      spec({ name: "core/secret", category: "text", capability: "x" }),
+    ]);
+    expect(
+      groupInsertables(registry, {
+        capabilities: new Set(["x"]),
+      }).flatMap((g) => g.entries.map((e) => e.slug)),
+    ).toEqual(["core/secret"]);
   });
 });
 
@@ -231,6 +159,15 @@ describe("createNodeFromEntry", () => {
     expect(content.map((n) => n.name)).toEqual(["core/heading"]);
     expect(content[0]?.id).not.toBe("seed-child");
   });
+
+  test("mints a fresh, unique id for every node so two inserts never collide", () => {
+    const entry = { name: "core/group", slug: "core/group", title: "Group" };
+    const a = createNodeFromEntry(registry, entry);
+    const b = createNodeFromEntry(registry, entry);
+    expect(a.id).not.toBe("seed");
+    expect(a.id.length).toBeGreaterThan(0);
+    expect(a.id).not.toBe(b.id);
+  });
 });
 
 describe("expandPattern", () => {
@@ -260,21 +197,5 @@ describe("expandPattern", () => {
     expect(nodes).toHaveLength(1);
     expect(nodes[0]?.name).toBe("core/pattern-ref");
     expect(nodes[0]?.attrs?.slug).toBe("cta");
-  });
-});
-
-describe("createBlockFromSpec", () => {
-  test("mints a fresh node with the spec's name and defaults", () => {
-    const node = createBlockFromSpec(
-      spec({ name: "core/heading", defaults: { level: 2 } }),
-    );
-    expect(node.name).toBe("core/heading");
-    expect(node.attrs).toEqual({ level: 2 });
-    // A real, non-seed id so two inserts never collide.
-    expect(node.id).not.toBe("seed");
-    expect(node.id.length).toBeGreaterThan(0);
-    expect(createBlockFromSpec(spec({ name: "core/heading" })).id).not.toBe(
-      node.id,
-    );
   });
 });

--- a/packages/admin-editor/src/block-catalog.test.ts
+++ b/packages/admin-editor/src/block-catalog.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, test } from "vitest";
 
-import type { BlockSpec } from "@plumix/blocks";
+import type { BlockNode, BlockPattern, BlockSpec } from "@plumix/blocks";
 import { createBlockRegistry } from "@plumix/blocks";
 
 import {
   createBlockFromSpec,
+  createNodeFromEntry,
+  expandPattern,
+  filterPatterns,
   groupBlocksByCategory,
+  groupInsertables,
   slotAllowedBlocks,
 } from "./block-catalog.js";
 
@@ -138,6 +142,124 @@ describe("groupBlocksByCategory", () => {
     });
     expect(byKeyword.map((g) => g.category)).toEqual(["text"]);
     expect(byKeyword[0]?.blocks.map((b) => b.name)).toEqual(["core/quote"]);
+  });
+});
+
+describe("groupInsertables", () => {
+  test("includes blocks and their inserter variations, grouped by category", () => {
+    const registry = createBlockRegistry([
+      spec({ name: "core/heading", category: "text", title: "Heading" }),
+      spec({
+        name: "core/group",
+        category: "layout",
+        title: "Group",
+        variations: [
+          { slug: "group/two-col", title: "Two columns", attrs: { cols: 2 } },
+        ],
+      }),
+    ]);
+
+    const groups = groupInsertables(registry, { capabilities: NO_CAPS });
+    const slugs = groups.flatMap((g) => g.entries.map((e) => e.slug));
+
+    // The group block has an inserter variation, so the variation surfaces in
+    // place of the bare parent; the heading (no variations) surfaces itself.
+    expect(slugs).toEqual(["core/heading", "group/two-col"]);
+    expect(groups.map((g) => g.category)).toEqual(["text", "layout"]);
+  });
+
+  test("excludes inserter:false and capability-gated blocks; filters by query", () => {
+    const registry = createBlockRegistry([
+      spec({ name: "core/heading", category: "text", title: "Heading" }),
+      spec({ name: "core/internal", category: "text", inserter: false }),
+      spec({ name: "core/secret", category: "text", capability: "x" }),
+    ]);
+
+    const slugs = groupInsertables(registry, {
+      capabilities: NO_CAPS,
+      query: "head",
+    }).flatMap((g) => g.entries.map((e) => e.slug));
+    expect(slugs).toEqual(["core/heading"]);
+  });
+});
+
+describe("filterPatterns", () => {
+  const patterns: readonly BlockPattern[] = [
+    { name: "hero", title: "Hero banner", content: [] },
+    { name: "cta", title: "Call to action", keywords: ["button"], content: [] },
+  ];
+
+  test("returns all patterns without a query", () => {
+    expect(filterPatterns(patterns).map((p) => p.name)).toEqual([
+      "hero",
+      "cta",
+    ]);
+  });
+
+  test("matches name, title and keywords", () => {
+    expect(filterPatterns(patterns, "hero").map((p) => p.name)).toEqual([
+      "hero",
+    ]);
+    expect(filterPatterns(patterns, "button").map((p) => p.name)).toEqual([
+      "cta",
+    ]);
+  });
+});
+
+describe("createNodeFromEntry", () => {
+  const registry = createBlockRegistry([
+    spec({
+      name: "core/group",
+      category: "layout",
+      defaults: { layout: "flow" },
+    }),
+  ]);
+
+  test("merges spec defaults under the variation attrs and seeds innerBlocks", () => {
+    const node = createNodeFromEntry(registry, {
+      name: "core/group",
+      slug: "group/two-col",
+      title: "Two columns",
+      attrs: { layout: "flex-row" },
+      innerBlocks: [{ id: "seed-child", name: "core/heading" }],
+    });
+
+    // Variation attr wins over the spec default; innerBlocks seed the content
+    // slot with freshly minted ids.
+    expect(node.attrs?.layout).toBe("flex-row");
+    const content = node.attrs?.content as readonly BlockNode[];
+    expect(content.map((n) => n.name)).toEqual(["core/heading"]);
+    expect(content[0]?.id).not.toBe("seed-child");
+  });
+});
+
+describe("expandPattern", () => {
+  test("copy patterns clone the composition with fresh ids", () => {
+    const nodes = expandPattern({
+      name: "hero",
+      title: "Hero",
+      content: [
+        { id: "p1", name: "core/heading", attrs: { text: "Hi" } },
+        { id: "p2", name: "core/rich-text" },
+      ],
+    });
+    expect(nodes.map((n) => n.name)).toEqual([
+      "core/heading",
+      "core/rich-text",
+    ]);
+    expect(nodes.map((n) => n.id)).not.toContain("p1");
+  });
+
+  test("reference patterns insert a single core/pattern-ref node", () => {
+    const nodes = expandPattern({
+      name: "cta",
+      title: "CTA",
+      insert: "reference",
+      content: [{ id: "p1", name: "core/heading" }],
+    });
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]?.name).toBe("core/pattern-ref");
+    expect(nodes[0]?.attrs?.slug).toBe("cta");
   });
 });
 

--- a/packages/admin-editor/src/block-catalog.ts
+++ b/packages/admin-editor/src/block-catalog.ts
@@ -2,7 +2,6 @@ import type {
   BlockNode,
   BlockPattern,
   BlockRegistry,
-  BlockSpec,
   InsertableBlockEntry,
 } from "@plumix/blocks";
 import { expandBlockVariations, rewriteBlockNodeIds } from "@plumix/blocks";
@@ -11,6 +10,17 @@ import { labelSourceText } from "@plumix/core/i18n";
 const PATTERN_REF_BLOCK = "core/pattern-ref";
 /** The conventional slot a block variation seeds its `innerBlocks` into. */
 const CONTENT_SLOT = "content";
+
+/**
+ * A pattern as the inserter consumes it. Identical to `BlockPattern` but with a
+ * plain-string `category`, so both authored patterns and the manifest's wire
+ * form (`PatternManifestEntry`, whose category is an open string) flow in. The
+ * inserter never groups by pattern category, so the narrow key buys nothing
+ * here.
+ */
+export type InserterPattern = Omit<BlockPattern, "category"> & {
+  readonly category?: string;
+};
 
 /**
  * A slot's `allowedBlocks` list (the block names it accepts), or undefined when
@@ -29,11 +39,6 @@ export function slotAllowedBlocks(
   return input?.allowedBlocks;
 }
 
-interface CatalogGroup {
-  readonly category: string;
-  readonly blocks: readonly BlockSpec[];
-}
-
 const UNCATEGORIZED = "uncategorized";
 
 interface GroupOptions {
@@ -42,39 +47,7 @@ interface GroupOptions {
   readonly query?: string;
 }
 
-/**
- * Build the inserter catalog: eligible blocks (shown in the inserter and
- * within the viewer's capabilities), optionally filtered by query, grouped by
- * category. Category and within-category order follow registry iteration
- * order; empty groups are dropped.
- */
-export function groupBlocksByCategory(
-  registry: BlockRegistry,
-  { capabilities, query }: GroupOptions,
-): readonly CatalogGroup[] {
-  const needle = query?.trim().toLowerCase() ?? "";
-  const order: string[] = [];
-  const buckets = new Map<string, BlockSpec[]>();
-  for (const spec of registry) {
-    if (spec.inserter === false) continue;
-    if (spec.capability && !capabilities.has(spec.capability)) continue;
-    if (needle && !matchesQuery(spec, needle)) continue;
-    const category = spec.category ?? UNCATEGORIZED;
-    let bucket = buckets.get(category);
-    if (!bucket) {
-      bucket = [];
-      buckets.set(category, bucket);
-      order.push(category);
-    }
-    bucket.push(spec);
-  }
-  return order.map((category) => ({
-    category,
-    blocks: buckets.get(category) ?? [],
-  }));
-}
-
-export interface InsertableGroup {
+interface InsertableGroup {
   readonly category: string;
   readonly entries: readonly InsertableBlockEntry[];
 }
@@ -95,30 +68,23 @@ export function groupInsertables(
       spec.inserter !== false &&
       (!spec.capability || capabilities.has(spec.capability)),
   );
-  const order: string[] = [];
+  // Map iteration is insertion-ordered, which is the registry order we want.
   const buckets = new Map<string, InsertableBlockEntry[]>();
   for (const entry of expandBlockVariations(eligible)) {
     if (needle && !matchesEntry(entry, needle)) continue;
     const category = entry.category ?? UNCATEGORIZED;
     let bucket = buckets.get(category);
-    if (!bucket) {
-      bucket = [];
-      buckets.set(category, bucket);
-      order.push(category);
-    }
+    if (!bucket) buckets.set(category, (bucket = []));
     bucket.push(entry);
   }
-  return order.map((category) => ({
-    category,
-    entries: buckets.get(category) ?? [],
-  }));
+  return [...buckets].map(([category, entries]) => ({ category, entries }));
 }
 
 /** Patterns matching the query (name / title / keywords); all when blank. */
 export function filterPatterns(
-  patterns: readonly BlockPattern[],
+  patterns: readonly InserterPattern[],
   query?: string,
-): readonly BlockPattern[] {
+): readonly InserterPattern[] {
   const needle = query?.trim().toLowerCase() ?? "";
   if (!needle) return patterns;
   return patterns.filter(
@@ -151,7 +117,7 @@ export function createNodeFromEntry(
 /** The concrete block(s) a pattern inserts: a deep-cloned, id-rewritten copy of
  *  its composition, or a single `core/pattern-ref` node for reference patterns
  *  (the walker resolves the reference at render). */
-export function expandPattern(pattern: BlockPattern): readonly BlockNode[] {
+export function expandPattern(pattern: InserterPattern): readonly BlockNode[] {
   if (pattern.insert === "reference") {
     return rewriteBlockNodeIds([
       { id: "seed", name: PATTERN_REF_BLOCK, attrs: { slug: pattern.name } },
@@ -164,31 +130,6 @@ function matchesEntry(entry: InsertableBlockEntry, needle: string): boolean {
   if (entry.name.toLowerCase().includes(needle)) return true;
   if (labelSourceText(entry.title).toLowerCase().includes(needle)) return true;
   return (entry.keywords ?? []).some((keyword) =>
-    labelSourceText(keyword).toLowerCase().includes(needle),
-  );
-}
-
-/** A fresh, insertable block node from a catalog spec: its defaults plus a
- *  freshly minted id (reusing the same crypto id path as pattern insertion). */
-export function createBlockFromSpec(spec: BlockSpec): BlockNode {
-  const seed: BlockNode = {
-    id: "seed",
-    name: spec.name,
-    attrs: { ...spec.defaults },
-  };
-  const [node = seed] = rewriteBlockNodeIds([seed]);
-  return node;
-}
-
-function matchesQuery(spec: BlockSpec, needle: string): boolean {
-  if (spec.name.toLowerCase().includes(needle)) return true;
-  if (
-    spec.title !== undefined &&
-    labelSourceText(spec.title).toLowerCase().includes(needle)
-  ) {
-    return true;
-  }
-  return (spec.keywords ?? []).some((keyword) =>
     labelSourceText(keyword).toLowerCase().includes(needle),
   );
 }

--- a/packages/admin-editor/src/block-catalog.ts
+++ b/packages/admin-editor/src/block-catalog.ts
@@ -1,6 +1,16 @@
-import type { BlockNode, BlockRegistry, BlockSpec } from "@plumix/blocks";
-import { rewriteBlockNodeIds } from "@plumix/blocks";
+import type {
+  BlockNode,
+  BlockPattern,
+  BlockRegistry,
+  BlockSpec,
+  InsertableBlockEntry,
+} from "@plumix/blocks";
+import { expandBlockVariations, rewriteBlockNodeIds } from "@plumix/blocks";
 import { labelSourceText } from "@plumix/core/i18n";
+
+const PATTERN_REF_BLOCK = "core/pattern-ref";
+/** The conventional slot a block variation seeds its `innerBlocks` into. */
+const CONTENT_SLOT = "content";
 
 /**
  * A slot's `allowedBlocks` list (the block names it accepts), or undefined when
@@ -62,6 +72,100 @@ export function groupBlocksByCategory(
     category,
     blocks: buckets.get(category) ?? [],
   }));
+}
+
+export interface InsertableGroup {
+  readonly category: string;
+  readonly entries: readonly InsertableBlockEntry[];
+}
+
+/**
+ * The inserter's block list: every eligible block plus its inserter-scoped
+ * variations (a block with inserter variations surfaces those instead of its
+ * bare self), capability-gated, query-filtered, grouped by category in
+ * registry order with empty groups dropped.
+ */
+export function groupInsertables(
+  registry: BlockRegistry,
+  { capabilities, query }: GroupOptions,
+): readonly InsertableGroup[] {
+  const needle = query?.trim().toLowerCase() ?? "";
+  const eligible = [...registry].filter(
+    (spec) =>
+      spec.inserter !== false &&
+      (!spec.capability || capabilities.has(spec.capability)),
+  );
+  const order: string[] = [];
+  const buckets = new Map<string, InsertableBlockEntry[]>();
+  for (const entry of expandBlockVariations(eligible)) {
+    if (needle && !matchesEntry(entry, needle)) continue;
+    const category = entry.category ?? UNCATEGORIZED;
+    let bucket = buckets.get(category);
+    if (!bucket) {
+      bucket = [];
+      buckets.set(category, bucket);
+      order.push(category);
+    }
+    bucket.push(entry);
+  }
+  return order.map((category) => ({
+    category,
+    entries: buckets.get(category) ?? [],
+  }));
+}
+
+/** Patterns matching the query (name / title / keywords); all when blank. */
+export function filterPatterns(
+  patterns: readonly BlockPattern[],
+  query?: string,
+): readonly BlockPattern[] {
+  const needle = query?.trim().toLowerCase() ?? "";
+  if (!needle) return patterns;
+  return patterns.filter(
+    (pattern) =>
+      pattern.name.toLowerCase().includes(needle) ||
+      labelSourceText(pattern.title).toLowerCase().includes(needle) ||
+      (pattern.keywords ?? []).some((keyword) =>
+        labelSourceText(keyword).toLowerCase().includes(needle),
+      ),
+  );
+}
+
+/** A fresh node for an inserter entry (block or variation): the spec's defaults
+ *  under the variation's attrs preset, innerBlocks seeded into the content slot,
+ *  every id freshly minted. */
+export function createNodeFromEntry(
+  registry: BlockRegistry,
+  entry: InsertableBlockEntry,
+): BlockNode {
+  const attrs: Record<string, unknown> = {
+    ...registry.get(entry.name)?.defaults,
+    ...entry.attrs,
+  };
+  if (entry.innerBlocks) attrs[CONTENT_SLOT] = entry.innerBlocks;
+  const seed: BlockNode = { id: "seed", name: entry.name, attrs };
+  const [node = seed] = rewriteBlockNodeIds([seed]);
+  return node;
+}
+
+/** The concrete block(s) a pattern inserts: a deep-cloned, id-rewritten copy of
+ *  its composition, or a single `core/pattern-ref` node for reference patterns
+ *  (the walker resolves the reference at render). */
+export function expandPattern(pattern: BlockPattern): readonly BlockNode[] {
+  if (pattern.insert === "reference") {
+    return rewriteBlockNodeIds([
+      { id: "seed", name: PATTERN_REF_BLOCK, attrs: { slug: pattern.name } },
+    ]);
+  }
+  return rewriteBlockNodeIds(pattern.content);
+}
+
+function matchesEntry(entry: InsertableBlockEntry, needle: string): boolean {
+  if (entry.name.toLowerCase().includes(needle)) return true;
+  if (labelSourceText(entry.title).toLowerCase().includes(needle)) return true;
+  return (entry.keywords ?? []).some((keyword) =>
+    labelSourceText(keyword).toLowerCase().includes(needle),
+  );
 }
 
 /** A fresh, insertable block node from a catalog spec: its defaults plus a

--- a/packages/admin-editor/src/block-inserter.test.tsx
+++ b/packages/admin-editor/src/block-inserter.test.tsx
@@ -1,0 +1,55 @@
+import type { ReactElement } from "react";
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, test } from "vitest";
+
+import { createBlockRegistry } from "@plumix/blocks";
+
+import { BlockInserterPopover } from "./block-inserter.js";
+import { EditorProvider, useEditorStore } from "./provider.js";
+
+beforeAll(() => {
+  i18n.loadAndActivate({ locale: "en", messages: {} });
+});
+
+afterEach(cleanup);
+
+const registry = createBlockRegistry([
+  { name: "core/heading", render: () => null, category: "text", title: "H" },
+]);
+
+const NO_CAPS: ReadonlySet<string> = new Set();
+
+function TreeProbe(): ReactElement {
+  const names = useEditorStore((s) => s.tree.map((n) => n.name).join(","));
+  return <output data-testid="tree-probe">{names}</output>;
+}
+
+function renderInserter(): ReturnType<typeof render> {
+  return render(
+    <I18nProvider i18n={i18n}>
+      <EditorProvider initialTree={[]}>
+        <BlockInserterPopover registry={registry} capabilities={NO_CAPS} />
+        <TreeProbe />
+      </EditorProvider>
+    </I18nProvider>,
+  );
+}
+
+describe("BlockInserterPopover", () => {
+  test("opens the catalog from the + Add Block trigger", () => {
+    const { getByTestId, queryByTestId } = renderInserter();
+    expect(queryByTestId("block-catalog")).toBeNull();
+    fireEvent.click(getByTestId("plumix-add-block"));
+    expect(getByTestId("block-catalog")).toBeDefined();
+  });
+
+  test("inserting a block appends it and closes the popover", () => {
+    const { getByTestId, queryByTestId } = renderInserter();
+    fireEvent.click(getByTestId("plumix-add-block"));
+    fireEvent.click(getByTestId("block-catalog-item-core/heading"));
+    expect(getByTestId("tree-probe").textContent).toBe("core/heading");
+    expect(queryByTestId("block-catalog")).toBeNull();
+  });
+});

--- a/packages/admin-editor/src/block-inserter.tsx
+++ b/packages/admin-editor/src/block-inserter.tsx
@@ -1,0 +1,61 @@
+import type { ReactElement } from "react";
+import { useState } from "react";
+import { Trans } from "@lingui/react";
+
+import type { BlockRegistry } from "@plumix/blocks";
+import { Button } from "@plumix/admin-ui/button";
+import { Plus } from "@plumix/admin-ui/icons";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@plumix/admin-ui/popover";
+
+import type { InserterPattern } from "./block-catalog.js";
+import { BlockCatalog } from "./block-catalog-tab.js";
+
+interface BlockInserterPopoverProps {
+  readonly registry: BlockRegistry;
+  readonly capabilities: ReadonlySet<string>;
+  readonly patterns?: readonly InserterPattern[];
+}
+
+/**
+ * Toolbar "+ Add Block" affordance: a popover hosting the same catalog as the
+ * left rail, so blocks, variations and patterns are insertable without the
+ * sidebar. Closes itself once something is inserted.
+ */
+export function BlockInserterPopover({
+  registry,
+  capabilities,
+  patterns,
+}: BlockInserterPopoverProps): ReactElement {
+  const [open, setOpen] = useState(false);
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          data-testid="plumix-add-block"
+        >
+          <Plus />
+          <Trans id="editor.toolbar.addBlock" message="Add Block" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="max-h-[70vh] w-80 overflow-auto p-0"
+        data-testid="plumix-add-block-popover"
+      >
+        <BlockCatalog
+          registry={registry}
+          capabilities={capabilities}
+          patterns={patterns}
+          onInsert={() => setOpen(false)}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/admin-editor/src/canvas-frame.test.tsx
+++ b/packages/admin-editor/src/canvas-frame.test.tsx
@@ -232,7 +232,14 @@ describe("CanvasFrame nested drop", () => {
       rects: [{ id: parentId, x: 0, y: 0, width: 500, height: 500 }],
       slots: [{ parentId, slotKey, x: 0, y: 0, width: 500, height: 500 }],
     });
-    act(() => storeApi?.getState().startBlockDrag(headingSpec));
+    act(() =>
+      storeApi?.getState().startBlockDrag({
+        name: "core/heading",
+        slug: "core/heading",
+        title: "Heading",
+        category: "text",
+      }),
+    );
     act(() => {
       window.dispatchEvent(
         new MouseEvent("pointermove", { clientX: 50, clientY: 50 }),

--- a/packages/admin-editor/src/canvas-frame.tsx
+++ b/packages/admin-editor/src/canvas-frame.tsx
@@ -7,8 +7,8 @@ import type { BlockRect, SlotRect } from "@plumix/blocks/renderer";
 
 import type { FrameOffset, OverlayBox } from "./overlay.js";
 import {
-  createBlockFromSpec,
-  groupBlocksByCategory,
+  createNodeFromEntry,
+  groupInsertables,
   slotAllowedBlocks,
 } from "./block-catalog.js";
 import { findBlock } from "./block-tree-ops.js";
@@ -247,7 +247,11 @@ export function CanvasFrame({
         if (dragSpec) {
           store
             .getState()
-            .insertBlockInto(createBlockFromSpec(dragSpec), target, allowed);
+            .insertBlockInto(
+              createNodeFromEntry(registry, dragSpec),
+              target,
+              allowed,
+            );
         } else if (movingId) {
           store.getState().moveBlock(movingId, target, allowed);
         }
@@ -257,7 +261,10 @@ export function CanvasFrame({
           if (dragSpec) {
             store
               .getState()
-              .insertBlock(createBlockFromSpec(dragSpec), placement.index);
+              .insertBlock(
+                createNodeFromEntry(registry, dragSpec),
+                placement.index,
+              );
           } else if (movingId) {
             // placement.index counts the pre-removal top level; moveBlock
             // removes the source first, so shift down by one when the source
@@ -297,9 +304,11 @@ export function CanvasFrame({
   }, [dragSpec, movingId, store, registry]);
 
   const addFirstBlock = useCallback((): void => {
-    const [group] = groupBlocksByCategory(registry, { capabilities });
-    const spec = group?.blocks[0];
-    if (spec) store.getState().insertBlock(createBlockFromSpec(spec), 0);
+    const [group] = groupInsertables(registry, { capabilities });
+    const entry = group?.entries[0];
+    if (entry) {
+      store.getState().insertBlock(createNodeFromEntry(registry, entry), 0);
+    }
   }, [registry, capabilities, store]);
 
   // Overlays live in a clip layer pinned over the canvas viewport, so their

--- a/packages/admin-editor/src/editor-toolbar.tsx
+++ b/packages/admin-editor/src/editor-toolbar.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from "react";
+import type { ReactElement, ReactNode } from "react";
 import { useEffect } from "react";
 import { Trans } from "@lingui/react";
 
@@ -30,11 +30,14 @@ export interface PublishActions {
   readonly draftMode?: DraftMode;
 }
 
-/** Top toolbar: undo/redo plus the host-wired publish / draft actions. */
+/** Top toolbar: an inline inserter slot, undo/redo, plus the host-wired
+ *  publish / draft actions. */
 export function EditorToolbar({
   publish,
+  inserter,
 }: {
   readonly publish?: PublishActions;
+  readonly inserter?: ReactNode;
 }): ReactElement {
   const undoAvailable = useEditorStore((s) => canUndo(s.history));
   const redoAvailable = useEditorStore((s) => canRedo(s.history));
@@ -48,6 +51,7 @@ export function EditorToolbar({
     >
       {/* Collapses both rails for a focused canvas (also Cmd/Ctrl+B). */}
       <SidebarTrigger data-testid="plumix-rails-toggle" />
+      {inserter}
       <Button
         type="button"
         variant="ghost"

--- a/packages/admin-editor/src/plumix-editor.tsx
+++ b/packages/admin-editor/src/plumix-editor.tsx
@@ -18,8 +18,10 @@ import {
 } from "@plumix/admin-ui/tabs";
 import { defineEntryContent } from "@plumix/blocks";
 
+import type { InserterPattern } from "./block-catalog.js";
 import type { PublishActions } from "./editor-toolbar.js";
 import { BlockCatalog } from "./block-catalog-tab.js";
+import { BlockInserterPopover } from "./block-inserter.js";
 import { BlockInspector } from "./block-inspector.js";
 import { CanvasFrame } from "./canvas-frame.js";
 import { EditorShortcuts, EditorToolbar } from "./editor-toolbar.js";
@@ -40,6 +42,8 @@ interface PlumixEditorProps {
   readonly registry: BlockRegistry;
   /** Viewer capabilities, gating which blocks the catalog offers. */
   readonly capabilities?: ReadonlySet<string>;
+  /** Theme + plugin patterns offered in the inserter alongside the blocks. */
+  readonly patterns?: readonly InserterPattern[];
   /** Fires with the full content envelope whenever the tree changes. The host
    *  debounces + persists (orpc lives in the app, never in this package). */
   readonly onChange?: (content: EntryContent) => void;
@@ -63,6 +67,7 @@ export function PlumixEditor({
   origin,
   registry,
   capabilities = NO_CAPABILITIES,
+  patterns,
   onChange,
   documentPanel,
   publish,
@@ -93,7 +98,11 @@ export function PlumixEditor({
             </SidebarHeader>
             <SidebarContent>
               <TabsContent value="blocks">
-                <BlockCatalog registry={registry} capabilities={capabilities} />
+                <BlockCatalog
+                  registry={registry}
+                  capabilities={capabilities}
+                  patterns={patterns}
+                />
               </TabsContent>
               <TabsContent value="layers">
                 <LayersTab registry={registry} />
@@ -102,7 +111,16 @@ export function PlumixEditor({
           </Tabs>
         </Sidebar>
         <SidebarInset className="min-w-0">
-          <EditorToolbar publish={publish} />
+          <EditorToolbar
+            publish={publish}
+            inserter={
+              <BlockInserterPopover
+                registry={registry}
+                capabilities={capabilities}
+                patterns={patterns}
+              />
+            }
+          />
           <CanvasFrame
             previewUrl={previewUrl}
             origin={origin}

--- a/packages/admin-editor/src/store.test.ts
+++ b/packages/admin-editor/src/store.test.ts
@@ -167,6 +167,47 @@ describe("insertBlock", () => {
   });
 });
 
+describe("insertBlocks", () => {
+  test("inserts multiple blocks at a top-level index and selects the first", () => {
+    const store = createEditorStore({ tree: [{ id: "a", name: "core/x" }] });
+
+    store.getState().insertBlocks(
+      [
+        { id: "p1", name: "core/y" },
+        { id: "p2", name: "core/z" },
+      ],
+      1,
+    );
+
+    expect(store.getState().tree.map((n) => n.id)).toEqual(["a", "p1", "p2"]);
+    expect(store.getState().activeId).toBe("p1");
+    expect([...store.getState().selectedIds]).toEqual(["p1"]);
+  });
+
+  test("is a no-op for an empty list", () => {
+    const tree: readonly BlockNode[] = [{ id: "a", name: "core/x" }];
+    const store = createEditorStore({ tree });
+
+    store.getState().insertBlocks([], 0);
+
+    expect(store.getState().tree).toBe(tree);
+  });
+
+  test("a pattern insert is one undo step", () => {
+    const store = createEditorStore({ tree: [{ id: "a", name: "core/x" }] });
+    store.getState().insertBlocks(
+      [
+        { id: "p1", name: "core/y" },
+        { id: "p2", name: "core/z" },
+      ],
+      1,
+    );
+
+    store.getState().undo();
+    expect(store.getState().tree.map((n) => n.id)).toEqual(["a"]);
+  });
+});
+
 describe("undo / redo", () => {
   test("undo reverts an insert; redo replays it", () => {
     const store = createEditorStore({ tree: [{ id: "a", name: "core/x" }] });

--- a/packages/admin-editor/src/store.ts
+++ b/packages/admin-editor/src/store.ts
@@ -52,6 +52,9 @@ export interface EditorActions {
   setTree: (tree: readonly BlockNode[]) => void;
   /** Insert a block at a top-level index (clamped) and select it. */
   insertBlock: (node: BlockNode, index: number) => void;
+  /** Insert several blocks at a top-level index as one step (a pattern's
+   *  composition); selects the first. No-op for an empty list. */
+  insertBlocks: (nodes: readonly BlockNode[], index: number) => void;
   /** Insert a block into a parent's slot (nested), gated by `allowed`, and
    *  select it. A no-op when the slot is absent or the block isn't allowed. */
   insertBlockInto: (
@@ -162,6 +165,23 @@ export function createEditorStore(
           tree,
           activeId: node.id,
           selectedIds: new Set([node.id]),
+          history: recordHistory(state.history, tree, null),
+        };
+      }),
+    insertBlocks: (nodes, index) =>
+      set((state) => {
+        const first = nodes[0];
+        if (!first) return {};
+        const at = Math.max(0, Math.min(index, state.tree.length));
+        const tree = [
+          ...state.tree.slice(0, at),
+          ...nodes,
+          ...state.tree.slice(at),
+        ];
+        return {
+          tree,
+          activeId: first.id,
+          selectedIds: new Set([first.id]),
           history: recordHistory(state.history, tree, null),
         };
       }),

--- a/packages/admin-editor/src/store.ts
+++ b/packages/admin-editor/src/store.ts
@@ -1,6 +1,6 @@
 import { createStore } from "zustand/vanilla";
 
-import type { BlockNode, BlockSpec } from "@plumix/blocks";
+import type { BlockNode, InsertableBlockEntry } from "@plumix/blocks";
 import { isBlockNodeArray } from "@plumix/blocks";
 
 import type { MoveTarget } from "./block-tree-ops.js";
@@ -40,8 +40,8 @@ export interface EditorState {
   readonly hoverId: string | null;
   readonly device: EditorDevice;
   readonly zoom: number;
-  /** The catalog block currently being dragged toward the canvas, if any. */
-  readonly dragSpec: BlockSpec | null;
+  /** The catalog entry (block or variation) being dragged toward the canvas. */
+  readonly dragSpec: InsertableBlockEntry | null;
   /** The existing block being dragged to a new position on the canvas, if any. */
   readonly movingId: string | null;
   /** Snapshot history of the tree, driving undo/redo. */
@@ -87,7 +87,7 @@ export interface EditorActions {
   setHover: (id: string | null) => void;
   setDevice: (device: EditorDevice) => void;
   setZoom: (zoom: number) => void;
-  startBlockDrag: (spec: BlockSpec) => void;
+  startBlockDrag: (entry: InsertableBlockEntry) => void;
   endBlockDrag: () => void;
   /** Begin / end dragging an existing block to a new canvas position. */
   startMove: (id: string) => void;

--- a/packages/admin-editor/vitest.setup.ts
+++ b/packages/admin-editor/vitest.setup.ts
@@ -14,3 +14,30 @@ window.matchMedia = vi.fn().mockImplementation((query: string) => ({
   removeListener: vi.fn(),
   dispatchEvent: vi.fn(),
 }));
+
+// jsdom has no ResizeObserver, but cmdk (the shadcn Command inserter) and the
+// canvas frame's measure-on-resize both construct one. A no-op stub keeps them
+// mountable under test.
+class ResizeObserverStub {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+globalThis.ResizeObserver = ResizeObserverStub;
+
+// jsdom omits Element.scrollIntoView; cmdk calls it on the active CommandItem
+// during keyboard navigation. Stub so the inserter doesn't crash under test.
+Element.prototype.scrollIntoView = function scrollIntoView(): void {
+  /* no-op */
+};
+
+// jsdom omits the PointerEvent capture API; Radix primitives call it on
+// pointerdown and crash without it.
+const elementProto = Element.prototype as unknown as {
+  hasPointerCapture?: (id: number) => boolean;
+  setPointerCapture?: (id: number) => void;
+  releasePointerCapture?: (id: number) => void;
+};
+elementProto.hasPointerCapture = (): boolean => false;
+elementProto.setPointerCapture = (): void => undefined;
+elementProto.releasePointerCapture = (): void => undefined;

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/editor.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/editor.tsx
@@ -9,7 +9,11 @@ import { detectStaleAutosave } from "@/editor/detect-stale-autosave.js";
 import { registerCoreBlocks } from "@/editor/register-core-blocks.js";
 import { resolveEditorMode } from "@/editor/resolve-editor-mode.js";
 import { StaleDraftDialog } from "@/editor/StaleDraftDialog.js";
-import { entryMetaBoxesForType, findEntryTypeBySlug } from "@/lib/manifest.js";
+import {
+  entryMetaBoxesForType,
+  findEntryTypeBySlug,
+  getPatterns,
+} from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import { getRegisteredBlocks } from "@/lib/plugin-registry.js";
 import { toastError, toastSuccess } from "@/lib/toast.js";
@@ -62,6 +66,9 @@ const M = {
 // module load, mirroring the Puck route.
 registerCoreBlocks();
 const registry = createBlockRegistry(getRegisteredBlocks());
+
+// Theme + plugin patterns, surfaced in the inserter alongside the blocks.
+const patterns = getPatterns();
 
 // Mint once and cache forever — each call writes a fresh preview token, and
 // the URL it returns is the canvas iframe's target for the editor's lifetime.
@@ -600,6 +607,7 @@ function BespokeEditor({
       defaultValue={isEntryContent(entry.content) ? entry.content : undefined}
       registry={registry}
       capabilities={capabilitySet}
+      patterns={patterns}
       onChange={handleChange}
       documentPanel={documentPanel}
       publish={publishActions}


### PR DESCRIPTION
Builds the bespoke editor's inserter on shadcn's `Command` (cmdk) — the same
primitive the existing slash menu uses — and surfaces block variations and
theme/plugin patterns alongside plain blocks, all behind one search box. This
closes the inserter parity gap for the bespoke editor (#1115).

The left-rail catalog now lists every eligible block, each block's inserter
variations as their own entries, and a patterns group whose entries splice a
whole composition in a single click. A new "+ Add Block" toolbar popover hosts
the very same catalog, so inserting works without the sidebar or a drag (AC4).
The admin editor route forwards the manifest's patterns to `PlumixEditor`, and
the standalone playground seeds a `core/group` variation plus a hero pattern so
the Playwright visual e2e covers both end to end.

Catalog drags now carry the resolved `InsertableBlockEntry` (variation attrs +
`innerBlocks`) instead of a bare block spec, so dropping a variation onto the
canvas applies its preset. The now-dead `groupBlocksByCategory` /
`createBlockFromSpec` helpers and their tests are removed.

Testing follows the package's layering: catalog/popover behavior is unit-tested
in `@plumix/admin-editor` (199 unit), the cross-iframe inserter flow is covered
by the playground e2e (12 e2e), and the admin side is integration-only (the
route just passes a prop). Lint, typecheck, knip, and format all pass.

Fixes #1115