### PR TITLE
feat: add a right-rail tiptap rich-text editor

### DIFF
--- a/packages/admin-editor/e2e/editor-visual.spec.ts
+++ b/packages/admin-editor/e2e/editor-visual.spec.ts
@@ -293,6 +293,59 @@ test.describe("editor playground", () => {
     await expect(popover).toBeHidden();
   });
 
+  test("selecting a text block reveals the right-rail Tiptap editor", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const canvas = page.frameLocator(CANVAS_FRAME);
+
+    await canvas.locator('[data-plumix-id="intro"]').click();
+
+    // The Block tab now hosts the rich-text rail: a formatting toolbar plus the
+    // contenteditable surface seeded with the block's body.
+    await expect(page.getByTestId("block-input-body-bold")).toBeVisible();
+    await expect(page.getByTestId("block-input-body-h2")).toBeVisible();
+    await expect(page.getByTestId("block-input-body-clear")).toBeVisible();
+    await expect(page.getByTestId("block-input-body-editor")).toBeVisible();
+  });
+
+  test("typing in the rail flows live to the canvas without losing focus", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const canvas = page.frameLocator(CANVAS_FRAME);
+
+    await canvas.locator('[data-plumix-id="intro"]').click();
+    const editor = page.getByTestId("block-input-body-editor");
+    await editor.click();
+    await page.keyboard.press("ControlOrMeta+A");
+    // A multi-character burst: if focus were lost across the patch loop's
+    // re-renders, only the first character would survive.
+    await page.keyboard.type("Edited inline");
+
+    await expect(editor).toContainText("Edited inline");
+    await expect(canvas.locator('[data-plumix-id="intro"]')).toContainText(
+      "Edited inline",
+    );
+  });
+
+  test("switching between text blocks re-points the rail at each body", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const canvas = page.frameLocator(CANVAS_FRAME);
+    const editor = page.getByTestId("block-input-body-editor");
+
+    await canvas.locator('[data-plumix-id="intro"]').click();
+    await expect(editor).toContainText("standalone harness");
+
+    // The same stable editor instance must swap to the next block's body — no
+    // content bleed from the previously selected block.
+    await canvas.locator('[data-plumix-id="col-left"]').click();
+    await expect(editor).toContainText("Left column");
+    await expect(editor).not.toContainText("standalone harness");
+  });
+
   test("the Layers tab outlines the nested structure", async ({ page }) => {
     await page.goto("/");
 

--- a/packages/admin-editor/locales/ar.po
+++ b/packages/admin-editor/locales/ar.po
@@ -59,6 +59,11 @@ msgid "editor.selection.duplicate"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/rich-text-field.tsx
+msgid "editor.richtext.hint"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.json"
 msgstr ""

--- a/packages/admin-editor/locales/de.po
+++ b/packages/admin-editor/locales/de.po
@@ -59,6 +59,11 @@ msgid "editor.selection.duplicate"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/rich-text-field.tsx
+msgid "editor.richtext.hint"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.json"
 msgstr ""

--- a/packages/admin-editor/locales/en.po
+++ b/packages/admin-editor/locales/en.po
@@ -59,6 +59,11 @@ msgid "editor.selection.duplicate"
 msgstr "Duplicate"
 
 #. js-lingui-explicit-id
+#: src/rich-text-field.tsx
+msgid "editor.richtext.hint"
+msgstr "Formatting applies to the selected text."
+
+#. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.json"
 msgstr "JSON"

--- a/packages/admin-editor/locales/uk.po
+++ b/packages/admin-editor/locales/uk.po
@@ -59,6 +59,11 @@ msgid "editor.selection.duplicate"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/rich-text-field.tsx
+msgid "editor.richtext.hint"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.json"
 msgstr ""

--- a/packages/admin-editor/locales/zh-CN.po
+++ b/packages/admin-editor/locales/zh-CN.po
@@ -59,6 +59,11 @@ msgid "editor.selection.duplicate"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/rich-text-field.tsx
+msgid "editor.richtext.hint"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.json"
 msgstr ""

--- a/packages/admin-editor/package.json
+++ b/packages/admin-editor/package.json
@@ -31,6 +31,9 @@
     "@plumix/admin-ui": "workspace:*",
     "@plumix/blocks": "workspace:*",
     "@plumix/core": "workspace:*",
+    "@tiptap/core": "catalog:",
+    "@tiptap/react": "catalog:",
+    "@tiptap/starter-kit": "catalog:",
     "zustand": "^5.0.14"
   },
   "peerDependencies": {

--- a/packages/admin-editor/playground/host.tsx
+++ b/packages/admin-editor/playground/host.tsx
@@ -62,6 +62,12 @@ function DocumentPanelStub(): ReactElement {
   );
 }
 
+// `?theme=dark` flips the shell into dark mode so the editor (and the Tiptap
+// rail) can be exercised + screenshotted in both themes against one build.
+if (new URLSearchParams(window.location.search).get("theme") === "dark") {
+  document.documentElement.classList.add("dark");
+}
+
 const root = document.getElementById("root");
 if (root) {
   createRoot(root).render(

--- a/packages/admin-editor/playground/playground.css
+++ b/packages/admin-editor/playground/playground.css
@@ -10,6 +10,8 @@
 @source "../src";
 @source "../../admin-ui/src";
 
+@custom-variant dark (&:is(.dark *));
+
 :root {
   --radius: 0.625rem;
   --background: oklch(1 0 0);
@@ -40,6 +42,35 @@
   --sidebar-ring: oklch(0.708 0 0);
 }
 
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.922 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.556 0 0);
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -59,6 +90,14 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);

--- a/packages/admin-editor/src/block-input-control.test.tsx
+++ b/packages/admin-editor/src/block-input-control.test.tsx
@@ -152,6 +152,20 @@ describe("BlockInputControl", () => {
     expect(onChange).toHaveBeenCalledWith("custom");
   });
 
+  test("richtext renders the Tiptap toolbar and editable surface", () => {
+    const { getByTestId } = renderControl(
+      { name: "body", type: "richtext", label: "Body" },
+      "<p>Hello</p>",
+    );
+    // The toolbar's formatting controls and the contenteditable surface mount.
+    expect(getByTestId("block-input-body-bold")).toBeDefined();
+    expect(getByTestId("block-input-body-h2")).toBeDefined();
+    expect(getByTestId("block-input-body-clear")).toBeDefined();
+    const editor = getByTestId("block-input-body-editor");
+    expect(editor.getAttribute("contenteditable")).toBe("true");
+    expect(editor.textContent).toContain("Hello");
+  });
+
   test("falls back to a text input for an unknown kind", () => {
     const { getByTestId } = renderControl(
       { name: "mystery", type: "future-kind" },

--- a/packages/admin-editor/src/block-input-control.tsx
+++ b/packages/admin-editor/src/block-input-control.tsx
@@ -8,6 +8,8 @@ import { Input } from "@plumix/admin-ui/input";
 import { Label } from "@plumix/admin-ui/label";
 import { resolveLabel } from "@plumix/core/i18n";
 
+import { RichTextField } from "./rich-text-field.js";
+
 interface BlockInputControlProps {
   readonly input: BlockInput;
   readonly value: unknown;
@@ -107,6 +109,14 @@ export function BlockInputControl({
               </label>
             ))}
           </div>
+        );
+      case "richtext":
+        return (
+          <RichTextField
+            value={asString(value)}
+            onChange={onChange}
+            testId={testId}
+          />
         );
       case "combobox": {
         const listId = `${id}-list`;

--- a/packages/admin-editor/src/rich-text-extensions.test.ts
+++ b/packages/admin-editor/src/rich-text-extensions.test.ts
@@ -1,0 +1,39 @@
+import { getSchema } from "@tiptap/core";
+import { describe, expect, test } from "vitest";
+
+import { HEADING_LEVELS, richTextExtensions } from "./rich-text-extensions.js";
+
+describe("richTextExtensions", () => {
+  // getSchema throws on a duplicate extension name, so a clean build proves the
+  // core marks and StarterKit's bundled marks don't collide.
+  test("builds one schema from StarterKit nodes + the core marks", () => {
+    const schema = getSchema([...richTextExtensions()]);
+
+    expect(Object.keys(schema.marks)).toEqual(
+      expect.arrayContaining([
+        "bold",
+        "italic",
+        "underline",
+        "strike",
+        "code",
+        "link",
+        "highlight",
+      ]),
+    );
+    expect(Object.keys(schema.nodes)).toEqual(
+      expect.arrayContaining([
+        "paragraph",
+        "heading",
+        "bulletList",
+        "orderedList",
+        "listItem",
+      ]),
+    );
+  });
+
+  test("restricts headings to h2–h4, matching the render sanitizer", () => {
+    // h1/h5/h6 are stripped by the block's sanitizer, so the editor must not
+    // offer them. The constant gates both the schema and the toolbar.
+    expect(HEADING_LEVELS).toEqual([2, 3, 4]);
+  });
+});

--- a/packages/admin-editor/src/rich-text-extensions.ts
+++ b/packages/admin-editor/src/rich-text-extensions.ts
@@ -1,0 +1,30 @@
+import type { Extensions } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+
+import { coreMarkExtensions } from "@plumix/blocks";
+
+// The render sanitizer only permits h2–h4, so the editor must not produce other
+// heading levels. Gates both the schema and the toolbar's heading buttons.
+export const HEADING_LEVELS = [2, 3, 4] as const;
+
+/**
+ * Tiptap extensions for the rich-text rail: StarterKit's block nodes
+ * (paragraph, heading, lists, …) plus `@plumix/blocks`' 13 canonical marks.
+ * StarterKit's own marks are disabled so they don't double-register with the
+ * shared core marks — the editor and the renderer then speak the same mark
+ * vocabulary.
+ */
+export function richTextExtensions(): Extensions {
+  return [
+    StarterKit.configure({
+      heading: { levels: [...HEADING_LEVELS] },
+      bold: false,
+      italic: false,
+      strike: false,
+      code: false,
+      link: false,
+      underline: false,
+    }),
+    ...coreMarkExtensions,
+  ];
+}

--- a/packages/admin-editor/src/rich-text-field.tsx
+++ b/packages/admin-editor/src/rich-text-field.tsx
@@ -1,0 +1,245 @@
+import type { Editor } from "@tiptap/react";
+import type { ReactElement, ReactNode } from "react";
+import { useEffect, useRef } from "react";
+import { Trans } from "@lingui/react";
+import { EditorContent, useEditor, useEditorState } from "@tiptap/react";
+
+import { Button } from "@plumix/admin-ui/button";
+import {
+  Bold,
+  Heading2,
+  Heading3,
+  Heading4,
+  Highlighter,
+  Italic,
+  Link2,
+  List,
+  ListOrdered,
+  RemoveFormatting,
+  Strikethrough,
+  Underline,
+} from "@plumix/admin-ui/icons";
+import { Toggle } from "@plumix/admin-ui/toggle";
+
+import { HEADING_LEVELS, richTextExtensions } from "./rich-text-extensions.js";
+
+interface RichTextFieldProps {
+  /** The block's body as an HTML string. */
+  readonly value: string;
+  /** Emits the serialized HTML on every edit. */
+  readonly onChange: (html: string) => void;
+  /** Stable testid for the field root (the inspector's per-input id). */
+  readonly testId: string;
+}
+
+// The uniform marks: each toggles via toggleMark(name) and paints its pressed
+// state from isActive(name), so one table drives the toolbar and the selector.
+const MARKS = [
+  { name: "bold", icon: Bold, testId: "bold" },
+  { name: "italic", icon: Italic, testId: "italic" },
+  { name: "underline", icon: Underline, testId: "underline" },
+  { name: "strike", icon: Strikethrough, testId: "strike" },
+  { name: "highlight", icon: Highlighter, testId: "highlight" },
+] as const;
+
+// The active-mark/-node flags the toolbar paints its pressed state from. Derived
+// via useEditorState so the toolbar re-renders on selection changes without
+// re-rendering on every keystroke.
+interface ActiveState {
+  readonly marks: Readonly<Record<string, boolean>>;
+  readonly link: boolean;
+  readonly bulletList: boolean;
+  readonly orderedList: boolean;
+  readonly headings: Readonly<Record<number, boolean>>;
+}
+
+const HEADING_ICON: Record<number, typeof Heading2> = {
+  2: Heading2,
+  3: Heading3,
+  4: Heading4,
+};
+
+/**
+ * Right-rail rich-text editor: a Tiptap instance over StarterKit nodes + the
+ * shared core marks, serializing to the HTML string the block stores and
+ * renders. The editor identity is stable — `useEditor` is created once and
+ * external value changes are pushed in without emitting an update — so typing
+ * never loses focus across the live patch loop's re-renders.
+ */
+export function RichTextField({
+  value,
+  onChange,
+  testId,
+}: RichTextFieldProps): ReactElement {
+  const onChangeRef = useRef(onChange);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  });
+
+  const editor = useEditor({
+    extensions: richTextExtensions(),
+    content: value,
+    immediatelyRender: false,
+    editorProps: {
+      attributes: {
+        class:
+          "min-h-32 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring [&_:focus]:outline-none",
+        "data-testid": `${testId}-editor`,
+      },
+    },
+    onUpdate: ({ editor }) => onChangeRef.current(editor.getHTML()),
+  });
+
+  // External value changes (undo/redo, switching to another block) sync into
+  // the editor without re-emitting. The guard compares against getHTML(), so the
+  // echo from our own onUpdate is a no-op and the caret never resets mid-type —
+  // this rests on the host storing back the exact getHTML() string; any
+  // re-serialization between onChange and `value` would defeat it.
+  useEffect(() => {
+    if (!editor) return;
+    if (value !== editor.getHTML()) {
+      editor.commands.setContent(value, { emitUpdate: false });
+    }
+  }, [editor, value]);
+
+  const active = useEditorState({
+    editor,
+    selector: ({ editor }): ActiveState | null =>
+      editor
+        ? {
+            marks: Object.fromEntries(
+              MARKS.map(({ name }) => [name, editor.isActive(name)]),
+            ),
+            link: editor.isActive("link"),
+            bulletList: editor.isActive("bulletList"),
+            orderedList: editor.isActive("orderedList"),
+            headings: Object.fromEntries(
+              HEADING_LEVELS.map((level) => [
+                level,
+                editor.isActive("heading", { level }),
+              ]),
+            ),
+          }
+        : null,
+  });
+
+  return (
+    <div className="flex flex-col gap-1.5" data-testid={testId}>
+      <div className="flex flex-wrap items-center gap-0.5" role="toolbar">
+        {HEADING_LEVELS.map((level) => {
+          const Icon = HEADING_ICON[level] ?? Heading2;
+          return (
+            <ToolbarToggle
+              key={level}
+              testId={`${testId}-h${String(level)}`}
+              pressed={active?.headings[level] ?? false}
+              disabled={!editor}
+              onToggle={() =>
+                editor?.chain().focus().toggleHeading({ level }).run()
+              }
+            >
+              <Icon />
+            </ToolbarToggle>
+          );
+        })}
+        {MARKS.map(({ name, icon: Icon, testId: suffix }) => (
+          <ToolbarToggle
+            key={name}
+            testId={`${testId}-${suffix}`}
+            pressed={active?.marks[name] ?? false}
+            disabled={!editor}
+            onToggle={() => editor?.chain().focus().toggleMark(name).run()}
+          >
+            <Icon />
+          </ToolbarToggle>
+        ))}
+        <ToolbarToggle
+          testId={`${testId}-bullet-list`}
+          pressed={active?.bulletList ?? false}
+          disabled={!editor}
+          onToggle={() => editor?.chain().focus().toggleBulletList().run()}
+        >
+          <List />
+        </ToolbarToggle>
+        <ToolbarToggle
+          testId={`${testId}-ordered-list`}
+          pressed={active?.orderedList ?? false}
+          disabled={!editor}
+          onToggle={() => editor?.chain().focus().toggleOrderedList().run()}
+        >
+          <ListOrdered />
+        </ToolbarToggle>
+        <ToolbarToggle
+          testId={`${testId}-link`}
+          pressed={active?.link ?? false}
+          disabled={!editor}
+          onToggle={() => toggleLink(editor)}
+        >
+          <Link2 />
+        </ToolbarToggle>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="size-8 p-0"
+          data-testid={`${testId}-clear`}
+          disabled={!editor}
+          onClick={() =>
+            editor?.chain().focus().unsetAllMarks().clearNodes().run()
+          }
+          aria-label="Clear formatting"
+          title="Clear formatting"
+        >
+          <RemoveFormatting />
+        </Button>
+      </div>
+      <EditorContent editor={editor} />
+      <p className="text-muted-foreground text-xs">
+        <Trans
+          id="editor.richtext.hint"
+          message="Formatting applies to the selected text."
+        />
+      </p>
+    </div>
+  );
+}
+
+function ToolbarToggle({
+  testId,
+  pressed,
+  disabled,
+  onToggle,
+  children,
+}: {
+  readonly testId: string;
+  readonly pressed: boolean;
+  readonly disabled: boolean;
+  readonly onToggle: () => void;
+  readonly children: ReactNode;
+}): ReactElement {
+  return (
+    <Toggle
+      size="sm"
+      data-testid={testId}
+      pressed={pressed}
+      disabled={disabled}
+      onPressedChange={onToggle}
+    >
+      {children}
+    </Toggle>
+  );
+}
+
+// Toggle the link mark: drop it when the selection already carries one,
+// otherwise wrap the selection in a prompted href. A blank/cancelled prompt is
+// a no-op.
+function toggleLink(editor: Editor | null): void {
+  if (!editor) return;
+  if (editor.isActive("link")) {
+    editor.chain().focus().unsetMark("link").run();
+    return;
+  }
+  const href = window.prompt("Link URL")?.trim();
+  if (!href) return;
+  editor.chain().focus().setMark("link", { href }).run();
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,14 @@ catalogs:
       specifier: ^14.6.1
       version: 14.6.1
     '@tiptap/core':
-      specifier: ^3.26.1
-      version: 3.26.1
+      specifier: ^3.27.1
+      version: 3.27.1
+    '@tiptap/react':
+      specifier: ^3.27.1
+      version: 3.27.1
+    '@tiptap/starter-kit':
+      specifier: ^3.27.1
+      version: 3.27.1
     '@types/node':
       specifier: ^24.13.2
       version: 24.13.2
@@ -306,7 +312,7 @@ importers:
         version: link:../admin-ui
       '@puckeditor/core':
         specifier: 0.21.2
-        version: 0.21.2(@floating-ui/dom@1.7.6)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
+        version: 0.21.2(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.101.0(react@19.2.7)
@@ -318,7 +324,7 @@ importers:
         version: 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tiptap/core':
         specifier: 'catalog:'
-        version: 3.26.1(@tiptap/pm@3.23.4)
+        version: 3.27.1(@tiptap/pm@3.23.4)
       cmdk:
         specifier: 'catalog:'
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -476,6 +482,15 @@ importers:
       '@plumix/core':
         specifier: workspace:*
         version: link:../core
+      '@tiptap/core':
+        specifier: 'catalog:'
+        version: 3.27.1(@tiptap/pm@3.23.4)
+      '@tiptap/react':
+        specifier: 'catalog:'
+        version: 3.27.1(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tiptap/starter-kit':
+        specifier: 'catalog:'
+        version: 3.27.1
       zustand:
         specifier: ^5.0.14
         version: 5.0.14(@types/react@19.2.16)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
@@ -630,7 +645,7 @@ importers:
     dependencies:
       '@tiptap/core':
         specifier: 'catalog:'
-        version: 3.26.1(@tiptap/pm@3.23.4)
+        version: 3.27.1(@tiptap/pm@3.23.4)
       sanitize-html:
         specifier: ^2.17.4
         version: 2.17.4
@@ -4660,107 +4675,143 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@tiptap/core@3.26.1':
-    resolution: {integrity: sha512-TX9PyPqBoix0qDLjtok/bddtdSy54QhzLVha405C07V+WySOpH3s/pWYkywehZQY0SQtcrcY4MNSCeQjCbA28A==}
+  '@tiptap/core@3.27.1':
+    resolution: {integrity: sha512-rV6Qn4wmC6BxfF+4mu6bqGWj9vA4oXXhsrpXaJL2uhjxeHAGofjwcHof2X84VYzeyXgdlsGmqKie4TAppVXZUQ==}
     peerDependencies:
       '@tiptap/pm': 3.23.4
 
-  '@tiptap/extension-blockquote@3.23.5':
-    resolution: {integrity: sha512-PBQRoGfSWfIY7HmGbS5PTHEBQl5nKbild5J5phPLFF+O3aOBQ0d49AC9cxbaou/6FRCtq6g4Uqse9rRTKJRM0w==}
+  '@tiptap/extension-blockquote@3.27.1':
+    resolution: {integrity: sha512-VMF7xJx6qEGiX6DTKNiL31NLqypOcd/4sNjFSe8rb41PwejBJh/nOqVIbBvWkiT6NMGFLxMhj7zJ8/zPo1hXeg==}
     peerDependencies:
-      '@tiptap/core': 3.23.5
+      '@tiptap/core': 3.27.1
 
-  '@tiptap/extension-bold@3.23.5':
-    resolution: {integrity: sha512-DZsDCCf53fA9HmsFzfUHl5jLOwDYf+XzfP+QJjJ4cK23SsxDirameTjgnwi4l1EgEPLWunMZQjU+wHmh7vvX6Q==}
+  '@tiptap/extension-bold@3.27.1':
+    resolution: {integrity: sha512-TlC5bsS+pqETTrlz4CZz9RO/cKBYtELGIxwtKeivUn3eNfnOxQbbu4WDsiwIfzRFyd0OMnKl6BPM2KnYEehoEQ==}
     peerDependencies:
-      '@tiptap/core': 3.23.5
+      '@tiptap/core': 3.27.1
 
-  '@tiptap/extension-bubble-menu@3.23.5':
-    resolution: {integrity: sha512-otcGwyVO6OfxdDPnbooZxYGrb+6q5WYmS+g2V+XGGNRn5oJgyY5pW0dqELIUJ66dosIIXXPyw2XqBDpMMY2kyQ==}
+  '@tiptap/extension-bubble-menu@3.27.1':
+    resolution: {integrity: sha512-j/j8Qp9Z5nViade2m7zjrO/CYH/Ca80Qj7aqo0eUaei6FZQ5izlF9o4XQU5EFMAutV6mwynsPUp8FVo5sCuYfw==}
     peerDependencies:
-      '@tiptap/core': 3.23.5
+      '@tiptap/core': 3.27.1
       '@tiptap/pm': 3.23.4
 
-  '@tiptap/extension-code-block@3.23.5':
-    resolution: {integrity: sha512-P2XH8WPM4UahavcWoQgAwNAKQCbF/JWi6ZqgsQmVBfAqQ3mf8gMxB7HnciMq1DlyI9EfjXoJH11yUqldF/6AaQ==}
+  '@tiptap/extension-bullet-list@3.27.1':
+    resolution: {integrity: sha512-faCUHnRP47o9Zh9VZZX6EX/569udw9Vopm2PgEKPWuKLE2qaS5WBuUVU0iItdJmKUqaWiOZkpoW4jvnDmj0dfg==}
     peerDependencies:
-      '@tiptap/core': 3.23.5
+      '@tiptap/extension-list': 3.27.1
+
+  '@tiptap/extension-code-block@3.27.1':
+    resolution: {integrity: sha512-pHlzmZx2OlHfyQ0yRlT5UL4mGokz947DthZuYefN1OleVqOkHpWBG+2JQwqoNq6bmzMne92zbH32rhcJUEYSjA==}
+    peerDependencies:
+      '@tiptap/core': 3.27.1
       '@tiptap/pm': 3.23.4
 
-  '@tiptap/extension-code@3.23.5':
-    resolution: {integrity: sha512-NOJUD2Z0hrtBWnovXiiH1XtOjEQePOfIG3bNJgXSs1bWxPVhqp6KjVd8mUJNra974hxbml3tC97sL9QqjpAWFg==}
+  '@tiptap/extension-code@3.27.1':
+    resolution: {integrity: sha512-epOUpFfEmBzjvnqvjv2qHX7NAuLo5dlOGV690lWu+sAYMjibuJBeVvAiKPyFCfRCCTUxdbDB3jbaOA1yEcEJ7w==}
     peerDependencies:
-      '@tiptap/core': 3.23.5
+      '@tiptap/core': 3.27.1
 
-  '@tiptap/extension-document@3.23.4':
-    resolution: {integrity: sha512-YC4G6VkxT629rlqUTwD6XvOpxjvghn7fxrK4RbyKVJY2C6E1vgmX0won1Ast6v+qTE6iONOMS6f6VyPxSGjg4w==}
+  '@tiptap/extension-document@3.27.1':
+    resolution: {integrity: sha512-8FbBTkfnRP4iVaoj+2h3iWa+H0eGDD3yTyVCwrmue/sQTkqUNUoSuAZa3GDG4Sd41xdPwTJxl9nUWGgM1qDCnw==}
     peerDependencies:
-      '@tiptap/core': 3.23.4
+      '@tiptap/core': 3.27.1
 
-  '@tiptap/extension-floating-menu@3.23.5':
-    resolution: {integrity: sha512-kP0bZKH/lxNogfvoIy/YJZ5gkty0OwqFVtQUwoc85vXYUfvy5Jh1VdO053tCE1iDzmvOITUpcb+MdWryP8dBxA==}
+  '@tiptap/extension-dropcursor@3.27.1':
+    resolution: {integrity: sha512-blFf9x9RG0Qr7P3FoAH/033ffa+mMLZn34trVs8Vi0Ppk6FmJAg5HpYFOtmYoeREdNDJ5rHJKV7SoACbOHgskQ==}
+    peerDependencies:
+      '@tiptap/extensions': 3.27.1
+
+  '@tiptap/extension-floating-menu@3.27.1':
+    resolution: {integrity: sha512-BmJF1VqB7dSJkgAalrpVFj88WLhxKjcWPuWHOqf2ITrUU2832BhKLXKmxjWUy1gqV8PfNNVWtGfIERy7I0y0+Q==}
     peerDependencies:
       '@floating-ui/dom': ^1.0.0
-      '@tiptap/core': 3.23.5
+      '@tiptap/core': 3.27.1
       '@tiptap/pm': 3.23.4
 
-  '@tiptap/extension-hard-break@3.23.4':
-    resolution: {integrity: sha512-ODlpZCi7n136BH9luM09EFL8Pg+bbRCd0tzCQM5BKMXRkLitYZA8Gl/f5DLmGJ50wzFsDPXK2Br2g9UvZK7COg==}
+  '@tiptap/extension-gapcursor@3.27.1':
+    resolution: {integrity: sha512-QoezN0wdvXIwLQ4ee2ccWDaX3RG0lzgQpIMpMz55oPDhpUVax1+19ApsS53LkcktpS4EbnPL4xO4DaJk0Vp7PQ==}
     peerDependencies:
-      '@tiptap/core': 3.23.4
+      '@tiptap/extensions': 3.27.1
 
-  '@tiptap/extension-heading@3.23.5':
-    resolution: {integrity: sha512-tFI+iYk34geacVOGqYgyoC8siQjdGn605XaYSZcGRFF8NY+HrGlLkQi2QRRCeLaUhxoctONmWc8USn3H5U7wLQ==}
+  '@tiptap/extension-hard-break@3.27.1':
+    resolution: {integrity: sha512-iv/m9hzl6jfSj9Q8UEjAxONvCoUDaP7M9SRCPx3PaLNxA230TTD6RE0Ye4zFJ8ze7ZVoJJMAqg9Qpq1iYg2JOQ==}
     peerDependencies:
-      '@tiptap/core': 3.23.5
+      '@tiptap/core': 3.27.1
 
-  '@tiptap/extension-horizontal-rule@3.23.5':
-    resolution: {integrity: sha512-9XkRYc4XE0stERZB3y8bsJd32Jw9UZfMwZXo1GLNYRHFr7dmhSGUj0IzgofqOVmLDcOMW6XcCk54TBYw6BCrWA==}
+  '@tiptap/extension-heading@3.27.1':
+    resolution: {integrity: sha512-SrC4l1kEIyv9ZXFaI/8LQqU2MyMmjczw7XXsWUQOTN4YXv0JyVgMNR3cI/wz0d2xsTfBdZ1N85Tdng+Ga1t0Sg==}
     peerDependencies:
-      '@tiptap/core': 3.23.5
+      '@tiptap/core': 3.27.1
+
+  '@tiptap/extension-horizontal-rule@3.27.1':
+    resolution: {integrity: sha512-QlKE7qn5qMnIGVGhXQlvYedvLtNJ9z0dmit5w8vPb8tKzW4Spk6M7N2kruprrDA8GBwHfeR5wmF+njfUm34qxg==}
+    peerDependencies:
+      '@tiptap/core': 3.27.1
       '@tiptap/pm': 3.23.4
 
-  '@tiptap/extension-italic@3.23.5':
-    resolution: {integrity: sha512-XjRSPr6j4mz+8O5j5KNfxVb+1fGNt0wr+js6MLxxGdU7M+PoDPdVY6fARbmBazv4ERlZ5PNS9m35Vo5xDjDfrg==}
+  '@tiptap/extension-italic@3.27.1':
+    resolution: {integrity: sha512-jGGeyn9uRUnNjSTHpbqhiGsp6KaYTSbV09jDXPJI9cDwfV9hpugLvpaCZd0BMBbhU1B1W6kOfX0BE15qX/HQfA==}
     peerDependencies:
-      '@tiptap/core': 3.23.5
+      '@tiptap/core': 3.27.1
 
-  '@tiptap/extension-link@3.23.5':
-    resolution: {integrity: sha512-FEI58NAPnauBbs4nw1dkgRyEhcWnure0vIlStfQoQGXxj3xSRvxKH2lOkz54fGzuzRJAoudyLU65HW6D7kc+8Q==}
+  '@tiptap/extension-link@3.27.1':
+    resolution: {integrity: sha512-/2jBfsxBZUDGJmpZifqRQPz7f1E5qpS1BckTZ39TADzUJX+feKy7RJ3DtQ02+8y6SSMzvP9loGVjrk6zEMTk4g==}
     peerDependencies:
-      '@tiptap/core': 3.23.5
+      '@tiptap/core': 3.27.1
       '@tiptap/pm': 3.23.4
 
-  '@tiptap/extension-list@3.23.5':
-    resolution: {integrity: sha512-nzZXpVwnyKwTj4TVyPyu1bCUFjJCsaXnhAthmvJDnX3RBtemNG9Ka07xGR2NIspzumSbQSMFtDxjmxv3W5dEtg==}
+  '@tiptap/extension-list-item@3.27.1':
+    resolution: {integrity: sha512-zwRl01ETfCkWUvtvK5fw9bXtAajMPkvlkE3Cq6JvH3LF7XXJwDtNj5Tj7exacMpCaSZmlNc43vFb2rAYnrnwMA==}
     peerDependencies:
-      '@tiptap/core': 3.23.5
+      '@tiptap/extension-list': 3.27.1
+
+  '@tiptap/extension-list-keymap@3.27.1':
+    resolution: {integrity: sha512-OIMZNlzPSO8WRd4ic73Fxckzl4N1tesjjLL2XApaNA/uMpO0LoF6WSRPAWv+Z24Wp92ARRJAnRP7iZoI5+Jxig==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.27.1
+
+  '@tiptap/extension-list@3.27.1':
+    resolution: {integrity: sha512-c2Upru7lj0/ZV/Ibww6cNz6sUS8m6Dp/9uygFhYcZOd3X8M0xBIEk42c6m6SQehkPziVA8QOgNJz7sMqsbz1OQ==}
+    peerDependencies:
+      '@tiptap/core': 3.27.1
       '@tiptap/pm': 3.23.4
 
-  '@tiptap/extension-paragraph@3.23.5':
-    resolution: {integrity: sha512-LtgMcR1rvWnZDtphFJ/LBltlC0+6HGA07k7vhy+U7P/zIg/V3Fb4RD6YDuAo0cPfBsLm8p1WYJV92WpAsGgtlg==}
+  '@tiptap/extension-ordered-list@3.27.1':
+    resolution: {integrity: sha512-GYrKqD//9nHJ2r80uXqbDMzRnFpGzbaEQRTSGaO/SH7DvXWFMow8evkOdjQ7PCQO07jNjJo75+A85Jwu3Ov3AA==}
     peerDependencies:
-      '@tiptap/core': 3.23.5
+      '@tiptap/extension-list': 3.27.1
 
-  '@tiptap/extension-strike@3.23.5':
-    resolution: {integrity: sha512-PMB9lpQGOJGuRTIS9rBw8UZtHQwmsiJbWKjcBr5z20MluaJQ3ZCHFhDYG6ncIDRz+0ny4ZvoJ7cKGpI+NTvXMA==}
+  '@tiptap/extension-paragraph@3.27.1':
+    resolution: {integrity: sha512-7K7eo1gruOgAsnbK+GCV23AUVUI0cL1bTig8HaPneoFMVbig7vddk8jNLKBWO8TXVbG7TuHdnDN4F98vdtwh5Q==}
     peerDependencies:
-      '@tiptap/core': 3.23.5
+      '@tiptap/core': 3.27.1
+
+  '@tiptap/extension-strike@3.27.1':
+    resolution: {integrity: sha512-Y3DW1jlSlCNCyMGHP3+3qBNNPS83wuFz4RTYGjZtvRRTCRh7apZme9XRWMq1rN5mJ2Cr7fKocA2/5Bs13KgN6Q==}
+    peerDependencies:
+      '@tiptap/core': 3.27.1
 
   '@tiptap/extension-text-align@3.23.5':
     resolution: {integrity: sha512-eOeXrbpPWc6gfXli2aXYg9t61HhkvEkdxQgpEpZPFhrT4pPQcIqTlihswByC+cPb8B5ynrc/iamiY9cRSU1qvw==}
     peerDependencies:
       '@tiptap/core': 3.23.5
 
-  '@tiptap/extension-text@3.23.4':
-    resolution: {integrity: sha512-q9kxver/MR18p66aWZHSPycnr9hcBFyVGeGj8gf+BQCzn5hpvtSYTfLvk1nq8GFhygdQ9/e3f7B5ovrm/jnpvw==}
+  '@tiptap/extension-text@3.27.1':
+    resolution: {integrity: sha512-6ZwaZwSrDh+KFFv6V1J79oO37yPs7y1bFxvk1/9Ih2rn3Xr5AWz+eMS+n8RpH3djBVVAQpdIAeYQgcn+VCSsTg==}
     peerDependencies:
-      '@tiptap/core': 3.23.4
+      '@tiptap/core': 3.27.1
 
-  '@tiptap/extension-underline@3.23.5':
-    resolution: {integrity: sha512-fyxthzE6CNCi9a9OVAwXs1sSyJ7jlrzT3aP2KhYLQCsJABHaPJgJA7k52/CRuKqCW3WbxU1ULH9LGuGtBbhEyw==}
+  '@tiptap/extension-underline@3.27.1':
+    resolution: {integrity: sha512-N889J4nXN/TPfVt8uF9N1A0SY82E90zwc1y26lqOcw6KWNLmQrlhMh/9OD4ikLDbekmFpOBq/UicpHf/6S8hbQ==}
     peerDependencies:
-      '@tiptap/core': 3.23.5
+      '@tiptap/core': 3.27.1
+
+  '@tiptap/extensions@3.27.1':
+    resolution: {integrity: sha512-1Tdx9faw8k0/83V6X+xCDVhV8yElGt95JxeW3YMkKQJI56QdlPz0xOdJPlMiSGJKinPyVier+x9LJD/YZUZIaw==}
+    peerDependencies:
+      '@tiptap/core': 3.27.1
+      '@tiptap/pm': 3.23.4
 
   '@tiptap/html@3.23.5':
     resolution: {integrity: sha512-lFJbuL3mFHvqe9BaFbEd43cb/lHKAoM0O69opFJLlIYn3dre6kt64Qr7UOXQ3dp6mRU0ptVUwBV3R1eG9EPpUQ==}
@@ -4772,15 +4823,18 @@ packages:
   '@tiptap/pm@3.23.4':
     resolution: {integrity: sha512-+C5ngcoza47n3MjtjVBqBEBICPC0McdbwzJ+X6SSCviCLoqnSYanv5mIX9HWG0Q4fJ4BkdNM3VibZUxQaTbKyQ==}
 
-  '@tiptap/react@3.23.5':
-    resolution: {integrity: sha512-aEdKfJxoa6tCEV4FrnBqMQoUPwGcTWLaDzmP4fL1gR7E40rYDTiYNKoF1Ob+UimUpguAP6Emv1WlJa5oyI8FSw==}
+  '@tiptap/react@3.27.1':
+    resolution: {integrity: sha512-/Wn2fc9zMtX08MXYScDFsm4wJ8lzfhfPEdbtls7WCDlbtrop48PWlkHDBBJrywARfAQTB2mFs9KiFy9yrQm5Lg==}
     peerDependencies:
-      '@tiptap/core': 3.23.5
+      '@tiptap/core': 3.27.1
       '@tiptap/pm': 3.23.4
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
       '@types/react-dom': ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tiptap/starter-kit@3.27.1':
+    resolution: {integrity: sha512-vfxRsqW8rCc0k4pzo0ilU3wobVi2wqVj88VZI2SlgZlNnUAkrDGDIAph7CTa9k9fshV+O1ivpEgPC5yC046jow==}
 
   '@turbo/darwin-64@2.9.18':
     resolution: {integrity: sha512-9f27peFu16ur8c0v9nUFUEyBnbKuuFsUTjHFWfmwGfzySBXbHwzU44QhZon6Mznz0cHsIr3984NQj/bVrnGSRw==}
@@ -7920,24 +7974,6 @@ packages:
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
-  zustand@5.0.13:
-    resolution: {integrity: sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==}
-    engines: {node: '>=12.20.0'}
-    peerDependencies:
-      '@types/react': '>=18.0.0'
-      immer: '>=9.0.6'
-      react: '>=18.0.0'
-      use-sync-external-store: '>=1.2.0'
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      immer:
-        optional: true
-      react:
-        optional: true
-      use-sync-external-store:
-        optional: true
-
   zustand@5.0.14:
     resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
     engines: {node: '>=12.20.0'}
@@ -9534,32 +9570,32 @@ snapshots:
 
   '@publint/pack@0.1.4': {}
 
-  '@puckeditor/core@0.21.2(@floating-ui/dom@1.7.6)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))':
+  '@puckeditor/core@0.21.2(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))':
     dependencies:
       '@dnd-kit/helpers': 0.1.18
       '@dnd-kit/react': 0.1.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-popover': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-virtual': 3.13.24(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tiptap/core': 3.26.1(@tiptap/pm@3.23.4)
-      '@tiptap/extension-blockquote': 3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))
-      '@tiptap/extension-bold': 3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))
-      '@tiptap/extension-code': 3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))
-      '@tiptap/extension-code-block': 3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
-      '@tiptap/extension-document': 3.23.4(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))
-      '@tiptap/extension-hard-break': 3.23.4(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))
-      '@tiptap/extension-heading': 3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))
-      '@tiptap/extension-horizontal-rule': 3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
-      '@tiptap/extension-italic': 3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))
-      '@tiptap/extension-link': 3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
-      '@tiptap/extension-list': 3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
-      '@tiptap/extension-paragraph': 3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))
-      '@tiptap/extension-strike': 3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))
-      '@tiptap/extension-text': 3.23.4(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))
-      '@tiptap/extension-text-align': 3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))
-      '@tiptap/extension-underline': 3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))
-      '@tiptap/html': 3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)(happy-dom@20.9.0)
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
+      '@tiptap/extension-blockquote': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/extension-bold': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/extension-code': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/extension-code-block': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
+      '@tiptap/extension-document': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/extension-hard-break': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/extension-heading': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/extension-horizontal-rule': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
+      '@tiptap/extension-italic': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/extension-link': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
+      '@tiptap/extension-list': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
+      '@tiptap/extension-paragraph': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/extension-strike': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/extension-text': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/extension-text-align': 3.23.5(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/extension-underline': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/html': 3.23.5(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)(happy-dom@20.9.0)
       '@tiptap/pm': 3.23.4
