### PR TITLE
feat: add a token-or-custom styles tab to the editor

### DIFF
--- a/packages/admin-editor/e2e/editor-visual.spec.ts
+++ b/packages/admin-editor/e2e/editor-visual.spec.ts
@@ -407,6 +407,29 @@ test.describe("editor playground", () => {
     await expect(percent).toContainText("%");
   });
 
+  test("the Styles tab edits a block's style per device", async ({ page }) => {
+    await page.goto("/");
+    const canvas = page.frameLocator(CANVAS_FRAME);
+    await canvas.locator('[data-plumix-id="heading-1"]').click();
+
+    await page.getByTestId("plumix-tab-styles").click();
+    await expect(page.getByTestId("styles-tab")).toBeVisible();
+    await expect(page.getByTestId("styles-section-typography")).toBeVisible();
+
+    // Set a typography token; the change lands on the canonical tree (visible
+    // through the JSON inspector).
+    await page.getByTestId("style-control-fontSize-token").selectOption("xl");
+    // Set a per-side custom padding via the box-model.
+    await page.getByTestId("style-control-paddingTop-mode-custom").click();
+    await page.getByTestId("style-control-paddingTop-custom").fill("12px");
+
+    await page.getByTestId("plumix-tab-json").click();
+    const json = page.getByTestId("json-inspector-output");
+    await expect(json).toContainText('"fontSize"');
+    await expect(json).toContainText('"paddingTop"');
+    await expect(json).toContainText('"12px"');
+  });
+
   test("the Layers tab outlines the nested structure", async ({ page }) => {
     await page.goto("/");
 

--- a/packages/admin-editor/locales/ar.po
+++ b/packages/admin-editor/locales/ar.po
@@ -49,6 +49,11 @@ msgid "editor.toolbar.copyPreviewLink"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/style-control.tsx
+msgid "editor.styles.mode.custom"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.delete"
 msgstr ""
@@ -61,6 +66,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.duplicate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.scope"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -81,6 +91,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.layers"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.margin"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -106,6 +121,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.page.empty"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.padding"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -154,8 +174,28 @@ msgid "editor.json.empty"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.empty"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.selectParent"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.spacing"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.styles"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/style-control.tsx
+msgid "editor.styles.mode.token"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/de.po
+++ b/packages/admin-editor/locales/de.po
@@ -49,6 +49,11 @@ msgid "editor.toolbar.copyPreviewLink"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/style-control.tsx
+msgid "editor.styles.mode.custom"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.delete"
 msgstr ""
@@ -61,6 +66,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.duplicate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.scope"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -81,6 +91,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.layers"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.margin"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -106,6 +121,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.page.empty"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.padding"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -154,8 +174,28 @@ msgid "editor.json.empty"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.empty"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.selectParent"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.spacing"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.styles"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/style-control.tsx
+msgid "editor.styles.mode.token"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/en.po
+++ b/packages/admin-editor/locales/en.po
@@ -49,6 +49,11 @@ msgid "editor.toolbar.copyPreviewLink"
 msgstr "Copy preview link"
 
 #. js-lingui-explicit-id
+#: src/style-control.tsx
+msgid "editor.styles.mode.custom"
+msgstr "Custom"
+
+#. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.delete"
 msgstr "Delete"
@@ -62,6 +67,11 @@ msgstr "Discard"
 #: src/selection-toolbar.tsx
 msgid "editor.selection.duplicate"
 msgstr "Duplicate"
+
+#. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.scope"
+msgstr "Editing"
 
 #. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
@@ -82,6 +92,11 @@ msgstr "JSON"
 #: src/plumix-editor.tsx
 msgid "editor.tab.layers"
 msgstr "Layers"
+
+#. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.margin"
+msgstr "Margin"
 
 #. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
@@ -107,6 +122,11 @@ msgstr "No blocks yet."
 #: src/plumix-editor.tsx
 msgid "editor.page.empty"
 msgstr "No document settings."
+
+#. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.padding"
+msgstr "Padding"
 
 #. js-lingui-explicit-id
 #: src/json-inspector.tsx
@@ -154,9 +174,29 @@ msgid "editor.json.empty"
 msgstr "Select a block to inspect."
 
 #. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.empty"
+msgstr "Select a block to style it."
+
+#. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.selectParent"
 msgstr "Select parent"
+
+#. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.spacing"
+msgstr "Spacing"
+
+#. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.styles"
+msgstr "Styles"
+
+#. js-lingui-explicit-id
+#: src/style-control.tsx
+msgid "editor.styles.mode.token"
+msgstr "Token"
 
 #. js-lingui-explicit-id
 #: src/editor-toolbar.tsx

--- a/packages/admin-editor/locales/uk.po
+++ b/packages/admin-editor/locales/uk.po
@@ -49,6 +49,11 @@ msgid "editor.toolbar.copyPreviewLink"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/style-control.tsx
+msgid "editor.styles.mode.custom"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.delete"
 msgstr ""
@@ -61,6 +66,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.duplicate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.scope"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -81,6 +91,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.layers"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.margin"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -106,6 +121,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.page.empty"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.padding"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -154,8 +174,28 @@ msgid "editor.json.empty"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.empty"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.selectParent"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.spacing"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.styles"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/style-control.tsx
+msgid "editor.styles.mode.token"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/zh-CN.po
+++ b/packages/admin-editor/locales/zh-CN.po
@@ -49,6 +49,11 @@ msgid "editor.toolbar.copyPreviewLink"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/style-control.tsx
+msgid "editor.styles.mode.custom"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.delete"
 msgstr ""
@@ -61,6 +66,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.duplicate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.scope"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -81,6 +91,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.tab.layers"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.margin"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -106,6 +121,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/plumix-editor.tsx
 msgid "editor.page.empty"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.padding"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -154,8 +174,28 @@ msgid "editor.json.empty"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.empty"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.selectParent"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.spacing"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/plumix-editor.tsx
+msgid "editor.tab.styles"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/style-control.tsx
+msgid "editor.styles.mode.token"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/playground/host.tsx
+++ b/packages/admin-editor/playground/host.tsx
@@ -48,6 +48,18 @@ const withVariations = coreBlocks.map(
 );
 const registry = createBlockRegistry(withVariations);
 
+// Seed theme tokens so the Styles tab's token-or-custom controls have options.
+const SEED_TOKENS = {
+  colors: {
+    primary: { value: "#2563eb", label: "Primary" },
+    ink: { value: "#0c2238", label: "Ink" },
+  },
+  spacing: { sm: { value: "8px" }, lg: { value: "24px" } },
+  typography: { base: { value: "16px" }, xl: { value: "24px" } },
+  radius: { md: { value: "8px" } },
+  shadow: { lg: { value: "0 4px 12px rgba(0,0,0,0.1)" } },
+} as const;
+
 function DocumentPanelStub(): ReactElement {
   return (
     <div
@@ -104,6 +116,7 @@ if (root) {
           defaultValue={defineEntryContent(SEED_BLOCKS)}
           capabilities={new Set()}
           patterns={SEED_PATTERNS}
+          tokens={SEED_TOKENS}
           readOnly={readOnly}
           previewBanner={readOnly ? <PreviewBannerStub /> : undefined}
           previewLink="https://example.test/blog/hello?preview=demo-token"

--- a/packages/admin-editor/src/plumix-editor.tsx
+++ b/packages/admin-editor/src/plumix-editor.tsx
@@ -6,6 +6,7 @@ import type {
   BlockRegistry,
   EntryContent,
   ThemeBreakpoints,
+  ThemeTokens,
 } from "@plumix/blocks";
 import {
   Sidebar,
@@ -32,6 +33,7 @@ import { EditorShortcuts, EditorToolbar } from "./editor-toolbar.js";
 import { JsonInspector } from "./json-inspector.js";
 import { LayersTab } from "./layers-tab.js";
 import { EditorProvider, useEditorStoreApi } from "./provider.js";
+import { StylesTab } from "./styles-tab.js";
 
 const NO_CAPABILITIES: ReadonlySet<string> = new Set();
 
@@ -50,6 +52,8 @@ interface PlumixEditorProps {
   readonly patterns?: readonly InserterPattern[];
   /** Theme breakpoints sizing the device-switch canvas widths. */
   readonly breakpoints?: ThemeBreakpoints;
+  /** Theme tokens offered in the Styles tab's token-or-custom controls. */
+  readonly tokens?: ThemeTokens;
   /** Preview mode: render the canvas read-only with the editing chrome hidden
    *  (used to view a past revision or a shared draft). */
   readonly readOnly?: boolean;
@@ -82,6 +86,7 @@ export function PlumixEditor({
   capabilities = NO_CAPABILITIES,
   patterns,
   breakpoints,
+  tokens,
   readOnly = false,
   previewBanner,
   previewLink,
@@ -183,6 +188,9 @@ export function PlumixEditor({
                 <TabsTrigger value="block" data-testid="plumix-tab-block">
                   <Trans id="editor.tab.block" message="Block" />
                 </TabsTrigger>
+                <TabsTrigger value="styles" data-testid="plumix-tab-styles">
+                  <Trans id="editor.tab.styles" message="Styles" />
+                </TabsTrigger>
                 <TabsTrigger value="page" data-testid="plumix-tab-page">
                   <Trans id="editor.tab.page" message="Page" />
                 </TabsTrigger>
@@ -194,6 +202,9 @@ export function PlumixEditor({
             <SidebarContent>
               <TabsContent value="block">
                 <BlockInspector registry={registry} />
+              </TabsContent>
+              <TabsContent value="styles">
+                <StylesTab tokens={tokens ?? {}} />
               </TabsContent>
               <TabsContent value="page" data-testid="plumix-page-panel">
                 {documentPanel ?? (

--- a/packages/admin-editor/src/store.test.ts
+++ b/packages/admin-editor/src/store.test.ts
@@ -5,10 +5,19 @@ import type { BlockNode } from "@plumix/blocks";
 import {
   createEditorStore,
   DESKTOP_CANVAS_WIDTH,
+  deviceBucket,
   deviceWidth,
   MAX_ZOOM,
   MIN_ZOOM,
 } from "./store.js";
+
+describe("deviceBucket", () => {
+  test("maps each device to its responsive style bucket", () => {
+    expect(deviceBucket("desktop")).toBe("large");
+    expect(deviceBucket("tablet")).toBe("medium");
+    expect(deviceBucket("mobile")).toBe("small");
+  });
+});
 
 describe("editor store", () => {
   test("select replaces the selection and marks the block active", () => {
@@ -532,5 +541,65 @@ describe("move drag", () => {
 
     store.getState().endMove();
     expect(store.getState().movingId).toBeNull();
+  });
+});
+
+describe("updateBlockStyle", () => {
+  test("sets a token style value in the given bucket", () => {
+    const store = createEditorStore({ tree: [{ id: "a", name: "core/x" }] });
+
+    store.getState().updateBlockStyle("a", "large", "padding", { token: "lg" });
+
+    expect(store.getState().tree[0]?.style).toEqual({
+      large: { padding: { token: "lg" } },
+    });
+  });
+
+  test("clears a property when the value is null, dropping empty buckets", () => {
+    const store = createEditorStore({
+      tree: [
+        {
+          id: "a",
+          name: "core/x",
+          style: { large: { padding: { token: "lg" } } },
+        },
+      ],
+    });
+
+    store.getState().updateBlockStyle("a", "large", "padding", null);
+
+    expect(store.getState().tree[0]?.style).toBeUndefined();
+  });
+
+  test("updates a nested block's style", () => {
+    const store = createEditorStore({
+      tree: [
+        {
+          id: "g",
+          name: "core/group",
+          attrs: { content: [{ id: "c", name: "core/x" }] },
+        },
+      ],
+    });
+
+    store
+      .getState()
+      .updateBlockStyle("c", "medium", "fontSize", { raw: "20px" });
+
+    const content = store.getState().tree[0]?.attrs?.content as BlockNode[];
+    expect(content[0]?.style).toEqual({
+      medium: { fontSize: { raw: "20px" } },
+    });
+  });
+
+  test("is a no-op (stable tree) for an unknown block", () => {
+    const tree: readonly BlockNode[] = [{ id: "a", name: "core/x" }];
+    const store = createEditorStore({ tree });
+
+    store.getState().updateBlockStyle("nope", "large", "padding", {
+      token: "lg",
+    });
+
+    expect(store.getState().tree).toBe(tree);
   });
 });

--- a/packages/admin-editor/src/store.ts
+++ b/packages/admin-editor/src/store.ts
@@ -3,6 +3,9 @@ import { createStore } from "zustand/vanilla";
 import type {
   BlockNode,
   InsertableBlockEntry,
+  ResponsiveStyleBucket,
+  ResponsiveStyleSlot,
+  StyleValue,
   ThemeBreakpoints,
 } from "@plumix/blocks";
 import { DEFAULT_BREAKPOINTS, isBlockNodeArray } from "@plumix/blocks";
@@ -19,6 +22,17 @@ import {
   selectionRoots,
 } from "./block-tree-ops.js";
 import { initHistory, recordHistory, redo, undo } from "./history.js";
+
+/** The responsive bucket a style edit targets (per active device). */
+export type StyleBucket = "large" | "medium" | "small";
+
+/** The style bucket the active device edits: desktop is the base (large),
+ *  tablet/mobile narrow to the medium/small @media buckets. */
+export function deviceBucket(device: EditorDevice): StyleBucket {
+  if (device === "tablet") return "medium";
+  if (device === "mobile") return "small";
+  return "large";
+}
 
 type TreeHistory = History<readonly BlockNode[]>;
 
@@ -95,6 +109,14 @@ export interface EditorActions {
     id: string,
     patch: Readonly<Record<string, unknown>>,
   ) => void;
+  /** Set (or clear, with `null`) one style property in a block's responsive
+   *  bucket, anywhere in the tree. Empty buckets / style are pruned. */
+  updateBlockStyle: (
+    id: string,
+    bucket: StyleBucket,
+    property: string,
+    value: StyleValue | null,
+  ) => void;
   select: (id: string, options?: { readonly additive?: boolean }) => void;
   clearSelection: () => void;
   /** Delete every selected block (bulk) and clear the selection. */
@@ -124,39 +146,63 @@ export interface EditorActions {
   redo: () => void;
 }
 
-// Merge `patch` into one node, returning the same reference when nothing
-// changed. Descends into slot attrs (any attr whose value is a BlockNode[]),
-// so a nested target is reachable and untouched branches stay stable.
-function patchNode(
+// Rebuild the tree with `transform` applied to the node carrying `id`,
+// descending into slot attrs (any attr whose value is a BlockNode[]) so a
+// nested target is reachable. Untouched branches — and the whole tree when
+// nothing changed — keep their reference, so React skips them.
+function mapNodeById(
+  nodes: readonly BlockNode[],
+  id: string,
+  transform: (node: BlockNode) => BlockNode,
+): readonly BlockNode[] {
+  const next = nodes.map((node) => mapNode(node, id, transform));
+  return next.some((node, i) => node !== nodes[i]) ? next : nodes;
+}
+
+function mapNode(
   node: BlockNode,
   id: string,
-  patch: Readonly<Record<string, unknown>>,
+  transform: (node: BlockNode) => BlockNode,
 ): BlockNode {
-  if (node.id === id) {
-    return { ...node, attrs: { ...node.attrs, ...patch } };
-  }
+  if (node.id === id) return transform(node);
   const attrs = node.attrs;
   if (!attrs) return node;
   let nextAttrs: Record<string, unknown> | undefined;
   for (const [key, value] of Object.entries(attrs)) {
     if (!isBlockNodeArray(value)) continue;
-    const patched = patchAttrs(value, id, patch);
-    if (patched !== value) {
-      (nextAttrs ??= { ...attrs })[key] = patched;
-    }
+    const patched = mapNodeById(value, id, transform);
+    if (patched !== value) (nextAttrs ??= { ...attrs })[key] = patched;
   }
   return nextAttrs ? { ...node, attrs: nextAttrs } : node;
 }
 
-// Rebuild the tree with `patch` applied to the node with `id`. Returns the
-// same array reference when nothing changed so React skips untouched branches.
-function patchAttrs(
-  nodes: readonly BlockNode[],
-  id: string,
-  patch: Readonly<Record<string, unknown>>,
-): readonly BlockNode[] {
-  const next = nodes.map((node) => patchNode(node, id, patch));
-  return next.some((node, i) => node !== nodes[i]) ? next : nodes;
+// Set/clear one style property on a single node, pruning an emptied bucket and
+// an emptied style slot. Returns the same reference when nothing changed. Raw
+// values are sanitized at emit time (the SSR emitter), not here.
+function setNodeStyle(
+  node: BlockNode,
+  bucket: StyleBucket,
+  property: string,
+  value: StyleValue | null,
+): BlockNode {
+  const slot: ResponsiveStyleSlot = node.style ?? {};
+  const current: ResponsiveStyleBucket = slot[bucket] ?? {};
+  let nextBucket: Record<string, StyleValue | string>;
+  if (value === null) {
+    if (!(property in current)) return node;
+    const { [property]: _dropped, ...rest } = current;
+    nextBucket = rest;
+  } else {
+    nextBucket = { ...current, [property]: value };
+  }
+  const nextSlot: Record<string, ResponsiveStyleBucket> = { ...slot };
+  if (Object.keys(nextBucket).length === 0) delete nextSlot[bucket];
+  else nextSlot[bucket] = nextBucket;
+  const style =
+    Object.keys(nextSlot).length === 0
+      ? undefined
+      : (nextSlot as ResponsiveStyleSlot);
+  return { ...node, style };
 }
 
 export type EditorStore = EditorState & EditorActions;
@@ -235,10 +281,23 @@ export function createEditorStore(
       }),
     updateBlockAttrs: (id, patch) =>
       set((state) => {
-        const tree = patchAttrs(state.tree, id, patch);
+        const tree = mapNodeById(state.tree, id, (node) => ({
+          ...node,
+          attrs: { ...node.attrs, ...patch },
+        }));
         if (tree === state.tree) return {};
         // Coalesce a typing burst on one field into a single undo step.
         const key = `attr:${id}:${Object.keys(patch).sort().join(",")}`;
+        return { tree, history: recordHistory(state.history, tree, key) };
+      }),
+    updateBlockStyle: (id, bucket, property, value) =>
+      set((state) => {
+        const tree = mapNodeById(state.tree, id, (node) =>
+          setNodeStyle(node, bucket, property, value),
+        );
+        if (tree === state.tree) return {};
+        // Coalesce edits to one property+bucket (e.g. typing a raw value).
+        const key = `style:${id}:${bucket}:${property}`;
         return { tree, history: recordHistory(state.history, tree, key) };
       }),
     select: (id, options) =>

--- a/packages/admin-editor/src/style-control.test.tsx
+++ b/packages/admin-editor/src/style-control.test.tsx
@@ -1,0 +1,69 @@
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
+
+import type { ThemeTokens } from "@plumix/blocks";
+
+import { StyleControl } from "./style-control.js";
+
+beforeAll(() => {
+  i18n.loadAndActivate({ locale: "en", messages: {} });
+});
+afterEach(cleanup);
+
+const tokens: ThemeTokens = {
+  spacing: { lg: { value: "24px" }, sm: { value: "8px" } },
+};
+
+function renderControl(
+  props: Partial<Parameters<typeof StyleControl>[0]> = {},
+) {
+  const onChange = vi.fn();
+  const utils = render(
+    <I18nProvider i18n={i18n}>
+      <StyleControl
+        label="Padding"
+        property="padding"
+        category="spacing"
+        value={undefined}
+        tokens={tokens}
+        onChange={onChange}
+        {...props}
+      />
+    </I18nProvider>,
+  );
+  return { ...utils, onChange };
+}
+
+describe("StyleControl", () => {
+  test("token mode emits a token ref, and clears on the empty option", () => {
+    const { getByTestId, onChange } = renderControl();
+    const select = getByTestId(
+      "style-control-padding-token",
+    ) as HTMLSelectElement;
+
+    fireEvent.change(select, { target: { value: "lg" } });
+    expect(onChange).toHaveBeenCalledWith({ token: "lg" });
+
+    fireEvent.change(select, { target: { value: "" } });
+    expect(onChange).toHaveBeenLastCalledWith(null);
+  });
+
+  test("custom mode emits a raw value", () => {
+    const { getByTestId, onChange } = renderControl();
+    fireEvent.click(getByTestId("style-control-padding-mode-custom"));
+    fireEvent.change(getByTestId("style-control-padding-custom"), {
+      target: { value: "20px" },
+    });
+    expect(onChange).toHaveBeenCalledWith({ raw: "20px" });
+  });
+
+  test("a custom-only control (no category) offers no token mode", () => {
+    const { getByTestId, queryByTestId } = renderControl({
+      category: undefined,
+    });
+    expect(getByTestId("style-control-padding-custom")).toBeDefined();
+    expect(queryByTestId("style-control-padding-token")).toBeNull();
+  });
+});

--- a/packages/admin-editor/src/style-control.tsx
+++ b/packages/admin-editor/src/style-control.tsx
@@ -1,0 +1,118 @@
+import type { ReactElement } from "react";
+import { useState } from "react";
+import { Trans } from "@lingui/react";
+
+import type { StyleValue, ThemeTokens, TokenCategory } from "@plumix/blocks";
+import { Input } from "@plumix/admin-ui/input";
+import { Label } from "@plumix/admin-ui/label";
+import { cn } from "@plumix/admin-ui/utils";
+
+interface StyleControlProps {
+  readonly label: string;
+  /** CSS property (camelCase), used for ids and the store write. */
+  readonly property: string;
+  /** Token group offered in token mode; omit for a custom-value-only control. */
+  readonly category?: TokenCategory;
+  readonly value: StyleValue | undefined;
+  readonly tokens: ThemeTokens;
+  /** Emits the next value, or null to clear the property. */
+  readonly onChange: (value: StyleValue | null) => void;
+}
+
+/**
+ * One style property edited as a theme token OR a custom value. Token mode
+ * binds to a CSS variable (reskins with the theme); custom mode writes a raw,
+ * sanitized literal (fixed). A control without a `category` is custom-only.
+ */
+export function StyleControl({
+  label,
+  property,
+  category,
+  value,
+  tokens,
+  onChange,
+}: StyleControlProps): ReactElement {
+  const testId = `style-control-${property}`;
+  const [custom, setCustom] = useState(value !== undefined && "raw" in value);
+  const isCustom = category === undefined || custom;
+  const group = category ? (tokens[category] ?? {}) : {};
+
+  return (
+    <div className="flex flex-col gap-1" data-testid={testId}>
+      <div className="flex items-center justify-between">
+        <Label className="text-xs">{label}</Label>
+        {category ? (
+          <div className="flex gap-0.5 text-xs">
+            <ModeButton
+              testId={`${testId}-mode-token`}
+              active={!custom}
+              onClick={() => setCustom(false)}
+            >
+              <Trans id="editor.styles.mode.token" message="Token" />
+            </ModeButton>
+            <ModeButton
+              testId={`${testId}-mode-custom`}
+              active={custom}
+              onClick={() => setCustom(true)}
+            >
+              <Trans id="editor.styles.mode.custom" message="Custom" />
+            </ModeButton>
+          </div>
+        ) : null}
+      </div>
+      {isCustom ? (
+        <Input
+          data-testid={`${testId}-custom`}
+          value={value && "raw" in value ? value.raw : ""}
+          onChange={(e) =>
+            onChange(e.target.value === "" ? null : { raw: e.target.value })
+          }
+        />
+      ) : (
+        <select
+          data-testid={`${testId}-token`}
+          className="border-input flex h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm"
+          value={value && "token" in value ? value.token : ""}
+          onChange={(e) =>
+            onChange(e.target.value === "" ? null : { token: e.target.value })
+          }
+        >
+          <option value="">—</option>
+          {Object.keys(group).map((id) => (
+            <option key={id} value={id}>
+              {group[id]?.label ?? id}
+            </option>
+          ))}
+        </select>
+      )}
+    </div>
+  );
+}
+
+function ModeButton({
+  testId,
+  active,
+  onClick,
+  children,
+}: {
+  readonly testId: string;
+  readonly active: boolean;
+  readonly onClick: () => void;
+  readonly children: ReactElement;
+}): ReactElement {
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      onClick={onClick}
+      className={cn(
+        "rounded px-1.5 py-0.5",
+        active
+          ? "bg-accent text-accent-foreground"
+          : "text-muted-foreground hover:text-foreground",
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/packages/admin-editor/src/styles-tab.test.tsx
+++ b/packages/admin-editor/src/styles-tab.test.tsx
@@ -1,0 +1,75 @@
+import type { ReactElement } from "react";
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, test } from "vitest";
+
+import type { BlockNode, ThemeTokens } from "@plumix/blocks";
+
+import { EditorProvider, useEditorStore } from "./provider.js";
+import { StylesTab } from "./styles-tab.js";
+
+beforeAll(() => {
+  i18n.loadAndActivate({ locale: "en", messages: {} });
+});
+afterEach(cleanup);
+
+const tokens: ThemeTokens = {
+  spacing: { lg: { value: "24px" } },
+  typography: { lg: { value: "20px" } },
+};
+
+function StyleProbe({ id }: { readonly id: string }): ReactElement {
+  const style = useEditorStore((s) => s.tree.find((n) => n.id === id)?.style);
+  return <output data-testid="style-probe">{JSON.stringify(style)}</output>;
+}
+
+function renderTab(tree: readonly BlockNode[], activeId?: string) {
+  return render(
+    <I18nProvider i18n={i18n}>
+      <EditorProvider initialTree={tree}>
+        <ActiveSeed activeId={activeId} />
+        <StylesTab tokens={tokens} />
+        <StyleProbe id={tree[0]?.id ?? ""} />
+      </EditorProvider>
+    </I18nProvider>,
+  );
+}
+
+function ActiveSeed({ activeId }: { readonly activeId?: string }): null {
+  const select = useEditorStore((s) => s.select);
+  if (activeId) select(activeId);
+  return null;
+}
+
+describe("StylesTab", () => {
+  test("shows an empty state when nothing is selected", () => {
+    const { getByTestId } = renderTab([{ id: "a", name: "core/x" }]);
+    expect(getByTestId("styles-tab-empty")).toBeDefined();
+  });
+
+  test("writes a token style to the active desktop bucket", () => {
+    const { getByTestId } = renderTab([{ id: "a", name: "core/x" }], "a");
+
+    fireEvent.change(getByTestId("style-control-fontSize-token"), {
+      target: { value: "lg" },
+    });
+
+    expect(getByTestId("style-probe").textContent).toContain(
+      '"large":{"fontSize":{"token":"lg"}}',
+    );
+  });
+
+  test("box-model writes a per-side custom padding value", () => {
+    const { getByTestId } = renderTab([{ id: "a", name: "core/x" }], "a");
+
+    fireEvent.click(getByTestId("style-control-paddingTop-mode-custom"));
+    fireEvent.change(getByTestId("style-control-paddingTop-custom"), {
+      target: { value: "12px" },
+    });
+
+    expect(getByTestId("style-probe").textContent).toContain(
+      '"paddingTop":{"raw":"12px"}',
+    );
+  });
+});

--- a/packages/admin-editor/src/styles-tab.tsx
+++ b/packages/admin-editor/src/styles-tab.tsx
@@ -1,0 +1,197 @@
+import type { ReactElement } from "react";
+import { Trans } from "@lingui/react";
+
+import type { StyleValue, ThemeTokens, TokenCategory } from "@plumix/blocks";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@plumix/admin-ui/accordion";
+import { normalizeStyleValue } from "@plumix/blocks";
+
+import type { StyleBucket } from "./store.js";
+import { findBlock } from "./block-tree-ops.js";
+import { useEditorStore } from "./provider.js";
+import { deviceBucket } from "./store.js";
+import { StyleControl } from "./style-control.js";
+
+interface StylesTabProps {
+  readonly tokens: ThemeTokens;
+}
+
+interface ControlSpec {
+  readonly property: string;
+  readonly label: string;
+  readonly category?: TokenCategory;
+}
+
+const SECTIONS: readonly {
+  readonly id: string;
+  readonly label: string;
+  readonly controls: readonly ControlSpec[];
+}[] = [
+  {
+    id: "typography",
+    label: "Typography",
+    controls: [
+      { property: "color", label: "Text color", category: "colors" },
+      { property: "fontSize", label: "Font size", category: "typography" },
+      { property: "fontWeight", label: "Font weight", category: "typography" },
+      { property: "lineHeight", label: "Line height", category: "typography" },
+    ],
+  },
+  {
+    id: "background",
+    label: "Background",
+    controls: [
+      { property: "background", label: "Background", category: "colors" },
+    ],
+  },
+  {
+    id: "border",
+    label: "Border",
+    controls: [
+      { property: "borderWidth", label: "Width", category: "border" },
+      { property: "borderColor", label: "Color", category: "colors" },
+      { property: "borderRadius", label: "Radius", category: "radius" },
+    ],
+  },
+  {
+    id: "effects",
+    label: "Shadow",
+    controls: [{ property: "boxShadow", label: "Shadow", category: "shadow" }],
+  },
+];
+
+const SECTION_IDS = [...SECTIONS.map((s) => s.id), "spacing"];
+
+/**
+ * Right-rail Styles tab: collapsible sections of token-or-custom controls plus a
+ * visual box-model for per-side spacing. Every edit targets the active device's
+ * responsive bucket, so styles are set per breakpoint.
+ */
+export function StylesTab({ tokens }: StylesTabProps): ReactElement {
+  const activeId = useEditorStore((s) => s.activeId);
+  const device = useEditorStore((s) => s.device);
+  const block = useEditorStore((s) =>
+    s.activeId ? findBlock(s.tree, s.activeId) : null,
+  );
+  const updateBlockStyle = useEditorStore((s) => s.updateBlockStyle);
+
+  if (!activeId || !block) {
+    return (
+      <p
+        className="text-muted-foreground p-4 text-sm"
+        data-testid="styles-tab-empty"
+      >
+        <Trans id="editor.styles.empty" message="Select a block to style it." />
+      </p>
+    );
+  }
+
+  const bucket: StyleBucket = deviceBucket(device);
+  const current = block.style?.[bucket];
+  const valueOf = (property: string): StyleValue | undefined =>
+    normalizeStyleValue(current?.[property]) ?? undefined;
+  const setter =
+    (property: string) =>
+    (value: StyleValue | null): void =>
+      updateBlockStyle(activeId, bucket, property, value);
+
+  return (
+    <div className="flex flex-col gap-2 p-3" data-testid="styles-tab">
+      <p
+        className="text-muted-foreground text-xs"
+        data-testid="styles-tab-scope"
+      >
+        <Trans id="editor.styles.scope" message="Editing" /> · {device}
+      </p>
+      <Accordion type="multiple" defaultValue={SECTION_IDS}>
+        {SECTIONS.map((section) => (
+          <AccordionItem key={section.id} value={section.id}>
+            <AccordionTrigger data-testid={`styles-section-${section.id}`}>
+              {section.label}
+            </AccordionTrigger>
+            <AccordionContent className="flex flex-col gap-3">
+              {section.controls.map((c) => (
+                <StyleControl
+                  key={c.property}
+                  label={c.label}
+                  property={c.property}
+                  category={c.category}
+                  value={valueOf(c.property)}
+                  tokens={tokens}
+                  onChange={setter(c.property)}
+                />
+              ))}
+            </AccordionContent>
+          </AccordionItem>
+        ))}
+        <AccordionItem value="spacing">
+          <AccordionTrigger data-testid="styles-section-spacing">
+            <Trans id="editor.styles.spacing" message="Spacing" />
+          </AccordionTrigger>
+          <AccordionContent>
+            <BoxModelControl
+              tokens={tokens}
+              valueOf={valueOf}
+              setter={setter}
+            />
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    </div>
+  );
+}
+
+const SIDES = ["Top", "Right", "Bottom", "Left"] as const;
+
+/** Visual box-model: a margin box wrapping a padding box, each with per-side
+ *  token-or-custom controls. */
+function BoxModelControl({
+  tokens,
+  valueOf,
+  setter,
+}: {
+  readonly tokens: ThemeTokens;
+  readonly valueOf: (property: string) => StyleValue | undefined;
+  readonly setter: (property: string) => (value: StyleValue | null) => void;
+}): ReactElement {
+  const sideControls = (prefix: "margin" | "padding"): ReactElement[] =>
+    SIDES.map((side) => {
+      const property = `${prefix}${side}`;
+      return (
+        <StyleControl
+          key={property}
+          label={side}
+          property={property}
+          category="spacing"
+          value={valueOf(property)}
+          tokens={tokens}
+          onChange={setter(property)}
+        />
+      );
+    });
+
+  return (
+    <div
+      className="border-border flex flex-col gap-2 rounded-md border p-2"
+      data-testid="box-model-margin"
+    >
+      <span className="text-muted-foreground text-xs">
+        <Trans id="editor.styles.margin" message="Margin" />
+      </span>
+      {sideControls("margin")}
+      <div
+        className="border-border mt-1 flex flex-col gap-2 rounded-md border p-2"
+        data-testid="box-model-padding"
+      >
+        <span className="text-muted-foreground text-xs">
+          <Trans id="editor.styles.padding" message="Padding" />
+        </span>
+        {sideControls("padding")}
+      </div>
+    </div>
+  );
+}

--- a/packages/admin/src/editor/StyleTab.tsx
+++ b/packages/admin/src/editor/StyleTab.tsx
@@ -16,11 +16,20 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@plumix/admin-ui/accordion";
+import { normalizeStyleValue } from "@plumix/blocks";
 
 import type { StyleBucket } from "./viewport-bucket.js";
 import { DEVICE_LABEL } from "./device-labels.js";
 import { setStyleProperty } from "./style-edit.js";
 import { TokenSwatchList } from "./TokenSwatchList.js";
+
+// Puck's style controls are token-only; read just the token id from a stored
+// value (a legacy bare string or a `{ token }` ref), ignoring `{ raw }` custom
+// values authored in the bespoke editor.
+function activeTokenId(value: unknown): string {
+  const normalized = normalizeStyleValue(value);
+  return normalized && "token" in normalized ? normalized.token : "";
+}
 
 type StyleProperty = "background" | "color" | "fontSize" | "padding";
 
@@ -96,28 +105,28 @@ export function StyleTab({
           heading={renderLabel(M.background)}
           property="background"
           tokens={tokens.colors}
-          activeToken={style?.[bucket]?.background ?? ""}
+          activeToken={activeTokenId(style?.[bucket]?.background)}
           onWrite={writeProperty}
         />
         <SwatchSection
           heading={renderLabel(M.textColor)}
           property="color"
           tokens={tokens.colors}
-          activeToken={style?.[bucket]?.color ?? ""}
+          activeToken={activeTokenId(style?.[bucket]?.color)}
           onWrite={writeProperty}
         />
         <SelectSection
           heading={renderLabel(M.fontSize)}
           property="fontSize"
           tokens={tokens.typography}
-          activeToken={style?.[bucket]?.fontSize ?? ""}
+          activeToken={activeTokenId(style?.[bucket]?.fontSize)}
           onWrite={writeProperty}
         />
         <SelectSection
           heading={renderLabel(M.padding)}
           property="padding"
           tokens={tokens.spacing}
-          activeToken={style?.[bucket]?.padding ?? ""}
+          activeToken={activeTokenId(style?.[bucket]?.padding)}
           onWrite={writeProperty}
         />
       </Accordion>

--- a/packages/admin/src/editor/style-edit.ts
+++ b/packages/admin/src/editor/style-edit.ts
@@ -1,4 +1,4 @@
-import type { ResponsiveStyleSlot } from "@plumix/blocks";
+import type { ResponsiveStyleSlot, StyleValue } from "@plumix/blocks";
 
 import type { StyleBucket } from "./viewport-bucket.js";
 
@@ -8,7 +8,9 @@ export function setStyleProperty(
   property: string,
   tokenId: string | undefined,
 ): ResponsiveStyleSlot | undefined {
-  const nextBucket: Record<string, string> = { ...(style?.[bucket] ?? {}) };
+  const nextBucket: Record<string, StyleValue | string> = {
+    ...(style?.[bucket] ?? {}),
+  };
   if (tokenId === undefined) {
     delete nextBucket[property];
   } else {

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/editor.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/editor.tsx
@@ -15,6 +15,7 @@ import {
   findEntryTypeBySlug,
   getPatterns,
   getThemeBreakpoints,
+  getThemeTokens,
 } from "@/lib/manifest.js";
 import { orpc } from "@/lib/orpc.js";
 import { getRegisteredBlocks } from "@/lib/plugin-registry.js";
@@ -81,6 +82,9 @@ const patterns = getPatterns();
 
 // Theme breakpoints sizing the editor's device-switch canvas widths.
 const breakpoints = getThemeBreakpoints();
+
+// Theme tokens offered in the Styles tab's token-or-custom controls.
+const themeTokens = getThemeTokens();
 
 // Mint once and cache forever — each call writes a fresh preview token, and
 // the URL it returns is the canvas iframe's target for the editor's lifetime.
@@ -646,6 +650,7 @@ function BespokeEditor({
       capabilities={capabilitySet}
       patterns={patterns}
       breakpoints={breakpoints}
+      tokens={themeTokens}
       previewLink={shareUrl}
       onChange={handleChange}
       documentPanel={documentPanel}

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -108,15 +108,18 @@ export type {
 export {
   DEFAULT_BREAKPOINTS,
   emitBlockStyleCss,
+  normalizeStyleValue,
   tokenIdToCssVar,
   VIEWPORT_MAX_PX,
 } from "./styles/style-emitter.js";
 export type {
   ResponsiveStyleBucket,
   ResponsiveStyleSlot,
+  StyleValue,
   ThemeBreakpoints,
   TokenCategory,
 } from "./styles/style-emitter.js";
+export { sanitizeCssValue } from "./styles/sanitize-css.js";
 export type {
   ThemeTokenEntry,
   ThemeTokenGroup,

--- a/packages/blocks/src/styles/sanitize-css.test.ts
+++ b/packages/blocks/src/styles/sanitize-css.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+
+import { sanitizeCssValue } from "./sanitize-css.js";
+
+describe("sanitizeCssValue", () => {
+  test("passes through ordinary CSS values", () => {
+    expect(sanitizeCssValue("16px")).toBe("16px");
+    expect(sanitizeCssValue("#0c2238")).toBe("#0c2238");
+    expect(sanitizeCssValue("rgba(0, 0, 0, 0.5)")).toBe("rgba(0, 0, 0, 0.5)");
+    expect(sanitizeCssValue("  1.5rem  ")).toBe("1.5rem");
+  });
+
+  test("rejects rule/breakout and script-injection vectors", () => {
+    // Brace breakout out of the declaration block.
+    expect(sanitizeCssValue("red } body { display:none")).toBeNull();
+    // Legacy IE expression() script execution.
+    expect(sanitizeCssValue("expression(alert(1))")).toBeNull();
+    // javascript: scheme (e.g. inside url()).
+    expect(sanitizeCssValue("url(javascript:alert(1))")).toBeNull();
+    // Tag / escape obfuscation vectors.
+    expect(sanitizeCssValue("</style><script>")).toBeNull();
+    expect(sanitizeCssValue("\\65 xpression(1)")).toBeNull();
+  });
+
+  test("rejects empty / non-string input", () => {
+    expect(sanitizeCssValue("")).toBeNull();
+    expect(sanitizeCssValue("   ")).toBeNull();
+  });
+});

--- a/packages/blocks/src/styles/sanitize-css.ts
+++ b/packages/blocks/src/styles/sanitize-css.ts
@@ -1,0 +1,31 @@
+// Patterns that must never appear in an author-supplied raw CSS value. The
+// trust boundary is the stored bytes — a raw value is emitted verbatim into a
+// `<style>` declaration, so anything that could break out of the declaration
+// block or smuggle script is dropped wholesale (the value is discarded, not
+// escaped, since a "fixed up" CSS value is rarely what the author meant).
+//
+// A denylist is safe here because the residual surface is the closed CSS-grammar
+// set: React already escapes `<`/`>`/`&` in `<style>` text, so HTML breakout is
+// inert and only braces / at-rules / extra declarations / dangerous schemes
+// remain. The brace rule is the load-bearing defense; `expression()` is kept for
+// belt-and-suspenders though it executes in no shipping browser.
+const DANGEROUS_CSS = [
+  /[{}<>]/, // declaration-block / tag breakout
+  /\\/, // backslash escapes (unicode-escape obfuscation)
+  /expression\s*\(/i, // legacy IE expression() script execution
+  /(javascript|vbscript|data)\s*:/i, // dangerous url() schemes
+  /[;@]/, // extra declarations / at-rules
+];
+
+/**
+ * A custom CSS value the emitter can safely write into a declaration, or
+ * `null` when it carries a breakout / injection vector. Trims surrounding
+ * whitespace; rejects empties. Token-bound values never pass through here —
+ * only authored raw values do.
+ */
+export function sanitizeCssValue(value: string): string | null {
+  const trimmed = value.trim();
+  if (trimmed === "") return null;
+  if (DANGEROUS_CSS.some((re) => re.test(trimmed))) return null;
+  return trimmed;
+}

--- a/packages/blocks/src/styles/style-emitter.test.ts
+++ b/packages/blocks/src/styles/style-emitter.test.ts
@@ -2,7 +2,31 @@ import { describe, expect, test } from "vitest";
 
 import type { ResponsiveStyleSlot } from "./style-emitter.js";
 import type { ThemeTokens } from "./types.js";
-import { emitBlockStyleCss, tokenIdToCssVar } from "./style-emitter.js";
+import {
+  emitBlockStyleCss,
+  normalizeStyleValue,
+  tokenIdToCssVar,
+} from "./style-emitter.js";
+
+describe("normalizeStyleValue", () => {
+  test("coerces a legacy bare-string value to a token ref (the migration)", () => {
+    expect(normalizeStyleValue("lg")).toEqual({ token: "lg" });
+  });
+
+  test("passes through token and raw refs unchanged", () => {
+    expect(normalizeStyleValue({ token: "primary" })).toEqual({
+      token: "primary",
+    });
+    expect(normalizeStyleValue({ raw: "16px" })).toEqual({ raw: "16px" });
+  });
+
+  test("rejects malformed values", () => {
+    expect(normalizeStyleValue(null)).toBeNull();
+    expect(normalizeStyleValue({})).toBeNull();
+    expect(normalizeStyleValue({ token: 2 })).toBeNull();
+    expect(normalizeStyleValue({ raw: "", token: "x" })).toBeNull();
+  });
+});
 
 describe("tokenIdToCssVar", () => {
   test("resolves a registered token to a CSS variable reference with the token's literal as fallback", () => {
@@ -71,6 +95,66 @@ describe("emitBlockStyleCss", () => {
     expect(css).toContain(
       "@media (max-width: 640px) { .block-1 { padding: var(--plumix-spacing-sm, 8px); } }",
     );
+  });
+
+  test("resolves the radius and shadow token categories", () => {
+    const themed: ThemeTokens = {
+      radius: { md: { value: "8px" } },
+      shadow: { lg: { value: "0 4px 8px rgba(0,0,0,0.1)" } },
+    };
+    const css = emitBlockStyleCss(
+      "block-1",
+      { large: { borderRadius: { token: "md" }, boxShadow: { token: "lg" } } },
+      themed,
+    );
+    expect(css).toContain("border-radius: var(--plumix-radius-md, 8px);");
+    expect(css).toContain(
+      "box-shadow: var(--plumix-shadow-lg, 0 4px 8px rgba(0,0,0,0.1));",
+    );
+  });
+
+  test("maps per-side spacing and extended typography properties", () => {
+    const themed: ThemeTokens = {
+      spacing: { sm: { value: "8px" } },
+      typography: { bold: { value: "700" } },
+    };
+    const css = emitBlockStyleCss(
+      "block-1",
+      { large: { marginTop: { token: "sm" }, fontWeight: { token: "bold" } } },
+      themed,
+    );
+    expect(css).toContain("margin-top: var(--plumix-spacing-sm, 8px);");
+    expect(css).toContain("font-weight: var(--plumix-typography-bold, 700);");
+  });
+
+  test("emits raw custom values alongside token refs", () => {
+    const style: ResponsiveStyleSlot = {
+      large: { padding: { raw: "20px" }, color: { token: "primary" } },
+    };
+
+    const css = emitBlockStyleCss("block-1", style, tokens);
+    // Raw value is emitted literally (fixed); token resolves to a CSS variable
+    // (reskins when the token changes).
+    expect(css).toContain("padding: 20px;");
+    expect(css).toContain("color: var(--plumix-color-primary, #0c2238);");
+  });
+
+  test("a legacy bare-string value still resolves as a token (no visual change)", () => {
+    const css = emitBlockStyleCss(
+      "block-1",
+      { large: { padding: "lg" } },
+      tokens,
+    );
+    expect(css).toBe(".block-1 { padding: var(--plumix-spacing-lg, 24px); }");
+  });
+
+  test("drops a raw value carrying a breakout vector", () => {
+    const css = emitBlockStyleCss(
+      "block-1",
+      { large: { padding: { raw: "1px } body { display:none" } } },
+      tokens,
+    );
+    expect(css).toBe("");
   });
 
   test("uses theme-supplied breakpoints for the @media maxima when given", () => {

--- a/packages/blocks/src/styles/style-emitter.ts
+++ b/packages/blocks/src/styles/style-emitter.ts
@@ -1,8 +1,32 @@
 import type { ThemeTokens } from "./types.js";
+import { sanitizeCssValue } from "./sanitize-css.js";
 
 export type TokenCategory = keyof ThemeTokens;
 
-export type ResponsiveStyleBucket = Readonly<Record<string, string>>;
+/**
+ * One declaration's value: a theme `token` (resolved to a CSS variable, so it
+ * reskins when the token changes) or a `raw` literal (sanitized, fixed). A
+ * legacy bare-string value is read as a token ref — that's the migration, done
+ * lazily at emit time with no stored-data rewrite.
+ */
+export type StyleValue = { readonly token: string } | { readonly raw: string };
+
+export type ResponsiveStyleBucket = Readonly<
+  Record<string, StyleValue | string>
+>;
+
+/** Coerce a stored bucket value (possibly the legacy bare-string token id) to a
+ *  `StyleValue`, or `null` when it's malformed. */
+export function normalizeStyleValue(value: unknown): StyleValue | null {
+  if (typeof value === "string") return value === "" ? null : { token: value };
+  if (!value || typeof value !== "object") return null;
+  const v = value as Record<string, unknown>;
+  const hasToken = typeof v.token === "string";
+  const hasRaw = typeof v.raw === "string";
+  // Exactly one of token | raw — never both, never neither.
+  if (hasToken === hasRaw) return null;
+  return hasToken ? { token: v.token as string } : { raw: v.raw as string };
+}
 
 export interface ResponsiveStyleSlot {
   readonly large?: ResponsiveStyleBucket;
@@ -12,12 +36,27 @@ export interface ResponsiveStyleSlot {
 
 const PROPERTY_TO_CATEGORY: Readonly<Record<string, TokenCategory>> = {
   padding: "spacing",
+  paddingTop: "spacing",
+  paddingRight: "spacing",
+  paddingBottom: "spacing",
+  paddingLeft: "spacing",
   margin: "spacing",
+  marginTop: "spacing",
+  marginRight: "spacing",
+  marginBottom: "spacing",
+  marginLeft: "spacing",
   gap: "spacing",
   background: "colors",
   color: "colors",
+  borderColor: "colors",
   fontSize: "typography",
   fontFamily: "typography",
+  fontWeight: "typography",
+  lineHeight: "typography",
+  letterSpacing: "typography",
+  borderWidth: "border",
+  borderRadius: "radius",
+  boxShadow: "shadow",
 };
 
 const SAFE_CSS_TOKEN_RE = /^[A-Za-z0-9_-]+$/;
@@ -90,17 +129,31 @@ function bucketToDeclarations(
   tokens: ThemeTokens,
 ): string {
   const decls: string[] = [];
-  for (const [property, tokenId] of Object.entries(bucket)) {
-    if (!SAFE_CSS_TOKEN_RE.test(property) || !SAFE_CSS_TOKEN_RE.test(tokenId)) {
-      continue;
-    }
-    const category = PROPERTY_TO_CATEGORY[property];
-    if (!category) continue;
-    decls.push(
-      `${propertyToCss(property)}: ${tokenIdToCssVar(tokenId, category, tokens)};`,
-    );
+  for (const [property, stored] of Object.entries(bucket)) {
+    if (!SAFE_CSS_TOKEN_RE.test(property)) continue;
+    const value = normalizeStyleValue(stored);
+    if (!value) continue;
+    const css = declarationValue(property, value, tokens);
+    if (css === null) continue;
+    decls.push(`${propertyToCss(property)}: ${css};`);
   }
   return decls.join(" ");
+}
+
+// Resolve one declaration's right-hand side: a token → its CSS variable (with
+// the registered literal as fallback), a raw value → the sanitized literal.
+// Returns null to drop the declaration (unknown token category, unsafe token
+// id, or a raw value carrying an injection vector).
+function declarationValue(
+  property: string,
+  value: StyleValue,
+  tokens: ThemeTokens,
+): string | null {
+  if ("raw" in value) return sanitizeCssValue(value.raw);
+  if (!SAFE_CSS_TOKEN_RE.test(value.token)) return null;
+  const category = PROPERTY_TO_CATEGORY[property];
+  if (!category) return null;
+  return tokenIdToCssVar(value.token, category, tokens);
 }
 
 function propertyToCss(property: string): string {

--- a/packages/blocks/src/styles/types.ts
+++ b/packages/blocks/src/styles/types.ts
@@ -20,4 +20,6 @@ export interface ThemeTokens {
   readonly spacing?: ThemeTokenGroup;
   readonly typography?: ThemeTokenGroup;
   readonly border?: ThemeTokenGroup;
+  readonly radius?: ThemeTokenGroup;
+  readonly shadow?: ThemeTokenGroup;
 }


### PR DESCRIPTION
A new right-rail **Styles** tab lets authors style any block: collapsible
sections (typography, background, border, shadow) plus a visual box-model for
per-side margin/padding. Every control offers a theme **token or a custom
value**, and edits target the active device's responsive bucket, so styles are
set per breakpoint. Closes #1119.

Token-bound values resolve to CSS variables (they reskin when the theme token
changes); custom values are written as sanitized literals (fixed). The bucket
value gains a `{ token } | { raw }` union, and a legacy bare-string value is
read as a token ref at emit time — so existing token-only data migrates with no
stored rewrite and **no visual change** (asserted byte-for-byte).

Security is enforced at the emit boundary: the SSR emitter runs every raw value
through a new `sanitizeCssValue` that drops brace-breakout, `url(javascript:)`,
`expression()`, extra declarations, and at-rules. A denylist is safe here
because React already escapes HTML-special chars in `<style>` text, leaving only
the closed CSS-grammar set. The emitter also gains radius/shadow token
categories and per-side / extended-typography property mappings.

The store gains `updateBlockStyle` (immutable, prunes empty buckets, coalesces
per property) and a `deviceBucket` mapping; the duplicated attr/style tree-patch
walkers collapse into one id-addressed `mapNodeById`. The legacy Puck StyleTab
is coerced to read the union token-only so it still compiles through the #1121
cutover (a follow-up tracks surfacing custom values there).

Out of scope: live style preview inside the editor canvas (the edit-mode canvas
doesn't emit token CSS today) — the SSR emitter renders styles on the published
page, which is what these controls drive.

Testing follows the package layering: the sanitizer, the token|raw union +
migration, the emitter, `updateBlockStyle`, and `StyleControl`/`StylesTab` are
unit-tested in their packages; the cross-iframe flow is a playground e2e
(Styles tab edits land on the canonical tree). blocks 444, core 2290, admin 568,
admin-editor 219 unit + 20 e2e; lint/typecheck/knip/format pass. Light + dark
screenshots shared during review.