### PR TITLE
feat: editor device switch, theme breakpoints, and zoom-to-fit

### DIFF
--- a/packages/admin-editor/e2e/editor-visual.spec.ts
+++ b/packages/admin-editor/e2e/editor-visual.spec.ts
@@ -374,6 +374,39 @@ test.describe("editor playground", () => {
     await expect(page.getByTestId("plumix-selection-toolbar")).toHaveCount(0);
   });
 
+  test("device switch resizes the canvas to the breakpoint widths", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const iframe = page.locator(CANVAS_FRAME);
+    const widthFor = async (device: string): Promise<number> => {
+      await page.getByTestId(`plumix-device-${device}`).click();
+      return iframe.evaluate((el) => (el as HTMLElement).offsetWidth);
+    };
+
+    // offsetWidth is the unscaled layout width (the device's breakpoint width),
+    // unaffected by the fit-to-width transform.
+    const mobile = await widthFor("mobile");
+    const tablet = await widthFor("tablet");
+    const desktop = await widthFor("desktop");
+    expect(mobile).toBeLessThan(tablet);
+    expect(tablet).toBeLessThan(desktop);
+    expect(desktop).toBe(1280);
+  });
+
+  test("zoom controls show a percentage and re-fit to width", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const percent = page.getByTestId("plumix-zoom-percent");
+    await expect(percent).toBeVisible();
+    await expect(percent).toContainText("%");
+
+    await page.getByTestId("plumix-zoom-in").click();
+    // A manual zoom pins a step; the readout reflects it.
+    await expect(percent).toContainText("%");
+  });
+
   test("the Layers tab outlines the nested structure", async ({ page }) => {
     await page.goto("/");
 

--- a/packages/admin-editor/locales/ar.po
+++ b/packages/admin-editor/locales/ar.po
@@ -64,6 +64,11 @@ msgid "editor.selection.duplicate"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.fitWidth"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/rich-text-field.tsx
 msgid "editor.richtext.hint"
 msgstr ""
@@ -161,4 +166,14 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
 msgid "editor.toolbar.unpublished"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.zoomIn"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.zoomOut"
 msgstr ""

--- a/packages/admin-editor/locales/de.po
+++ b/packages/admin-editor/locales/de.po
@@ -64,6 +64,11 @@ msgid "editor.selection.duplicate"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.fitWidth"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/rich-text-field.tsx
 msgid "editor.richtext.hint"
 msgstr ""
@@ -161,4 +166,14 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
 msgid "editor.toolbar.unpublished"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.zoomIn"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.zoomOut"
 msgstr ""

--- a/packages/admin-editor/locales/en.po
+++ b/packages/admin-editor/locales/en.po
@@ -64,6 +64,11 @@ msgid "editor.selection.duplicate"
 msgstr "Duplicate"
 
 #. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.fitWidth"
+msgstr "Fit to width"
+
+#. js-lingui-explicit-id
 #: src/rich-text-field.tsx
 msgid "editor.richtext.hint"
 msgstr "Formatting applies to the selected text."
@@ -162,3 +167,13 @@ msgstr "Undo"
 #: src/editor-toolbar.tsx
 msgid "editor.toolbar.unpublished"
 msgstr "Unpublished changes"
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.zoomIn"
+msgstr "Zoom in"
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.zoomOut"
+msgstr "Zoom out"

--- a/packages/admin-editor/locales/uk.po
+++ b/packages/admin-editor/locales/uk.po
@@ -64,6 +64,11 @@ msgid "editor.selection.duplicate"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.fitWidth"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/rich-text-field.tsx
 msgid "editor.richtext.hint"
 msgstr ""
@@ -161,4 +166,14 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
 msgid "editor.toolbar.unpublished"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.zoomIn"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.zoomOut"
 msgstr ""

--- a/packages/admin-editor/locales/zh-CN.po
+++ b/packages/admin-editor/locales/zh-CN.po
@@ -64,6 +64,11 @@ msgid "editor.selection.duplicate"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.fitWidth"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/rich-text-field.tsx
 msgid "editor.richtext.hint"
 msgstr ""
@@ -161,4 +166,14 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
 msgid "editor.toolbar.unpublished"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.zoomIn"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.zoomOut"
 msgstr ""

--- a/packages/admin-editor/src/canvas-frame.tsx
+++ b/packages/admin-editor/src/canvas-frame.tsx
@@ -17,7 +17,7 @@ import { dropPlacement } from "./drop-index.js";
 import { overlayBox } from "./overlay.js";
 import { useEditorStore, useEditorStoreApi } from "./provider.js";
 import { SelectionToolbar } from "./selection-toolbar.js";
-import { DEVICE_WIDTH } from "./store.js";
+import { deviceWidth } from "./store.js";
 
 interface CanvasFrameProps {
   /** URL the iframe loads — the entry's real route with `?plumix.edit`. */
@@ -72,6 +72,9 @@ export function CanvasFrame({
   const store = useEditorStoreApi();
   const device = useEditorStore((s) => s.device);
   const zoom = useEditorStore((s) => s.zoom);
+  const breakpoints = useEditorStore((s) => s.breakpoints);
+  const zoomFit = useEditorStore((s) => s.zoomFit);
+  const frameWidth = deviceWidth(device, breakpoints);
   const activeId = useEditorStore((s) => s.activeId);
   const selectedIds = useEditorStore((s) => s.selectedIds);
   const hoverId = useEditorStore((s) => s.hoverId);
@@ -91,6 +94,13 @@ export function CanvasFrame({
   const geometryRef = useRef<Geometry>(geometry);
   const [dropY, setDropY] = useState<number | null>(null);
   const [dropSlot, setDropSlot] = useState<SlotDrop | null>(null);
+  // The iframe's own document height (same-origin), so the frame sizes to its
+  // content — footer visible, no fixed gap below it.
+  const [contentHeight, setContentHeight] = useState<number | null>(null);
+  const measureContent = useCallback((): void => {
+    const doc = iframeRef.current?.contentDocument;
+    if (doc) setContentHeight(doc.documentElement.scrollHeight);
+  }, []);
 
   // The iframe's on-screen offset and the canvas viewport box, read live from
   // the DOM. These move on scroll, window resize, and rail collapse — none of
@@ -122,10 +132,13 @@ export function CanvasFrame({
         };
         geometryRef.current = next;
         setGeometry(next);
+        // A fresh geometry report follows a tree change, so the document height
+        // may have shifted too.
+        measureContent();
       },
     });
     return () => connection.dispose();
-  }, [store, origin, measureHost]);
+  }, [store, origin, measureHost, measureContent]);
 
   // Keep frame/container fresh when the canvas moves without a block report:
   // column scroll, window resize, and rail collapse (which resizes the inset).
@@ -150,6 +163,17 @@ export function CanvasFrame({
       observer?.disconnect();
     };
   }, [measureHost]);