-      '@tiptap/react': 3.23.5(@floating-ui/dom@1.7.6)(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tiptap/react': 3.27.1(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       deep-diff: 1.0.2
       fast-equals: 5.2.2
       flat: 5.0.2
@@ -9569,7 +9605,7 @@ snapshots:
       react-hotkeys-hook: 4.6.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       use-debounce: 9.0.4(react@19.2.7)
       uuid: 11.1.1
-      zustand: 5.0.13(@types/react@19.2.16)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
+      zustand: 5.0.14(@types/react@19.2.16)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
     transitivePeerDependencies:
       - '@floating-ui/dom'
       - '@types/react'
@@ -10672,96 +10708,125 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@tiptap/core@3.26.1(@tiptap/pm@3.23.4)':
+  '@tiptap/core@3.27.1(@tiptap/pm@3.23.4)':
     dependencies:
       '@tiptap/pm': 3.23.4
 
-  '@tiptap/extension-blockquote@3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))':
+  '@tiptap/extension-blockquote@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))':
     dependencies:
-      '@tiptap/core': 3.26.1(@tiptap/pm@3.23.4)
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
 
-  '@tiptap/extension-bold@3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))':
+  '@tiptap/extension-bold@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))':
     dependencies:
-      '@tiptap/core': 3.26.1(@tiptap/pm@3.23.4)
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
 
-  '@tiptap/extension-bubble-menu@3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)':
+  '@tiptap/extension-bubble-menu@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)':
     dependencies:
       '@floating-ui/dom': 1.7.6
-      '@tiptap/core': 3.26.1(@tiptap/pm@3.23.4)
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
       '@tiptap/pm': 3.23.4
     optional: true
 
-  '@tiptap/extension-code-block@3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)':
+  '@tiptap/extension-bullet-list@3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4))':
     dependencies:
-      '@tiptap/core': 3.26.1(@tiptap/pm@3.23.4)
+      '@tiptap/extension-list': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
+
+  '@tiptap/extension-code-block@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)':
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
       '@tiptap/pm': 3.23.4
 
-  '@tiptap/extension-code@3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))':
+  '@tiptap/extension-code@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))':
     dependencies:
-      '@tiptap/core': 3.26.1(@tiptap/pm@3.23.4)
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
 
-  '@tiptap/extension-document@3.23.4(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))':
+  '@tiptap/extension-document@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))':
     dependencies:
-      '@tiptap/core': 3.26.1(@tiptap/pm@3.23.4)
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
 
-  '@tiptap/extension-floating-menu@3.23.5(@floating-ui/dom@1.7.6)(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)':
+  '@tiptap/extension-dropcursor@3.27.1(@tiptap/extensions@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4))':
+    dependencies:
+      '@tiptap/extensions': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
+
+  '@tiptap/extension-floating-menu@3.27.1(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)':
     dependencies:
       '@floating-ui/dom': 1.7.6
-      '@tiptap/core': 3.26.1(@tiptap/pm@3.23.4)
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
       '@tiptap/pm': 3.23.4
     optional: true
 
-  '@tiptap/extension-hard-break@3.23.4(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))':
+  '@tiptap/extension-gapcursor@3.27.1(@tiptap/extensions@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4))':
     dependencies:
-      '@tiptap/core': 3.26.1(@tiptap/pm@3.23.4)
+      '@tiptap/extensions': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
 
-  '@tiptap/extension-heading@3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))':
+  '@tiptap/extension-hard-break@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))':
     dependencies:
-      '@tiptap/core': 3.26.1(@tiptap/pm@3.23.4)
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
 
-  '@tiptap/extension-horizontal-rule@3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)':
+  '@tiptap/extension-heading@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))':
     dependencies:
-      '@tiptap/core': 3.26.1(@tiptap/pm@3.23.4)
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
+
+  '@tiptap/extension-horizontal-rule@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)':
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
       '@tiptap/pm': 3.23.4
 
-  '@tiptap/extension-italic@3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))':
+  '@tiptap/extension-italic@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))':
     dependencies:
-      '@tiptap/core': 3.26.1(@tiptap/pm@3.23.4)
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
 
-  '@tiptap/extension-link@3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)':
+  '@tiptap/extension-link@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)':
     dependencies:
-      '@tiptap/core': 3.26.1(@tiptap/pm@3.23.4)
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
       '@tiptap/pm': 3.23.4
       linkifyjs: 4.3.3
 
-  '@tiptap/extension-list@3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)':
+  '@tiptap/extension-list-item@3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4))':
     dependencies:
-      '@tiptap/core': 3.26.1(@tiptap/pm@3.23.4)
+      '@tiptap/extension-list': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
+
+  '@tiptap/extension-list-keymap@3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4))':
+    dependencies:
+      '@tiptap/extension-list': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
+
+  '@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)':
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
       '@tiptap/pm': 3.23.4
 
-  '@tiptap/extension-paragraph@3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))':
+  '@tiptap/extension-ordered-list@3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4))':
     dependencies:
-      '@tiptap/core': 3.26.1(@tiptap/pm@3.23.4)
+      '@tiptap/extension-list': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
 
-  '@tiptap/extension-strike@3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))':
+  '@tiptap/extension-paragraph@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))':
     dependencies:
-      '@tiptap/core': 3.26.1(@tiptap/pm@3.23.4)
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
 
-  '@tiptap/extension-text-align@3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))':
+  '@tiptap/extension-strike@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))':
     dependencies:
-      '@tiptap/core': 3.26.1(@tiptap/pm@3.23.4)
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
 
-  '@tiptap/extension-text@3.23.4(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))':
+  '@tiptap/extension-text-align@3.23.5(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))':
     dependencies:
-      '@tiptap/core': 3.26.1(@tiptap/pm@3.23.4)
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
 
-  '@tiptap/extension-underline@3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))':
+  '@tiptap/extension-text@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))':
     dependencies:
-      '@tiptap/core': 3.26.1(@tiptap/pm@3.23.4)
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
 
-  '@tiptap/html@3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)(happy-dom@20.9.0)':
+  '@tiptap/extension-underline@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))':
     dependencies:
-      '@tiptap/core': 3.26.1(@tiptap/pm@3.23.4)
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
+
+  '@tiptap/extensions@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)':
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
+      '@tiptap/pm': 3.23.4
+
+  '@tiptap/html@3.23.5(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)(happy-dom@20.9.0)':
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
       '@tiptap/pm': 3.23.4
       happy-dom: 20.9.0
 
@@ -10780,9 +10845,9 @@ snapshots:
       prosemirror-transform: 1.12.0
       prosemirror-view: 1.41.8
 
-  '@tiptap/react@3.23.5(@floating-ui/dom@1.7.6)(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@tiptap/react@3.27.1(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@tiptap/core': 3.26.1(@tiptap/pm@3.23.4)
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
       '@tiptap/pm': 3.23.4
       '@types/react': 19.2.16
       '@types/react-dom': 19.2.3(@types/react@19.2.16)
@@ -10792,10 +10857,37 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       use-sync-external-store: 1.6.0(react@19.2.7)
     optionalDependencies:
-      '@tiptap/extension-bubble-menu': 3.23.5(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
-      '@tiptap/extension-floating-menu': 3.23.5(@floating-ui/dom@1.7.6)(@tiptap/core@3.26.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
+      '@tiptap/extension-bubble-menu': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
+      '@tiptap/extension-floating-menu': 3.27.1(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
     transitivePeerDependencies:
       - '@floating-ui/dom'
+
+  '@tiptap/starter-kit@3.27.1':
+    dependencies:
+      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
+      '@tiptap/extension-blockquote': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/extension-bold': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/extension-bullet-list': 3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4))
+      '@tiptap/extension-code': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/extension-code-block': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
+      '@tiptap/extension-document': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/extension-dropcursor': 3.27.1(@tiptap/extensions@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4))
+      '@tiptap/extension-gapcursor': 3.27.1(@tiptap/extensions@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4))
+      '@tiptap/extension-hard-break': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/extension-heading': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/extension-horizontal-rule': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
+      '@tiptap/extension-italic': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/extension-link': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
+      '@tiptap/extension-list': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
+      '@tiptap/extension-list-item': 3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4))
+      '@tiptap/extension-list-keymap': 3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4))
+      '@tiptap/extension-ordered-list': 3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4))
+      '@tiptap/extension-paragraph': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/extension-strike': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/extension-text': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/extension-underline': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/extensions': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
+      '@tiptap/pm': 3.23.4
 
   '@turbo/darwin-64@2.9.18':
     optional: true
