### PR TITLE
feat: add preview mode and revision read-only restore to the editor

### DIFF
--- a/packages/admin-editor/e2e/editor-visual.spec.ts
+++ b/packages/admin-editor/e2e/editor-visual.spec.ts
@@ -346,6 +346,34 @@ test.describe("editor playground", () => {
     await expect(editor).not.toContainText("standalone harness");
   });
 
+  test("the edit toolbar exposes a copy-preview-link action", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await expect(page.getByTestId("plumix-copy-preview-link")).toBeVisible();
+  });
+
+  test("preview mode hides the editing chrome and renders read-only", async ({
+    page,
+  }) => {
+    await page.goto("/?readonly");
+
+    // The preview shell renders the banner + canvas, no editing rails/toolbar.
+    await expect(page.getByTestId("plumix-editor-preview")).toBeVisible();
+    await expect(page.getByTestId("playground-preview-banner")).toBeVisible();
+    await expect(page.getByTestId("plumix-editor-toolbar")).toHaveCount(0);
+    await expect(page.getByTestId("plumix-editor-left")).toHaveCount(0);
+    await expect(page.getByTestId("plumix-add-block")).toHaveCount(0);
+
+    // The real theme still renders the content; clicking a block draws no
+    // selection overlay (no editing affordances).
+    const canvas = page.frameLocator(CANVAS_FRAME);
+    await expect(canvas.locator('[data-plumix-id="heading-1"]')).toBeVisible();
+    await canvas.locator('[data-plumix-id="heading-1"]').click();
+    await expect(page.getByTestId("plumix-overlay-selected")).toHaveCount(0);
+    await expect(page.getByTestId("plumix-selection-toolbar")).toHaveCount(0);
+  });
+
   test("the Layers tab outlines the nested structure", async ({ page }) => {
     await page.goto("/");
 

--- a/packages/admin-editor/locales/ar.po
+++ b/packages/admin-editor/locales/ar.po
@@ -44,6 +44,11 @@ msgid "editor.tab.blocks"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.copyPreviewLink"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.delete"
 msgstr ""

--- a/packages/admin-editor/locales/de.po
+++ b/packages/admin-editor/locales/de.po
@@ -44,6 +44,11 @@ msgid "editor.tab.blocks"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.copyPreviewLink"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.delete"
 msgstr ""

--- a/packages/admin-editor/locales/en.po
+++ b/packages/admin-editor/locales/en.po
@@ -44,6 +44,11 @@ msgid "editor.tab.blocks"
 msgstr "Blocks"
 
 #. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.copyPreviewLink"
+msgstr "Copy preview link"
+
+#. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.delete"
 msgstr "Delete"

--- a/packages/admin-editor/locales/uk.po
+++ b/packages/admin-editor/locales/uk.po
@@ -44,6 +44,11 @@ msgid "editor.tab.blocks"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.copyPreviewLink"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.delete"
 msgstr ""

--- a/packages/admin-editor/locales/zh-CN.po
+++ b/packages/admin-editor/locales/zh-CN.po
@@ -44,6 +44,11 @@ msgid "editor.tab.blocks"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.copyPreviewLink"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.delete"
 msgstr ""

--- a/packages/admin-editor/playground/host.tsx
+++ b/packages/admin-editor/playground/host.tsx
@@ -62,10 +62,34 @@ function DocumentPanelStub(): ReactElement {
   );
 }
 
+const params = new URLSearchParams(window.location.search);
 // `?theme=dark` flips the shell into dark mode so the editor (and the Tiptap
 // rail) can be exercised + screenshotted in both themes against one build.
-if (new URLSearchParams(window.location.search).get("theme") === "dark") {
+if (params.get("theme") === "dark") {
   document.documentElement.classList.add("dark");
+}
+// `?readonly` exercises preview mode: read-only canvas, editing chrome hidden,
+// a host-supplied banner standing in for the revision/restore overlay.
+const readOnly = params.has("readonly");
+
+// A stand-in for the admin's revision/share preview banner.
+function PreviewBannerStub(): ReactElement {
+  return (
+    <div
+      className="bg-muted text-muted-foreground flex items-center justify-between border-b px-4 py-2 text-sm"
+      data-testid="playground-preview-banner"
+    >
+      <span>Previewing a past revision (read-only)</span>
+      <button
+        type="button"
+        className="bg-primary text-primary-foreground rounded-md px-3 py-1 text-xs"
+        data-testid="playground-restore"
+        onClick={() => console.info("[playground] restore")}
+      >
+        Restore this revision
+      </button>
+    </div>
+  );
 }
 
 const root = document.getElementById("root");
@@ -80,6 +104,9 @@ if (root) {
           defaultValue={defineEntryContent(SEED_BLOCKS)}
           capabilities={new Set()}
           patterns={SEED_PATTERNS}
+          readOnly={readOnly}
+          previewBanner={readOnly ? <PreviewBannerStub /> : undefined}
+          previewLink="https://example.test/blog/hello?preview=demo-token"
           documentPanel={<DocumentPanelStub />}
           publish={{
             onPublish: () => console.info("[playground] publish"),

--- a/packages/admin-editor/src/canvas-frame.tsx
+++ b/packages/admin-editor/src/canvas-frame.tsx
@@ -28,6 +28,9 @@ interface CanvasFrameProps {
   readonly registry: BlockRegistry;
   /** Viewer capabilities, gating which block the empty state inserts. */
   readonly capabilities: ReadonlySet<string>;
+  /** Preview mode: still render the pushed tree, but draw no selection /
+   *  hover overlays, toolbar, drop indicators, or empty-state affordance. */
+  readonly readOnly?: boolean;
 }
 
 const SELECTED_OUTLINE = "#2563eb";
@@ -64,6 +67,7 @@ export function CanvasFrame({
   origin,
   registry,
   capabilities,
+  readOnly = false,
 }: CanvasFrameProps): ReactElement {
   const store = useEditorStoreApi();
   const device = useEditorStore((s) => s.device);
@@ -369,7 +373,7 @@ export function CanvasFrame({
       {/* Clip layer pinned over the visible canvas column. Its overflow:hidden
           keeps the absolutely-positioned overlays + toolbar from spilling onto
           the side rails when the iframe renders wider than the column. */}
-      {container && (
+      {!readOnly && container && (
         <div
           data-testid="plumix-overlay-clip"
           style={{
@@ -426,7 +430,7 @@ export function CanvasFrame({
       )}
       {/* Stays visible during a drag so an empty canvas still shows a drop
           target (no block geometry exists to draw an indicator against). */}
-      {isEmpty && (
+      {!readOnly && isEmpty && (
         <button
           type="button"
           data-testid="plumix-empty-add"

--- a/packages/admin-editor/src/editor-toolbar.test.tsx
+++ b/packages/admin-editor/src/editor-toolbar.test.tsx
@@ -125,6 +125,37 @@ describe("EditorToolbar", () => {
     expect(queryByTestId("unpublished-changes-banner")).toBeNull();
   });
 
+  test("a preview link surfaces a copy-to-clipboard action", () => {
+    const writeText = vi.fn();
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    const { getByTestId, queryByTestId } = render(
+      <I18nProvider i18n={i18n}>
+        <EditorProvider initialTree={[]}>
+          <SidebarProvider>
+            <EditorToolbar previewLink="https://x.test/blog/hi?preview=tok" />
+          </SidebarProvider>
+        </EditorProvider>
+      </I18nProvider>,
+    );
+    fireEvent.click(getByTestId("plumix-copy-preview-link"));
+    expect(writeText).toHaveBeenCalledWith(
+      "https://x.test/blog/hi?preview=tok",
+    );
+    vi.unstubAllGlobals();
+    // No link → no action.
+    cleanup();
+    render(
+      <I18nProvider i18n={i18n}>
+        <EditorProvider initialTree={[]}>
+          <SidebarProvider>
+            <EditorToolbar />
+          </SidebarProvider>
+        </EditorProvider>
+      </I18nProvider>,
+    );
+    expect(queryByTestId("plumix-copy-preview-link")).toBeNull();
+  });
+
   test("a pending draft enables discard/publish and shows the banner", () => {
     const draftMode = {
       hasPendingDraft: true,

--- a/packages/admin-editor/src/editor-toolbar.tsx
+++ b/packages/admin-editor/src/editor-toolbar.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 import { Trans } from "@lingui/react";
 
 import { Button } from "@plumix/admin-ui/button";
+import { Share2 } from "@plumix/admin-ui/icons";
 import { SidebarTrigger } from "@plumix/admin-ui/sidebar";
 
 import { canRedo, canUndo } from "./history.js";
@@ -35,9 +36,12 @@ export interface PublishActions {
 export function EditorToolbar({
   publish,
   inserter,
+  previewLink,
 }: {
   readonly publish?: PublishActions;
   readonly inserter?: ReactNode;
+  /** A shareable `?preview=…` URL; when set, a copy-to-clipboard action shows. */
+  readonly previewLink?: string;
 }): ReactElement {
   const undoAvailable = useEditorStore((s) => canUndo(s.history));
   const redoAvailable = useEditorStore((s) => canRedo(s.history));
@@ -72,8 +76,26 @@ export function EditorToolbar({
       >
         <Trans id="editor.toolbar.redo" message="Redo" />
       </Button>
+      {previewLink ? <CopyPreviewLink url={previewLink} /> : null}
       {publish ? <PublishControls publish={publish} /> : null}
     </header>
+  );
+}
+
+/** Copies the shareable preview URL to the clipboard. The host mints the URL
+ *  (a `?preview=<token>` link); this only surfaces the copy action. */
+function CopyPreviewLink({ url }: { readonly url: string }): ReactElement {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      data-testid="plumix-copy-preview-link"
+      onClick={() => void navigator.clipboard.writeText(url)}
+    >
+      <Share2 />
+      <Trans id="editor.toolbar.copyPreviewLink" message="Copy preview link" />
+    </Button>
   );
 }
 

--- a/packages/admin-editor/src/plumix-editor.test.tsx
+++ b/packages/admin-editor/src/plumix-editor.test.tsx
@@ -53,6 +53,29 @@ describe("PlumixEditor", () => {
     // Block tab is active by default → inspector empty state shows.
     expect(getByTestId("block-inspector-empty")).toBeDefined();
   });
+
+  test("read-only mode hides the editing chrome and shows the preview banner", () => {
+    const { getByTestId, queryByTestId } = render(
+      <I18nProvider i18n={i18n}>
+        <PlumixEditor
+          previewUrl="about:blank"
+          origin="http://localhost:3000"
+          defaultValue={{ version: "plumix.v2", blocks: [] }}
+          registry={registry}
+          readOnly
+          previewBanner={<div data-testid="preview-banner">Revision</div>}
+        />
+      </I18nProvider>,
+    );
+
+    // Preview shell: the canvas + banner render, the editing rails/toolbar do not.
+    expect(getByTestId("plumix-editor-preview")).toBeDefined();
+    expect(getByTestId("plumix-canvas-frame")).toBeDefined();
+    expect(getByTestId("preview-banner")).toBeDefined();
+    expect(queryByTestId("plumix-editor-layout")).toBeNull();
+    expect(queryByTestId("plumix-editor-toolbar")).toBeNull();
+    expect(queryByTestId("plumix-editor-left")).toBeNull();
+  });
 });
 
 describe("TreeChangeEmitter", () => {

--- a/packages/admin-editor/src/plumix-editor.tsx
+++ b/packages/admin-editor/src/plumix-editor.tsx
@@ -44,6 +44,13 @@ interface PlumixEditorProps {
   readonly capabilities?: ReadonlySet<string>;
   /** Theme + plugin patterns offered in the inserter alongside the blocks. */
   readonly patterns?: readonly InserterPattern[];
+  /** Preview mode: render the canvas read-only with the editing chrome hidden
+   *  (used to view a past revision or a shared draft). */
+  readonly readOnly?: boolean;
+  /** Banner shown above the canvas in preview mode (e.g. revision + restore). */
+  readonly previewBanner?: ReactNode;
+  /** A shareable `?preview=…` URL; surfaces a copy-link action in the toolbar. */
+  readonly previewLink?: string;
   /** Fires with the full content envelope whenever the tree changes. The host
    *  debounces + persists (orpc lives in the app, never in this package). */
   readonly onChange?: (content: EntryContent) => void;
@@ -68,11 +75,34 @@ export function PlumixEditor({
   registry,
   capabilities = NO_CAPABILITIES,
   patterns,
+  readOnly = false,
+  previewBanner,
+  previewLink,
   onChange,
   documentPanel,
   publish,
   overlay,
 }: PlumixEditorProps): ReactElement {
+  if (readOnly) {
+    return (
+      <EditorProvider initialTree={defaultValue?.blocks}>
+        <div
+          className="flex h-full min-h-0 flex-col"
+          data-testid="plumix-editor-preview"
+        >
+          {previewBanner}
+          <CanvasFrame
+            previewUrl={previewUrl}
+            origin={origin}
+            registry={registry}
+            capabilities={capabilities}
+            readOnly
+          />
+        </div>
+        {overlay}
+      </EditorProvider>
+    );
+  }
   return (
     <EditorProvider initialTree={defaultValue?.blocks}>
       <SidebarProvider
@@ -113,6 +143,7 @@ export function PlumixEditor({
         <SidebarInset className="min-w-0">
           <EditorToolbar
             publish={publish}
+            previewLink={previewLink}
             inserter={
               <BlockInserterPopover
                 registry={registry}

--- a/packages/admin/locales/ar.po
+++ b/packages/admin/locales/ar.po
@@ -1043,14 +1043,14 @@ msgid "terms.create.error.emptySlug"
 msgstr "تعذّر اشتقاق slug من ذلك الاسم — يرجى كتابة واحد يدوياً."
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/editor.tsx
-msgid "editor.bespoke.toast.discardFailed"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
 msgid "editor.entry.edit.toast.discardFailed"
 msgstr "تعذّر تجاهل المسودة — حاول مرة أخرى."
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.discardFailed"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/profile/passkeys-card.tsx
@@ -1133,14 +1133,14 @@ msgid "editor.bespoke.previewFailed"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/editor.tsx
-msgid "editor.bespoke.toast.publishFailed"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
 msgid "editor.entry.edit.toast.publishFailed"
 msgstr "تعذّر النشر — حاول مرة أخرى."
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.publishFailed"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/lib/oauth-errors.ts
@@ -1538,14 +1538,14 @@ msgid "entries.list.statusFilter.draft"
 msgstr "مسودة"
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/editor.tsx
-msgid "editor.bespoke.toast.discarded"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
 msgid "editor.entry.edit.toast.draftDiscarded"
 msgstr "تم تجاهل المسودة."
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.discarded"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
@@ -2091,14 +2091,14 @@ msgid "users.list.loading"
 msgstr "جارٍ تحميل المستخدمين"
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/editor.tsx
-msgid "editor.bespoke.stale.loading"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
 msgid "editor.entry.edit.stale.loading"
 msgstr "جارٍ التحميل…"
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.stale.loading"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/allowed-domains/index.tsx
@@ -2761,14 +2761,14 @@ msgid "type.generic.itemPublishedPrivately"
 msgstr "منشور بشكل خاص"
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/editor.tsx
-msgid "editor.bespoke.toast.published"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
 msgid "editor.entry.edit.toast.published"
 msgstr "تم النشر."
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.published"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/editor/revisions/RevisionsSheet.tsx
@@ -3696,6 +3696,11 @@ msgstr "هذا الجهاز"
 #: src/components/profile/passkeys-card.tsx
 msgid "profile.passkeys.enroll.noAuthenticator"
 msgstr "هذا الجهاز لا يدعم passkeys."
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.revision.conflict"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/meta-box/plugin-field-error-boundary.tsx

--- a/packages/admin/locales/de.po
+++ b/packages/admin/locales/de.po
@@ -1043,14 +1043,14 @@ msgid "terms.create.error.emptySlug"
 msgstr "Aus diesem Namen konnte kein Slug abgeleitet werden — bitte manuell eingeben."
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/editor.tsx
-msgid "editor.bespoke.toast.discardFailed"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
 msgid "editor.entry.edit.toast.discardFailed"
 msgstr "Entwurf konnte nicht verworfen werden — bitte erneut versuchen."
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.discardFailed"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/profile/passkeys-card.tsx
@@ -1133,14 +1133,14 @@ msgid "editor.bespoke.previewFailed"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/editor.tsx
-msgid "editor.bespoke.toast.publishFailed"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
 msgid "editor.entry.edit.toast.publishFailed"
 msgstr "Veröffentlichen fehlgeschlagen — bitte erneut versuchen."
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.publishFailed"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/lib/oauth-errors.ts
@@ -1538,14 +1538,14 @@ msgid "entries.list.statusFilter.draft"
 msgstr "Entwurf"
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/editor.tsx
-msgid "editor.bespoke.toast.discarded"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
 msgid "editor.entry.edit.toast.draftDiscarded"
 msgstr "Entwurf verworfen."
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.discarded"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
@@ -2091,14 +2091,14 @@ msgid "users.list.loading"
 msgstr "Benutzer werden geladen"
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/editor.tsx
-msgid "editor.bespoke.stale.loading"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
 msgid "editor.entry.edit.stale.loading"
 msgstr "Wird geladen…"
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.stale.loading"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/allowed-domains/index.tsx
@@ -2761,14 +2761,14 @@ msgid "type.generic.itemPublishedPrivately"
 msgstr "Privat veröffentlicht"
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/editor.tsx
-msgid "editor.bespoke.toast.published"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
 msgid "editor.entry.edit.toast.published"
 msgstr "Veröffentlicht."
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.published"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/editor/revisions/RevisionsSheet.tsx
@@ -3696,6 +3696,11 @@ msgstr "Dieses Gerät"
 #: src/components/profile/passkeys-card.tsx
 msgid "profile.passkeys.enroll.noAuthenticator"
 msgstr "Dieses Gerät unterstützt keine Passkeys."
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.revision.conflict"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/meta-box/plugin-field-error-boundary.tsx

--- a/packages/admin/locales/en.po
+++ b/packages/admin/locales/en.po
@@ -1043,13 +1043,13 @@ msgid "terms.create.error.emptySlug"
 msgstr "Couldn't derive a slug from that name — please type one manually."
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/editor.tsx
-msgid "editor.bespoke.toast.discardFailed"
+#: src/routes/_editor/entries/$slug/$id/edit.tsx
+msgid "editor.entry.edit.toast.discardFailed"
 msgstr "Couldn't discard the draft — try again."
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/edit.tsx
-msgid "editor.entry.edit.toast.discardFailed"
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.discardFailed"
 msgstr "Couldn't discard the draft — try again."
 
 #. js-lingui-explicit-id
@@ -1133,13 +1133,13 @@ msgid "editor.bespoke.previewFailed"
 msgstr "Couldn't open this entry in the editor."
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/editor.tsx
-msgid "editor.bespoke.toast.publishFailed"
+#: src/routes/_editor/entries/$slug/$id/edit.tsx
+msgid "editor.entry.edit.toast.publishFailed"
 msgstr "Couldn't publish — try again."
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/edit.tsx
-msgid "editor.entry.edit.toast.publishFailed"
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.publishFailed"
 msgstr "Couldn't publish — try again."
 
 #. js-lingui-explicit-id
@@ -1538,13 +1538,13 @@ msgid "entries.list.statusFilter.draft"
 msgstr "Draft"
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/editor.tsx
-msgid "editor.bespoke.toast.discarded"
+#: src/routes/_editor/entries/$slug/$id/edit.tsx
+msgid "editor.entry.edit.toast.draftDiscarded"
 msgstr "Draft discarded."
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/edit.tsx
-msgid "editor.entry.edit.toast.draftDiscarded"
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.discarded"
 msgstr "Draft discarded."
 
 #. js-lingui-explicit-id
@@ -2091,13 +2091,13 @@ msgid "users.list.loading"
 msgstr "Loading users"
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/editor.tsx
-msgid "editor.bespoke.stale.loading"
+#: src/routes/_editor/entries/$slug/$id/edit.tsx
+msgid "editor.entry.edit.stale.loading"
 msgstr "Loading…"
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/edit.tsx
-msgid "editor.entry.edit.stale.loading"
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.stale.loading"
 msgstr "Loading…"
 
 #. js-lingui-explicit-id
@@ -2761,13 +2761,13 @@ msgid "type.generic.itemPublishedPrivately"
 msgstr "Published privately"
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/editor.tsx
-msgid "editor.bespoke.toast.published"
+#: src/routes/_editor/entries/$slug/$id/edit.tsx
+msgid "editor.entry.edit.toast.published"
 msgstr "Published."
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/edit.tsx
-msgid "editor.entry.edit.toast.published"
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.published"
 msgstr "Published."
 
 #. js-lingui-explicit-id
@@ -3696,6 +3696,11 @@ msgstr "This device"
 #: src/components/profile/passkeys-card.tsx
 msgid "profile.passkeys.enroll.noAuthenticator"
 msgstr "This device doesn't support passkeys."
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.revision.conflict"
+msgstr "This entry changed since the preview loaded — reload and retry."
 
 #. js-lingui-explicit-id
 #: src/components/meta-box/plugin-field-error-boundary.tsx

--- a/packages/admin/locales/uk.po
+++ b/packages/admin/locales/uk.po
@@ -1043,14 +1043,14 @@ msgid "terms.create.error.emptySlug"
 msgstr "Не вдалося визначити slug з цієї назви — введіть його вручну."
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/editor.tsx
-msgid "editor.bespoke.toast.discardFailed"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
 msgid "editor.entry.edit.toast.discardFailed"
 msgstr "Не вдалося відхилити чернетку — спробуйте ще раз."
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.discardFailed"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/profile/passkeys-card.tsx
@@ -1133,14 +1133,14 @@ msgid "editor.bespoke.previewFailed"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/editor.tsx
-msgid "editor.bespoke.toast.publishFailed"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
 msgid "editor.entry.edit.toast.publishFailed"
 msgstr "Не вдалося опублікувати — спробуйте ще раз."
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.publishFailed"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/lib/oauth-errors.ts
@@ -1538,14 +1538,14 @@ msgid "entries.list.statusFilter.draft"
 msgstr "Чернетка"
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/editor.tsx
-msgid "editor.bespoke.toast.discarded"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
 msgid "editor.entry.edit.toast.draftDiscarded"
 msgstr "Чернетку відхилено."
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.discarded"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
@@ -2091,14 +2091,14 @@ msgid "users.list.loading"
 msgstr "Завантаження користувачів"
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/editor.tsx
-msgid "editor.bespoke.stale.loading"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
 msgid "editor.entry.edit.stale.loading"
 msgstr "Завантаження…"
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.stale.loading"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/allowed-domains/index.tsx
@@ -2761,14 +2761,14 @@ msgid "type.generic.itemPublishedPrivately"
 msgstr "Опубліковано приватно"
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/editor.tsx
-msgid "editor.bespoke.toast.published"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
 msgid "editor.entry.edit.toast.published"
 msgstr "Опубліковано."
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.published"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/editor/revisions/RevisionsSheet.tsx
@@ -3696,6 +3696,11 @@ msgstr "Цей пристрій"
 #: src/components/profile/passkeys-card.tsx
 msgid "profile.passkeys.enroll.noAuthenticator"
 msgstr "Цей пристрій не підтримує passkeys."
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.revision.conflict"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/meta-box/plugin-field-error-boundary.tsx

--- a/packages/admin/locales/zh-CN.po
+++ b/packages/admin/locales/zh-CN.po
@@ -1043,14 +1043,14 @@ msgid "terms.create.error.emptySlug"
 msgstr "无法从此名称生成别名 — 请手动输入。"
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/editor.tsx
-msgid "editor.bespoke.toast.discardFailed"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
 msgid "editor.entry.edit.toast.discardFailed"
 msgstr "无法放弃草稿，请重试。"
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.discardFailed"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/profile/passkeys-card.tsx
@@ -1133,14 +1133,14 @@ msgid "editor.bespoke.previewFailed"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/editor.tsx
-msgid "editor.bespoke.toast.publishFailed"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
 msgid "editor.entry.edit.toast.publishFailed"
 msgstr "无法发布，请重试。"
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.publishFailed"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/lib/oauth-errors.ts
@@ -1538,14 +1538,14 @@ msgid "entries.list.statusFilter.draft"
 msgstr "草稿"
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/editor.tsx
-msgid "editor.bespoke.toast.discarded"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
 msgid "editor.entry.edit.toast.draftDiscarded"
 msgstr "已放弃草稿。"
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.discarded"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/entries/$slug/index.tsx
@@ -2091,14 +2091,14 @@ msgid "users.list.loading"
 msgstr "正在加载用户"
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/editor.tsx
-msgid "editor.bespoke.stale.loading"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
 msgid "editor.entry.edit.stale.loading"
 msgstr "加载中…"
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.stale.loading"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/routes/_authenticated/allowed-domains/index.tsx
@@ -2761,14 +2761,14 @@ msgid "type.generic.itemPublishedPrivately"
 msgstr "已私密发布"
 
 #. js-lingui-explicit-id
-#: src/routes/_editor/entries/$slug/$id/editor.tsx
-msgid "editor.bespoke.toast.published"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/routes/_editor/entries/$slug/$id/edit.tsx
 msgid "editor.entry.edit.toast.published"
 msgstr "已发布。"
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.toast.published"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/editor/revisions/RevisionsSheet.tsx
@@ -3696,6 +3696,11 @@ msgstr "此设备"
 #: src/components/profile/passkeys-card.tsx
 msgid "profile.passkeys.enroll.noAuthenticator"
 msgstr "此设备不支持 Passkey。"
+
+#. js-lingui-explicit-id
+#: src/routes/_editor/entries/$slug/$id/editor.tsx
+msgid "editor.bespoke.revision.conflict"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: src/components/meta-box/plugin-field-error-boundary.tsx

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/editor.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/editor.tsx
@@ -8,6 +8,7 @@ import { createDebouncer } from "@/editor/debounce.js";
 import { detectStaleAutosave } from "@/editor/detect-stale-autosave.js";
 import { registerCoreBlocks } from "@/editor/register-core-blocks.js";
 import { resolveEditorMode } from "@/editor/resolve-editor-mode.js";
+import { PreviewBanner } from "@/editor/revisions/PreviewBanner.js";
 import { StaleDraftDialog } from "@/editor/StaleDraftDialog.js";
 import {
   entryMetaBoxesForType,
@@ -17,9 +18,11 @@ import {
 import { orpc } from "@/lib/orpc.js";
 import { getRegisteredBlocks } from "@/lib/plugin-registry.js";
 import { toastError, toastSuccess } from "@/lib/toast.js";
+import { useFormatters } from "@/lib/use-formatters.js";
 import { useLabel } from "@/lib/use-label.js";
 import { defineMessage } from "@lingui/core/macro";
 import { Trans } from "@lingui/react";
+import { ORPCError } from "@orpc/client";
 import {
   useMutation,
   useQuery,
@@ -30,6 +33,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import * as v from "valibot";
 
 import type { EntryContent } from "@plumix/blocks";
+import type { Label } from "@plumix/core/i18n";
 import type { EntryTypeManifestEntry } from "@plumix/core/manifest";
 import { PlumixEditor } from "@plumix/admin-editor";
 import {
@@ -60,6 +64,10 @@ const M = {
     id: "editor.bespoke.stale.loading",
     message: "Loading…",
   }),
+  revisionConflict: defineMessage({
+    id: "editor.bespoke.revision.conflict",
+    message: "This entry changed since the preview loaded — reload and retry.",
+  }),
 } satisfies Record<string, MessageDescriptor>;
 
 // Core + plugin blocks supply the inspector's input schemas. Built once at
@@ -84,6 +92,12 @@ const previewLinkQuery = (
 // stays the default editor). The entry load and the preview mint both run in
 // the loader so a failure (unreadable entry, no public url) surfaces through
 // one ErrorScreen rather than a dead canvas.
+const editorSearch = v.object({
+  // Opening `?revision=<id>` views that past revision read-only with a restore
+  // banner; absent → the normal editing session.
+  revision: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1))),
+});
+
 export const Route = createFileRoute("/_editor/entries/$slug/$id/editor")({
   params: {
     parse: (raw) => {
@@ -95,6 +109,7 @@ export const Route = createFileRoute("/_editor/entries/$slug/$id/editor")({
       return { slug: raw.slug, id: result.output };
     },
   },
+  validateSearch: editorSearch,
   loader: ({ context, params }) =>
     Promise.all([
       context.queryClient.ensureQueryData(
@@ -143,6 +158,7 @@ function ErrorScreen(): ReactNode {
 function BespokeEditorRoute(): ReactNode {
   const { slug, id } = Route.useParams();
   const { user } = Route.useRouteContext();
+  const { revision } = Route.useSearch();
   const { data: entry } = useSuspenseQuery(
     orpc.entry.get.queryOptions({ input: { id, preview: true } }),
   );
@@ -152,9 +168,22 @@ function BespokeEditorRoute(): ReactNode {
   // a freshly-made draft leaves the source at "live" (no flip) — the inner
   // bumps it so the canvas drops the discarded edits. (Mirrors the Puck route,
   // which reseeds Puck in place instead.)
-  const previewSource = entry._preview?.source ?? "live";
   const [reseedNonce, setReseedNonce] = useState(0);
   const reseed = useCallback(() => setReseedNonce((n) => n + 1), []);
+
+  // A `?revision=<id>` request opens that revision read-only with a restore
+  // banner — keyed so leaving/entering preview re-seeds the canvas.
+  if (revision !== undefined) {
+    return (
+      <RevisionPreview
+        key={`revision:${String(revision)}`}
+        id={id}
+        revisionId={revision}
+        capabilities={user.capabilities}
+      />
+    );
+  }
+  const previewSource = entry._preview?.source ?? "live";
   // Pass capabilities + entryType + userId across a prop boundary so the React
   // Compiler treats them as stable inputs (member/derived reads inline read as
   // possibly-mutated, which forces the compiler to skip optimizing).
@@ -595,9 +624,13 @@ function BespokeEditor({
   );
 
   // `createPreviewLink` returns a site-relative url (`/blog/hello?preview=…`);
-  // resolve it against the admin's own origin (the public site is same-origin)
-  // and flip on `plumix.edit` so the public render boots the editor runtime.
+  // resolve it against the admin's own origin (the public site is same-origin).
+  // The shareable draft-preview link is that token URL as-is; the canvas reuses
+  // it with `plumix.edit` flipped on so the public render boots the runtime.
   const target = new URL(previewLink.url, window.location.origin);
+  // The shareable draft-preview link is the token URL as-is (captured before
+  // the edit flag is added); the canvas reuses the same URL with `plumix.edit`.
+  const shareUrl = target.toString();
   target.searchParams.set("plumix.edit", "");
 
   return (
@@ -608,10 +641,110 @@ function BespokeEditor({
       registry={registry}
       capabilities={capabilitySet}
       patterns={patterns}
+      previewLink={shareUrl}
       onChange={handleChange}
       documentPanel={documentPanel}
       publish={publishActions}
       overlay={overlay}
+    />
+  );
+}
+
+// Opens a past revision read-only in the same editor, with a banner offering
+// "back to live" and restore. Restore reuses the shared revisions RPC (which
+// lands on the caller's autosave row for autosave types, or the live row with
+// an optimistic-concurrency token for legacy types), then returns to live.
+function RevisionPreview({
+  id,
+  revisionId,
+  capabilities,
+}: {
+  readonly id: number;
+  readonly revisionId: number;
+  readonly capabilities: readonly string[];
+}): ReactNode {
+  const navigate = Route.useNavigate();
+  const queryClient = useQueryClient();
+  const renderLabel = useLabel();
+  const { formatRelative } = useFormatters();
+  const capabilitySet = useMemo(() => new Set(capabilities), [capabilities]);
+  const { data: previewLink } = useSuspenseQuery(previewLinkQuery(id));
+  const revisionQuery = useQuery(
+    orpc.entry.revisions.get.queryOptions({ input: { revisionId } }),
+  );
+  const liveQuery = useQuery(orpc.entry.get.queryOptions({ input: { id } }));
+
+  const handleBackToLive = useCallback(
+    () =>
+      void navigate({ search: (prev) => ({ ...prev, revision: undefined }) }),
+    [navigate],
+  );
+
+  const liveUpdatedAt = liveQuery.data?.updatedAt;
+  const restore = useMutation({
+    mutationFn: () =>
+      orpc.entry.revisions.restore.call({
+        revisionId,
+        // Honored only on the legacy live-write path; the autosave destination
+        // ignores it. Pass the live row's token to keep that contract.
+        expectedLiveUpdatedAt: liveUpdatedAt,
+      }),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: orpc.entry.get.queryOptions({ input: { id } }).queryKey,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: orpc.entry.get.queryOptions({
+            input: { id, preview: true },
+          }).queryKey,
+        }),
+      ]);
+      handleBackToLive();
+    },
+  });
+
+  const revision = revisionQuery.data;
+  // Gate on the live entry too: its `updatedAt` is the restore concurrency
+  // token, so Restore must not be clickable until it's loaded (an undefined
+  // token would skip the stale-check on the legacy live-write path).
+  if (!revision || !liveQuery.data) return <PendingScreen />;
+
+  const target = new URL(previewLink.url, window.location.origin);
+  target.searchParams.set("plumix.edit", "");
+
+  const restoreErrorLabel: Label | null =
+    restore.error instanceof ORPCError && restore.error.code === "CONFLICT"
+      ? M.revisionConflict
+      : restore.error instanceof Error
+        ? restore.error.message
+        : null;
+  const restoreError =
+    restoreErrorLabel !== null ? renderLabel(restoreErrorLabel) : null;
+  const revisionAuthor =
+    revision.authorName ?? revision.authorEmail ?? `#${String(revisionId)}`;
+
+  return (
+    <PlumixEditor
+      previewUrl={target.toString()}
+      origin={target.origin}
+      defaultValue={
+        isEntryContent(revision.content) ? revision.content : undefined
+      }
+      registry={registry}
+      capabilities={capabilitySet}
+      readOnly
+      previewBanner={
+        <PreviewBanner
+          revisionUpdatedAt={revision.updatedAt}
+          revisionAuthor={revisionAuthor}
+          relativeTime={formatRelative}
+          onBackToLive={handleBackToLive}
+          onRestore={() => restore.mutate()}
+          isRestoring={restore.isPending}
+          restoreError={restoreError}
+        />
+      }
     />
   );
 }


### PR DESCRIPTION
The bespoke editor can now open an entry as a read-only preview — the editing
chrome (rails, toolbar, inserter, selection overlays) is hidden and the canvas
renders the real theme behind an optional banner. Two flows use it: a shareable
draft-preview link, and viewing a past revision with restore. Closes #1111.

`PlumixEditor` gains `readOnly`, `previewBanner`, and `previewLink`. In
read-only mode it renders just the banner over a non-interactive canvas; the
iframe keeps its bridge so the host still pushes and renders the chosen tree,
but every content-mutating path (inserter, selection toolbar, drag, undo
shortcuts) is unrendered, so nothing can edit. The toolbar surfaces a
copy-preview-link action for the existing `?preview=<token>` URL, which renders
the draft read-only to authorized viewers through the unchanged token infra.

The admin route adds a `?revision=<id>` param that opens that revision in a
read-only editor with a Back-to-live + Restore banner, reusing the shared
revisions RPC (autosave-aware restore with an optimistic-concurrency token).
Restore is gated on the live entry loading first so the token is always present
— closing a lost-update window the Puck route guards via suspense.

The preview-token and revisions RPC infra already existed; this is bespoke-editor
wiring that mirrors the Puck route. Read-only behavior is covered at the package
level (unit + a playground `?readonly` e2e that asserts the chrome is hidden and
clicks draw no selection); the admin route is integration glue over proven RPC,
so it reuses the existing revision tests rather than a new route harness.

Verification: admin-editor 204 unit + 17 e2e, admin 568 unit; typecheck, lint,
knip, and format pass. Light + dark preview-mode screenshots shared during review.