+
+  // Fit-to-width: while in fit mode, scale the frame so its full width fits the
+  // canvas column (never upscaling past 100%). A manual zoom turns fit off; a
+  // device switch turns it back on, so the new width refits.
+  useEffect(() => {
+    if (!zoomFit) return;
+    const columnWidth = geometry.container?.width;
+    if (!columnWidth) return;
+    const fit = Math.min(1, columnWidth / frameWidth);
+    if (fit !== store.getState().zoom) store.getState().applyFitZoom(fit);
+  }, [zoomFit, frameWidth, geometry.container?.width, store]);
 
   // Canvas drag, shared by two sources: a catalog block being inserted
   // (dragSpec) and an existing block being moved (movingId). While dragging, the
@@ -362,9 +386,10 @@ export function CanvasFrame({
         ref={iframeRef}
         src={previewUrl}
         title="plumix-editor-canvas"
+        onLoad={measureContent}
         style={{
-          width: DEVICE_WIDTH[device],
-          height: CANVAS_HEIGHT,
+          width: frameWidth,
+          height: contentHeight ?? CANVAS_HEIGHT,
           border: 0,
           transform: `scale(${String(zoom)})`,
           transformOrigin: "top left",
@@ -418,7 +443,7 @@ export function CanvasFrame({
                 position: "absolute",
                 left: geometry.frame.left - container.left,
                 top: dropY - container.top,
-                width: DEVICE_WIDTH[device] * zoom,
+                width: frameWidth * zoom,
                 height: 2,
                 background: SELECTED_OUTLINE,
                 pointerEvents: "none",

--- a/packages/admin-editor/src/editor-canvas.tsx
+++ b/packages/admin-editor/src/editor-canvas.tsx
@@ -85,6 +85,16 @@ export function EditorCanvas({
     reportGeometry();
   }, [tree, reportGeometry]);
 
+  // Re-report after async layout shifts that aren't tree changes — late image
+  // loads, web-font swap, island hydration — so the host's content-height sizing
+  // and overlay rects track the settled document, not just the initial paint.
+  useEffect(() => {
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => reportGeometry());
+    observer.observe(document.documentElement);
+    return () => observer.disconnect();
+  }, [reportGeometry]);
+
   const blockIdAt = (event: MouseEvent<HTMLDivElement>): string | null => {
     const block = (event.target as HTMLElement).closest("[data-plumix-id]");
     return block?.getAttribute("data-plumix-id") ?? null;

--- a/packages/admin-editor/src/editor-toolbar.test.tsx
+++ b/packages/admin-editor/src/editor-toolbar.test.tsx
@@ -125,6 +125,24 @@ describe("EditorToolbar", () => {
     expect(queryByTestId("unpublished-changes-banner")).toBeNull();
   });
 
+  test("device switch + zoom controls drive the store", () => {
+    const { getByTestId } = renderToolbar();
+
+    // Device switch.
+    fireEvent.click(getByTestId("plumix-device-tablet"));
+    expect(storeApi?.getState().device).toBe("tablet");
+
+    // Zoom in steps up and turns off fit; the percent reflects it.
+    fireEvent.click(getByTestId("plumix-zoom-in"));
+    expect(storeApi?.getState().zoomFit).toBe(false);
+    expect(Number(storeApi?.getState().zoom)).toBeGreaterThan(1);
+    expect(getByTestId("plumix-zoom-percent").textContent).toContain("%");
+
+    // The percent readout re-enables fit-to-width.
+    fireEvent.click(getByTestId("plumix-zoom-percent"));
+    expect(storeApi?.getState().zoomFit).toBe(true);
+  });
+
   test("a preview link surfaces a copy-to-clipboard action", () => {
     const writeText = vi.fn();
     vi.stubGlobal("navigator", { clipboard: { writeText } });

--- a/packages/admin-editor/src/editor-toolbar.tsx
+++ b/packages/admin-editor/src/editor-toolbar.tsx
@@ -1,13 +1,33 @@
 import type { ReactElement, ReactNode } from "react";
 import { useEffect } from "react";
-import { Trans } from "@lingui/react";
+import { Trans, useLingui } from "@lingui/react";
 
 import { Button } from "@plumix/admin-ui/button";
-import { Share2 } from "@plumix/admin-ui/icons";
+import {
+  Monitor,
+  Share2,
+  Smartphone,
+  Tablet,
+  ZoomIn,
+  ZoomOut,
+} from "@plumix/admin-ui/icons";
 import { SidebarTrigger } from "@plumix/admin-ui/sidebar";
+import { ToggleGroup, ToggleGroupItem } from "@plumix/admin-ui/toggle-group";
 
+import type { EditorDevice } from "./store.js";
 import { canRedo, canUndo } from "./history.js";
 import { useEditorStore, useEditorStoreApi } from "./provider.js";
+
+const ZOOM_STEPS = [0.5, 0.75, 1, 1.25, 1.5, 2] as const;
+
+const DEVICES: readonly {
+  readonly value: EditorDevice;
+  readonly Icon: typeof Monitor;
+}[] = [
+  { value: "desktop", Icon: Monitor },
+  { value: "tablet", Icon: Tablet },
+  { value: "mobile", Icon: Smartphone },
+];
 
 /** Draft-mode actions for a published entry with a pending autosave. The host
  *  owns the mutations; the toolbar only renders the buttons and their state. */
@@ -56,6 +76,7 @@ export function EditorToolbar({
       {/* Collapses both rails for a focused canvas (also Cmd/Ctrl+B). */}
       <SidebarTrigger data-testid="plumix-rails-toggle" />
       {inserter}
+      <DeviceZoomControls />
       <Button
         type="button"
         variant="ghost"
@@ -79,6 +100,90 @@ export function EditorToolbar({
       {previewLink ? <CopyPreviewLink url={previewLink} /> : null}
       {publish ? <PublishControls publish={publish} /> : null}
     </header>
+  );
+}
+
+/** Device switch (sizing the canvas to the theme's breakpoint widths) plus zoom
+ *  out/in and a percent readout that doubles as the fit-to-width action. */
+function DeviceZoomControls(): ReactElement {
+  const { i18n } = useLingui();
+  const device = useEditorStore((s) => s.device);
+  const zoom = useEditorStore((s) => s.zoom);
+  const setDevice = useEditorStore((s) => s.setDevice);
+  const setZoom = useEditorStore((s) => s.setZoom);
+  const enableZoomFit = useEditorStore((s) => s.enableZoomFit);
+
+  const zoomOut = (): void =>
+    setZoom([...ZOOM_STEPS].reverse().find((s) => s < zoom - 0.01) ?? zoom);
+  const zoomIn = (): void =>
+    setZoom(ZOOM_STEPS.find((s) => s > zoom + 0.01) ?? zoom);
+
+  return (
+    <div
+      className="flex items-center gap-1"
+      data-testid="plumix-canvas-controls"
+    >
+      <ToggleGroup
+        type="single"
+        variant="outline"
+        size="sm"
+        value={device}
+        onValueChange={(value) => {
+          if (value) setDevice(value as EditorDevice);
+        }}
+      >
+        {DEVICES.map(({ value, Icon }) => (
+          <ToggleGroupItem
+            key={value}
+            value={value}
+            data-testid={`plumix-device-${value}`}
+            aria-label={i18n._({
+              id: `editor.toolbar.device.${value}`,
+              message: value,
+            })}
+          >
+            <Icon />
+          </ToggleGroupItem>
+        ))}
+      </ToggleGroup>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="size-8 p-0"
+        data-testid="plumix-zoom-out"
+        onClick={zoomOut}
+        aria-label={i18n._({
+          id: "editor.toolbar.zoomOut",
+          message: "Zoom out",
+        })}
+      >
+        <ZoomOut />
+      </Button>
+      <button
+        type="button"
+        data-testid="plumix-zoom-percent"
+        onClick={enableZoomFit}
+        className="text-muted-foreground hover:text-foreground w-12 text-center text-xs tabular-nums"
+        title={i18n._({
+          id: "editor.toolbar.fitWidth",
+          message: "Fit to width",
+        })}
+      >
+        {Math.round(zoom * 100)}%
+      </button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="size-8 p-0"
+        data-testid="plumix-zoom-in"
+        onClick={zoomIn}
+        aria-label={i18n._({ id: "editor.toolbar.zoomIn", message: "Zoom in" })}
+      >
+        <ZoomIn />
+      </Button>
+    </div>
   );
 }
 

--- a/packages/admin-editor/src/plumix-editor.tsx
+++ b/packages/admin-editor/src/plumix-editor.tsx
@@ -2,7 +2,11 @@ import type { CSSProperties, ReactElement, ReactNode } from "react";
 import { useEffect, useRef } from "react";
 import { Trans } from "@lingui/react";
 
-import type { BlockRegistry, EntryContent } from "@plumix/blocks";
+import type {
+  BlockRegistry,
+  EntryContent,
+  ThemeBreakpoints,
+} from "@plumix/blocks";
 import {
   Sidebar,
   SidebarContent,
@@ -44,6 +48,8 @@ interface PlumixEditorProps {
   readonly capabilities?: ReadonlySet<string>;
   /** Theme + plugin patterns offered in the inserter alongside the blocks. */
   readonly patterns?: readonly InserterPattern[];
+  /** Theme breakpoints sizing the device-switch canvas widths. */
+  readonly breakpoints?: ThemeBreakpoints;
   /** Preview mode: render the canvas read-only with the editing chrome hidden
    *  (used to view a past revision or a shared draft). */
   readonly readOnly?: boolean;
@@ -75,6 +81,7 @@ export function PlumixEditor({
   registry,
   capabilities = NO_CAPABILITIES,
   patterns,
+  breakpoints,
   readOnly = false,
   previewBanner,
   previewLink,
@@ -85,7 +92,10 @@ export function PlumixEditor({
 }: PlumixEditorProps): ReactElement {
   if (readOnly) {
     return (
-      <EditorProvider initialTree={defaultValue?.blocks}>
+      <EditorProvider
+        initialTree={defaultValue?.blocks}
+        breakpoints={breakpoints}
+      >
         <div
           className="flex h-full min-h-0 flex-col"
           data-testid="plumix-editor-preview"
@@ -104,7 +114,10 @@ export function PlumixEditor({
     );
   }
   return (
-    <EditorProvider initialTree={defaultValue?.blocks}>
+    <EditorProvider
+      initialTree={defaultValue?.blocks}
+      breakpoints={breakpoints}
+    >
       <SidebarProvider
         className="h-full min-h-0"
         style={{ "--sidebar-width": "18rem" } as CSSProperties}

--- a/packages/admin-editor/src/provider.tsx
+++ b/packages/admin-editor/src/provider.tsx
@@ -2,7 +2,7 @@ import type { ReactElement, ReactNode } from "react";
 import { createContext, useContext, useState } from "react";
 import { useStore } from "zustand";
 
-import type { BlockNode } from "@plumix/blocks";
+import type { BlockNode, ThemeBreakpoints } from "@plumix/blocks";
 
 import type { EditorDevice, EditorStore, EditorStoreApi } from "./store.js";
 import { EditorError } from "./errors.js";
@@ -19,15 +19,17 @@ export function EditorProvider({
   initialTree,
   device,
   zoom,
+  breakpoints,
   children,
 }: {
   readonly initialTree?: readonly BlockNode[];
   readonly device?: EditorDevice;
   readonly zoom?: number;
+  readonly breakpoints?: ThemeBreakpoints;
   readonly children: ReactNode;
 }): ReactElement {
   const [store] = useState<EditorStoreApi>(() =>
-    createEditorStore({ tree: initialTree, device, zoom }),
+    createEditorStore({ tree: initialTree, device, zoom, breakpoints }),
   );
 
   return (

--- a/packages/admin-editor/src/store.test.ts
+++ b/packages/admin-editor/src/store.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, test } from "vitest";
 
 import type { BlockNode } from "@plumix/blocks";
 
-import { createEditorStore, MAX_ZOOM, MIN_ZOOM } from "./store.js";
+import {
+  createEditorStore,
+  DESKTOP_CANVAS_WIDTH,
+  deviceWidth,
+  MAX_ZOOM,
+  MIN_ZOOM,
+} from "./store.js";
 
 describe("editor store", () => {
   test("select replaces the selection and marks the block active", () => {
@@ -57,6 +63,46 @@ describe("editor store", () => {
 
     store.getState().setZoom(0);
     expect(store.getState().zoom).toBe(MIN_ZOOM);
+  });
+
+  test("deviceWidth: desktop is fixed; tablet/mobile track the breakpoints", () => {
+    const breakpoints = { tablet: 900, mobile: 500 };
+    expect(deviceWidth("desktop", breakpoints)).toBe(DESKTOP_CANVAS_WIDTH);
+    expect(deviceWidth("tablet", breakpoints)).toBe(900);
+    expect(deviceWidth("mobile", breakpoints)).toBe(500);
+  });
+
+  test("manual zoom turns off fit; device switch + applyFitZoom keep/restore it", () => {
+    const store = createEditorStore();
+    expect(store.getState().zoomFit).toBe(true);
+
+    store.getState().setZoom(1.5);
+    expect(store.getState().zoomFit).toBe(false);
+
+    // The canvas applies a computed fit without leaving fit mode...
+    store.getState().enableZoomFit();
+    store.getState().applyFitZoom(0.8);
+    expect(store.getState().zoom).toBe(0.8);
+    expect(store.getState().zoomFit).toBe(true);
+
+    // ...and a manual zoom leaves it, while switching device restores it.
+    store.getState().setZoom(2);
+    expect(store.getState().zoomFit).toBe(false);
+    store.getState().setDevice("mobile");
+    expect(store.getState().device).toBe("mobile");
+    expect(store.getState().zoomFit).toBe(true);
+  });
+
+  test("breakpoints default and seed from the initializer", () => {
+    expect(createEditorStore().getState().breakpoints).toEqual({
+      tablet: 991,
+      mobile: 640,
+    });
+    expect(
+      createEditorStore({
+        breakpoints: { tablet: 800, mobile: 400 },
+      }).getState().breakpoints,
+    ).toEqual({ tablet: 800, mobile: 400 });
   });
 
   test("setTree replaces the canonical tree", () => {

--- a/packages/admin-editor/src/store.ts
+++ b/packages/admin-editor/src/store.ts
@@ -1,7 +1,11 @@
 import { createStore } from "zustand/vanilla";
 
-import type { BlockNode, InsertableBlockEntry } from "@plumix/blocks";
-import { isBlockNodeArray } from "@plumix/blocks";
+import type {
+  BlockNode,
+  InsertableBlockEntry,
+  ThemeBreakpoints,
+} from "@plumix/blocks";
+import { DEFAULT_BREAKPOINTS, isBlockNodeArray } from "@plumix/blocks";
 
 import type { MoveTarget } from "./block-tree-ops.js";
 import type { History } from "./history.js";
@@ -20,16 +24,28 @@ type TreeHistory = History<readonly BlockNode[]>;
 
 export type EditorDevice = "desktop" | "tablet" | "mobile";
 
-// Default canvas widths per device. The theme can override these via the
-// manifest (theme-defined breakpoints); these are the fallbacks.
-export const DEVICE_WIDTH: Record<EditorDevice, number> = {
-  desktop: 1280,
-  tablet: 768,
-  mobile: 375,
-};
+// Desktop has no breakpoint (the large bucket has no @media), so its canvas
+// width is a fixed comfortable default; tablet/mobile track the theme
+// breakpoints so the canvas width equals the viewport where that bucket applies
+// (preview equals shipped).
+export const DESKTOP_CANVAS_WIDTH = 1280;
+
+/** The canvas width for a device: desktop is fixed; tablet/mobile use the
+ *  theme's breakpoint thresholds. */
+export function deviceWidth(
+  device: EditorDevice,
+  breakpoints: ThemeBreakpoints,
+): number {
+  if (device === "tablet") return breakpoints.tablet;
+  if (device === "mobile") return breakpoints.mobile;
+  return DESKTOP_CANVAS_WIDTH;
+}
 
 export const MIN_ZOOM = 0.25;
 export const MAX_ZOOM = 2;
+
+const clampZoom = (zoom: number): number =>
+  Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoom));
 
 export interface EditorState {
   /** Canonical block tree — the single source of truth pushed to the canvas. */
@@ -40,6 +56,11 @@ export interface EditorState {
   readonly hoverId: string | null;
   readonly device: EditorDevice;
   readonly zoom: number;
+  /** Theme breakpoints driving the device canvas widths. */
+  readonly breakpoints: ThemeBreakpoints;
+  /** When true, zoom auto-fits the canvas to the viewport width; a manual zoom
+   *  clears it until the device changes or fit is re-enabled. */
+  readonly zoomFit: boolean;
   /** The catalog entry (block or variation) being dragged toward the canvas. */
   readonly dragSpec: InsertableBlockEntry | null;
   /** The existing block being dragged to a new position on the canvas, if any. */
@@ -85,8 +106,14 @@ export interface EditorActions {
   /** Move the active block by `delta` positions among its siblings. */
   moveSelectedBy: (delta: number) => void;
   setHover: (id: string | null) => void;
+  /** Switch device; re-enables fit-to-width so the new width fits the viewport. */
   setDevice: (device: EditorDevice) => void;
+  /** Manual zoom — pins the level and turns off fit-to-width. */
   setZoom: (zoom: number) => void;
+  /** Apply a computed fit-to-width zoom without leaving fit mode (canvas-driven). */
+  applyFitZoom: (zoom: number) => void;
+  /** Re-enable fit-to-width (the toolbar's "Fit" action). */
+  enableZoomFit: () => void;
   startBlockDrag: (entry: InsertableBlockEntry) => void;
   endBlockDrag: () => void;
   /** Begin / end dragging an existing block to a new canvas position. */
@@ -137,7 +164,9 @@ export type EditorStore = EditorState & EditorActions;
 export type EditorStoreApi = ReturnType<typeof createEditorStore>;
 
 export function createEditorStore(
-  initial?: Partial<Pick<EditorState, "tree" | "device" | "zoom">>,
+  initial?: Partial<
+    Pick<EditorState, "tree" | "device" | "zoom" | "breakpoints">
+  >,
 ) {
   return createStore<EditorStore>((set) => ({
     tree: initial?.tree ?? [],
@@ -146,6 +175,8 @@ export function createEditorStore(
     hoverId: null,
     device: initial?.device ?? "desktop",
     zoom: initial?.zoom ?? 1,
+    breakpoints: initial?.breakpoints ?? DEFAULT_BREAKPOINTS,
+    zoomFit: true,
     dragSpec: null,
     movingId: null,
     history: initHistory(initial?.tree ?? []),
@@ -274,9 +305,10 @@ export function createEditorStore(
         return { tree, history: recordHistory(state.history, tree, null) };
       }),
     setHover: (hoverId) => set({ hoverId }),
-    setDevice: (device) => set({ device }),
-    setZoom: (zoom) =>
-      set({ zoom: Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoom)) }),
+    setDevice: (device) => set({ device, zoomFit: true }),
+    setZoom: (zoom) => set({ zoom: clampZoom(zoom), zoomFit: false }),
+    applyFitZoom: (zoom) => set({ zoom: clampZoom(zoom) }),
+    enableZoomFit: () => set({ zoomFit: true }),
     startBlockDrag: (dragSpec) => set({ dragSpec }),
     endBlockDrag: () => set({ dragSpec: null }),
     startMove: (movingId) => set({ movingId }),

--- a/packages/admin/src/lib/manifest.ts
+++ b/packages/admin/src/lib/manifest.ts
@@ -1,4 +1,4 @@
-import type { ThemeTokens } from "@plumix/blocks";
+import type { ThemeBreakpoints, ThemeTokens } from "@plumix/blocks";
 import type {
   AdminNavGroup,
   AdminNavItem,
@@ -13,6 +13,7 @@ import type {
   TermTaxonomyManifestEntry,
   UserMetaBoxManifestEntry,
 } from "@plumix/core/manifest";
+import { DEFAULT_BREAKPOINTS } from "@plumix/blocks";
 import { byPriorityThen, MANIFEST_SCRIPT_ID } from "@plumix/core/manifest";
 
 export function readManifest(doc: Document = document): PlumixManifest {
@@ -76,6 +77,12 @@ const manifest: PlumixManifest = readManifest();
 
 export function getThemeTokens(source: PlumixManifest = manifest): ThemeTokens {
   return source.tokens ?? {};
+}
+
+export function getThemeBreakpoints(
+  source: PlumixManifest = manifest,
+): ThemeBreakpoints {
+  return source.breakpoints ?? DEFAULT_BREAKPOINTS;
 }
 
 export function getPatterns(

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/editor.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/editor.tsx
@@ -14,6 +14,7 @@ import {
   entryMetaBoxesForType,
   findEntryTypeBySlug,
   getPatterns,
+  getThemeBreakpoints,
 } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import { getRegisteredBlocks } from "@/lib/plugin-registry.js";
@@ -77,6 +78,9 @@ const registry = createBlockRegistry(getRegisteredBlocks());
 
 // Theme + plugin patterns, surfaced in the inserter alongside the blocks.
 const patterns = getPatterns();
+
+// Theme breakpoints sizing the editor's device-switch canvas widths.
+const breakpoints = getThemeBreakpoints();
 
 // Mint once and cache forever — each call writes a fresh preview token, and
 // the URL it returns is the canvas iframe's target for the editor's lifetime.
@@ -641,6 +645,7 @@ function BespokeEditor({
       registry={registry}
       capabilities={capabilitySet}
       patterns={patterns}
+      breakpoints={breakpoints}
       previewLink={shareUrl}
       onChange={handleChange}
       documentPanel={documentPanel}
@@ -733,6 +738,7 @@ function RevisionPreview({
       }
       registry={registry}
       capabilities={capabilitySet}
+      breakpoints={breakpoints}
       readOnly
       previewBanner={
         <PreviewBanner

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -106,6 +106,7 @@ export type {
 
 // ─── Style emission + theme tokens ──────────────────────────────────────────
 export {
+  DEFAULT_BREAKPOINTS,
   emitBlockStyleCss,
   tokenIdToCssVar,
   VIEWPORT_MAX_PX,
@@ -113,6 +114,7 @@ export {
 export type {
   ResponsiveStyleBucket,
   ResponsiveStyleSlot,
+  ThemeBreakpoints,
   TokenCategory,
 } from "./styles/style-emitter.js";
 export type {

--- a/packages/blocks/src/render-block-tree.ts
+++ b/packages/blocks/src/render-block-tree.ts
@@ -9,7 +9,10 @@ import type {
 } from "./loaders.js";
 import type { PatternRegistry } from "./pattern-registry.js";
 import type { ShortcodeRegistry } from "./shortcodes/types.js";
-import type { ResponsiveStyleSlot } from "./styles/style-emitter.js";
+import type {
+  ResponsiveStyleSlot,
+  ThemeBreakpoints,
+} from "./styles/style-emitter.js";
 import type { ThemeTokens } from "./styles/types.js";
 import { emitBlockStyleCss } from "./styles/style-emitter.js";
 
@@ -61,6 +64,8 @@ export interface BlockRenderHooks {
 
 export interface RenderBlockTreeOptions {
   readonly tokens?: ThemeTokens;
+  /** Theme breakpoints driving the emitter's @media maxima (default 991/640). */
+  readonly breakpoints?: ThemeBreakpoints;
   readonly hooks?: BlockRenderHooks;
   readonly loaderData?: ResolvedBlockLoaders;
   readonly patterns?: PatternRegistry;
@@ -185,6 +190,7 @@ interface WalkerEnv {
   readonly registry: BlockRegistry;
   readonly devState: DevWarnState;
   readonly tokens: ThemeTokens | undefined;
+  readonly breakpoints: ThemeBreakpoints | undefined;
   readonly hooks: BlockRenderHooks | undefined;
   readonly loaderData: ResolvedBlockLoaders | undefined;
   readonly patterns: PatternRegistry | undefined;
@@ -245,7 +251,12 @@ function renderNode(
   const safeId = SAFE_ID_RE.test(node.id) ? node.id : null;
   const styleCss =
     safeId && node.style && tokens
-      ? emitBlockStyleCss(`plumix-block-${safeId}`, node.style, tokens)
+      ? emitBlockStyleCss(
+          `plumix-block-${safeId}`,
+          node.style,
+          tokens,
+          env.breakpoints,
+        )
       : "";
   const className = safeId && styleCss ? `plumix-block-${safeId}` : undefined;
   const styleTag = styleCss
@@ -312,6 +323,7 @@ export function renderBlockTree(
     registry,
     devState: devWarnState(registry),
     tokens: options?.tokens,
+    breakpoints: options?.breakpoints,
     hooks: options?.hooks,
     loaderData: options?.loaderData,
     patterns: options?.patterns,

--- a/packages/blocks/src/renderer/index.tsx
+++ b/packages/blocks/src/renderer/index.tsx
@@ -5,6 +5,7 @@ import type { BlockRegistry } from "../block-registry.js";
 import type { EntryContent } from "../entry-content.js";
 import type { ResolvedBlockLoaders } from "../loaders.js";
 import type { ShortcodeRegistry } from "../shortcodes/types.js";
+import type { ThemeBreakpoints } from "../styles/style-emitter.js";
 import type { ThemeTokens } from "../styles/types.js";
 import type { ImageResolver, RemotePattern } from "./image-attrs.js";
 import { renderBlockTree } from "../render-block-tree.js";
@@ -32,6 +33,8 @@ export interface PlumixContextValue {
   /** Render mode; defaults to `"live"`. `edit`/`preview` drive the editor hooks. */
   readonly mode?: PlumixRenderMode;
   readonly tokens?: ThemeTokens;
+  /** Theme breakpoints feeding the style emitter's @media maxima. */
+  readonly breakpoints?: ThemeBreakpoints;
   readonly loaderData?: ResolvedBlockLoaders;
   readonly user?: RendererUser | null;
   readonly queriedEntry?: RendererQueriedEntry | null;
@@ -79,6 +82,7 @@ export function BlockRenderer({
   const ctx = usePlumixContext("BlockRenderer");
   const tree = renderBlockTree(content.blocks, ctx.registry, {
     tokens: ctx.tokens,
+    breakpoints: ctx.breakpoints,
     loaderData: ctx.loaderData,
     locale: ctx.locale,
     shortcodes: ctx.shortcodes,

--- a/packages/blocks/src/styles/style-emitter.test.ts
+++ b/packages/blocks/src/styles/style-emitter.test.ts
@@ -73,6 +73,23 @@ describe("emitBlockStyleCss", () => {
     );
   });
 
+  test("uses theme-supplied breakpoints for the @media maxima when given", () => {
+    const style: ResponsiveStyleSlot = {
+      medium: { padding: "lg" },
+      small: { padding: "sm" },
+    };
+
+    const css = emitBlockStyleCss("block-1", style, tokens, {
+      tablet: 900,
+      mobile: 500,
+    });
+
+    expect(css).toContain("@media (max-width: 900px)");
+    expect(css).toContain("@media (max-width: 500px)");
+    expect(css).not.toContain("991px");
+    expect(css).not.toContain("640px");
+  });
+
   test("skips unmapped CSS properties without emitting raw token ids as literal CSS values", () => {
     const style: ResponsiveStyleSlot = {
       large: { padding: "lg", width: "lg" },

--- a/packages/blocks/src/styles/style-emitter.ts
+++ b/packages/blocks/src/styles/style-emitter.ts
@@ -27,6 +27,23 @@ export const VIEWPORT_MAX_PX: Readonly<Record<"medium" | "small", number>> = {
   small: 640,
 };
 
+/**
+ * Theme-supplied responsive breakpoints (max-width, px): `tablet` gates the
+ * medium bucket, `mobile` the small bucket. A theme overrides these; both the
+ * SSR emitter and the editor canvas read the same values so preview equals
+ * shipped. Defaults match the historical viewport maxima, so an unspecified
+ * theme emits identical CSS.
+ */
+export interface ThemeBreakpoints {
+  readonly tablet: number;
+  readonly mobile: number;
+}
+
+export const DEFAULT_BREAKPOINTS: ThemeBreakpoints = {
+  tablet: VIEWPORT_MAX_PX.medium,
+  mobile: VIEWPORT_MAX_PX.small,
+};
+
 export function tokenIdToCssVar(
   id: string,
   category: TokenCategory,
@@ -44,8 +61,13 @@ export function emitBlockStyleCss(
   className: string,
   style: ResponsiveStyleSlot | undefined,
   tokens: ThemeTokens,
+  breakpoints: ThemeBreakpoints = DEFAULT_BREAKPOINTS,
 ): string {
   if (!style) return "";
+  const maxWidth: Readonly<Record<"medium" | "small", number>> = {
+    medium: breakpoints.tablet,
+    small: breakpoints.mobile,
+  };
   const parts: string[] = [];
   if (style.large) {
     const decls = bucketToDeclarations(style.large, tokens);
@@ -57,7 +79,7 @@ export function emitBlockStyleCss(
     const decls = bucketToDeclarations(bucket, tokens);
     if (decls)
       parts.push(
-        `@media (max-width: ${VIEWPORT_MAX_PX[viewport]}px) { .${className} { ${decls} } }`,
+        `@media (max-width: ${String(maxWidth[viewport])}px) { .${className} { ${decls} } }`,
       );
   }
   return parts.join(" ");

--- a/packages/core/src/plugin/manifest.ts
+++ b/packages/core/src/plugin/manifest.ts
@@ -8,8 +8,10 @@ import type {
   PatternPreview,
   PatternTarget,
   ShortcodeSpec,
+  ThemeBreakpoints,
   ThemeTokens,
 } from "@plumix/blocks";
+import { DEFAULT_BREAKPOINTS } from "@plumix/blocks";
 
 import type {
   EntryTypeCapabilityOverrides,
@@ -1755,6 +1757,12 @@ export interface PlumixManifest {
    */
   readonly tokens?: ThemeTokens;
   /**
+   * Theme responsive breakpoints from `defineTheme({ breakpoints })`. Same
+   * manifest-channel reason as `tokens`: the precompiled admin shell can't
+   * import the user's config, but the editor needs them for device widths.
+   */
+  readonly breakpoints?: ThemeBreakpoints;
+  /**
    * Site i18n config — populates the locale-switcher dropdown and gives
    * admin components access to the active default. Same channel reason as
    * `tokens`: the precompiled admin shell can't import the user's config.
@@ -1856,6 +1864,7 @@ export function buildManifest(
   registry: PluginRegistry,
   options?: {
     readonly tokens?: ThemeTokens;
+    readonly breakpoints?: ThemeBreakpoints;
     readonly i18n?: ResolvedI18n;
     readonly plugins?: readonly {
       readonly id: string;
@@ -1953,6 +1962,7 @@ export function buildManifest(
     marks,
     patterns,
     tokens: options?.tokens ?? {},
+    breakpoints: options?.breakpoints ?? DEFAULT_BREAKPOINTS,
     i18n: {
       defaultLocale: options?.i18n?.defaultLocale.code ?? "en",
       // Wire-filtered to enabled entries — the admin dropdown ships exactly

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -6,6 +6,7 @@ import type {
   BlockNode,
   LoaderErrorEvent,
   ResolvedBlockLoaders,
+  ThemeBreakpoints,
   ThemeTokens,
 } from "@plumix/blocks";
 import { resolveBlockLoaders } from "@plumix/blocks";
@@ -130,6 +131,7 @@ export async function renderThroughTheme({
     deps,
     loaderData,
     tokens: theme.tokens,
+    breakpoints: theme.breakpoints,
     editMode,
   });
 }
@@ -210,6 +212,7 @@ export async function renderErrorThroughTheme({
     deps,
     loaderData: undefined,
     tokens: theme.tokens,
+    breakpoints: theme.breakpoints,
     editMode: LIVE_EDIT_MODE,
   });
 }
@@ -291,6 +294,7 @@ interface RenderTreeArgs {
   readonly deps: Record<string, Record<string, unknown>>;
   readonly loaderData: ResolvedBlockLoaders | undefined;
   readonly tokens: ThemeTokens | undefined;
+  readonly breakpoints: ThemeBreakpoints | undefined;
   readonly editMode: EditModeDecision;
 }
 
@@ -309,6 +313,7 @@ function renderTree({
   template,
   deps,
   tokens,
+  breakpoints,
   loaderData,
   editMode,
 }: RenderTreeArgs): string {
@@ -341,6 +346,7 @@ function renderTree({
         registry: ctx.blocks,
         mode: editMode.mode,
         tokens,
+        breakpoints,
         loaderData,
         user: ctx.user,
         queriedEntry: ctx.resolvedEntity,

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -1,6 +1,10 @@
 import type { ComponentType, JSX } from "react";
 
-import type { ShortcodeSpec, ThemeTokens } from "@plumix/blocks";
+import type {
+  ShortcodeSpec,
+  ThemeBreakpoints,
+  ThemeTokens,
+} from "@plumix/blocks";
 
 import type {
   ArchiveData,
@@ -134,6 +138,13 @@ export interface ThemeDescriptor extends TemplateDepDeclarations {
   readonly templates: TemplateRegistry;
   readonly document?: DocumentManifest;
   readonly tokens?: ThemeTokens;
+  /**
+   * Responsive breakpoints (max-width px) for the `tablet`/`mobile` buckets.
+   * Feed both the SSR style emitter's @media maxima and the editor's
+   * device-switch canvas widths, so preview equals shipped. Defaults to
+   * `DEFAULT_BREAKPOINTS` (991/640) when unspecified.
+   */
+  readonly breakpoints?: ThemeBreakpoints;
   /**
    * Shortcodes the theme declares without a setup hook (like `tokens`).
    * These take precedence over plugin and core shortcodes of the same tag

--- a/packages/plumix/src/vite/index.ts
+++ b/packages/plumix/src/vite/index.ts
@@ -13,7 +13,7 @@ import { fileURLToPath } from "node:url";
 import type { Plugin, UserConfig } from "vite";
 import { mergeConfig } from "vite";
 
-import type { ThemeTokens } from "@plumix/blocks";
+import type { ThemeBreakpoints, ThemeTokens } from "@plumix/blocks";
 import type {
   AnyPluginDescriptor,
   PluginRegistry,
@@ -363,7 +363,11 @@ async function regenerate(
 
   const { manifest, registry } = await computeManifestAndRegistry(
     config.plugins,
-    { tokens: config.theme.tokens, i18n: config.i18n },
+    {
+      tokens: config.theme.tokens,
+      breakpoints: config.theme.breakpoints,
+      i18n: config.i18n,
+    },
     cwd,
   );
 
@@ -382,7 +386,11 @@ type PluginDescriptors = Parameters<typeof installPlugins>[0]["plugins"];
 // so plugins should keep setup free of IO.
 async function computeManifestAndRegistry(
   plugins: PluginDescriptors,
-  options: { readonly tokens?: ThemeTokens; readonly i18n?: ResolvedI18n },
+  options: {
+    readonly tokens?: ThemeTokens;
+    readonly breakpoints?: ThemeBreakpoints;
+    readonly i18n?: ResolvedI18n;
+  },
   projectRoot: string,
 ): Promise<{ manifest: PlumixManifest; registry: PluginRegistry }> {
   const { registry } = await installPlugins({


### PR DESCRIPTION
The bespoke editor gains a desktop/tablet/mobile device switch that sizes the
canvas to the theme's breakpoint widths, zoom with a visible percentage and a
fit-to-width default, and an iframe sized to its content height (footer visible,
no fixed gap). Crucially, the same theme breakpoints feed the SSR style emitter,
so the editor preview matches the shipped page. Closes #1109.

A theme declares `breakpoints: { tablet, mobile }` via `defineTheme`, defaulting
to the historical 991/640 so an unspecified theme emits **byte-identical** CSS
(no published-page regression). `emitBlockStyleCss` is parameterized on these for
its `@media` maxima and threaded through the renderer context on the live SSR
path; stored style data is untouched. The breakpoints ride the manifest channel
(`getThemeBreakpoints`) so the precompiled admin can read them without importing
the user config.

In the editor, a device's canvas width is its breakpoint threshold (so the width
equals the viewport where that bucket applies); desktop is a fixed default. Zoom
auto-fits the column (never upscaling past 100%) until a manual zoom pins a
level — switching device or clicking the percent re-fits. The canvas is
same-origin, so the host reads the iframe's content height directly; an
in-iframe `ResizeObserver` re-reports geometry after async layout shifts (late
images, font swap, hydration) so both the height and the selection overlays
stay accurate.

Reviewed by senpai + code-simplifier; folded in the content-height
ResizeObserver (async-shift gap), a redundant-set guard on the fit zoom, and a
`clampZoom` helper. Verification: blocks 433, core 2290, admin 568, admin-editor
208 unit + 19 playground e2e (device-width + zoom-percent tests new);
typecheck/lint/knip/format clean. Device-switch screenshots shared during review.