@@ -14205,12 +14297,6 @@ snapshots:
       zod: 4.4.3
 
   zod@4.4.3: {}
-
-  zustand@5.0.13(@types/react@19.2.16)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)):
-    optionalDependencies:
-      '@types/react': 19.2.16
-      react: 19.2.7
-      use-sync-external-store: 1.6.0(react@19.2.7)
 
   zustand@5.0.14(@types/react@19.2.16)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)):
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,7 +28,9 @@ catalog:
   "@testing-library/jest-dom": ^6.9.1
   "@testing-library/react": ^16.3.2
   "@testing-library/user-event": ^14.6.1
-  "@tiptap/core": ^3.26.1
+  "@tiptap/core": ^3.27.1
+  "@tiptap/react": ^3.27.1
+  "@tiptap/starter-kit": ^3.27.1
   "@types/node": ^24.13.2
   "@types/react": ^19.2.16
   "@types/react-dom": ^19.2.3


### PR DESCRIPTION
Rich-text block bodies are now edited in the right rail with a real Tiptap
editor instead of the raw-HTML text fallback. Selecting a text block shows a
toolbar — headings (h2–h4), bold/italic/underline/strike, highlight,
bullet/ordered lists, link, and clear-format — and edits flow live to the
canvas and persist through the existing patch loop. Closes #1114.

The editor composes StarterKit's block nodes with the shared `@plumix/blocks`
core marks (StarterKit's own marks disabled so they don't double-register), so
the editor and the renderer share one mark vocabulary. Heading levels are
capped at h2–h4 to match the render sanitizer; text colour is omitted on
purpose (the sanitizer strips inline styles, so it can't round-trip — highlight
covers the colour affordance).

The focus-retention contract is the delicate part: the Tiptap instance is
created once and external value changes are synced with `setContent` guarded on
`getHTML()` equality, so the live patch loop's re-renders never steal focus or
reset the caret. An e2e types a multi-character burst to pin this, and another
asserts switching between text blocks swaps the rail content with no bleed.

`@tiptap/react` and `@tiptap/starter-kit` join `@tiptap/core` in the workspace
catalog (bumped to ^3.27.1) so the whole family stays in lockstep on one
ProseMirror schema — `@plumix/blocks` is rebuilt against it (432 unit green).

Verification: 202 admin-editor unit + 15 playground e2e (the rail reveal,
live-typing/focus-retention, and block-switch tests are new); lint, typecheck,
knip, and format pass. Screenshots of the rail in light and dark mode were
shared during review.