### PR TITLE
feat: editor islands + dynamic-data in the canvas

### DIFF
--- a/packages/admin-editor/e2e/editor-visual.spec.ts
+++ b/packages/admin-editor/e2e/editor-visual.spec.ts
@@ -430,6 +430,29 @@ test.describe("editor playground", () => {
     await expect(json).toContainText('"12px"');
   });
 
+  test("a loader-backed block offers a scoped refresh that updates the canvas", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const canvas = page.frameLocator(CANVAS_FRAME);
+
+    // The feed block opens with no loader data (no SSR in the harness).
+    const feedData = canvas.locator('[data-testid="feed-data"]');
+    await expect(feedData).toContainText("no data yet");
+
+    // Selecting it reveals the refresh control; a plain block does not.
+    await canvas.locator('[data-plumix-id="feed-1"]').click();
+    await expect(page.getByTestId("refresh-block-loader")).toBeVisible();
+
+    // Refresh round-trips through the host stub and pushes data to the canvas.
+    await page.getByTestId("refresh-block-loader").click();
+    await expect(feedData).toContainText("refreshed");
+
+    // A non-loader block hides the control entirely.
+    await canvas.locator('[data-plumix-id="heading-1"]').click();
+    await expect(page.getByTestId("refresh-block-loader")).toHaveCount(0);
+  });
+
   test("the Layers tab outlines the nested structure", async ({ page }) => {
     await page.goto("/");
 

--- a/packages/admin-editor/locales/ar.po
+++ b/packages/admin-editor/locales/ar.po
@@ -154,6 +154,11 @@ msgid "editor.toolbar.redo"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/block-inspector.tsx
+msgid "editor.inspector.refreshData"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
 msgid "editor.toolbar.saveDraft"
 msgstr ""

--- a/packages/admin-editor/locales/de.po
+++ b/packages/admin-editor/locales/de.po
@@ -154,6 +154,11 @@ msgid "editor.toolbar.redo"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/block-inspector.tsx
+msgid "editor.inspector.refreshData"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
 msgid "editor.toolbar.saveDraft"
 msgstr ""

--- a/packages/admin-editor/locales/en.po
+++ b/packages/admin-editor/locales/en.po
@@ -154,6 +154,11 @@ msgid "editor.toolbar.redo"
 msgstr "Redo"
 
 #. js-lingui-explicit-id
+#: src/block-inspector.tsx
+msgid "editor.inspector.refreshData"
+msgstr "Refresh data"
+
+#. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
 msgid "editor.toolbar.saveDraft"
 msgstr "Save draft"

--- a/packages/admin-editor/locales/uk.po
+++ b/packages/admin-editor/locales/uk.po
@@ -154,6 +154,11 @@ msgid "editor.toolbar.redo"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/block-inspector.tsx
+msgid "editor.inspector.refreshData"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
 msgid "editor.toolbar.saveDraft"
 msgstr ""

--- a/packages/admin-editor/locales/zh-CN.po
+++ b/packages/admin-editor/locales/zh-CN.po
@@ -154,6 +154,11 @@ msgid "editor.toolbar.redo"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/block-inspector.tsx
+msgid "editor.inspector.refreshData"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
 msgid "editor.toolbar.saveDraft"
 msgstr ""

--- a/packages/admin-editor/playground/canvas.tsx
+++ b/packages/admin-editor/playground/canvas.tsx
@@ -4,6 +4,7 @@ import { createRoot } from "react-dom/client";
 import { coreBlocks, createBlockRegistry } from "@plumix/blocks";
 
 import { EditorCanvas } from "../src/editor-canvas.js";
+import { feedSpec } from "./feed-block.js";
 import { SEED_BLOCKS } from "./seed.js";
 
 import "./playground.css";
@@ -12,7 +13,7 @@ import "./playground.css";
 // (handshake + host:tree / canvas:* reports) works for real — no worker, no
 // public route. Mirrors what the SSR-injected editor runtime does in
 // production, minus the server.
-const registry = createBlockRegistry(coreBlocks);
+const registry = createBlockRegistry([...coreBlocks, feedSpec]);
 
 const root = document.getElementById("root");
 if (root) {

--- a/packages/admin-editor/playground/feed-block.tsx
+++ b/packages/admin-editor/playground/feed-block.tsx
@@ -1,0 +1,30 @@
+import type { BlockNode, BlockSpec } from "@plumix/blocks";
+
+// A loader-backed block so the inspector's scoped-refresh control (#1120) has
+// something to act on. The loader is a server function — it never runs in this
+// backend-less harness, so the canvas opens with no data and the host's refresh
+// stub pushes some in over the bridge. The render reflects whichever it has.
+export const feedSpec: BlockSpec = {
+  name: "playground/feed",
+  inputs: [{ name: "title", type: "text", label: "Title" }],
+  loaders: {
+    items: () => Promise.resolve({ label: "from the server" }),
+  },
+  render: ({ attrs, loaders }) => {
+    const items = loaders.items as { label?: string } | undefined;
+    const title =
+      typeof attrs.title === "string" ? attrs.title : "Latest posts";
+    return (
+      <div data-testid="feed-block" className="rounded border p-4">
+        <strong>{title}</strong>{" "}
+        <span data-testid="feed-data">{items?.label ?? "no data yet"}</span>
+      </div>
+    );
+  },
+};
+
+export const FEED_SEED: BlockNode = {
+  id: "feed-1",
+  name: "playground/feed",
+  attrs: { title: "Latest posts" },
+};

--- a/packages/admin-editor/playground/host.tsx
+++ b/packages/admin-editor/playground/host.tsx
@@ -13,6 +13,7 @@ import {
 } from "@plumix/blocks";
 
 import { PlumixEditor } from "../src/plumix-editor.js";
+import { feedSpec } from "./feed-block.js";
 import { SEED_BLOCKS, SEED_PATTERNS } from "./seed.js";
 
 import "./playground.css";
@@ -46,7 +47,7 @@ const withVariations = coreBlocks.map(
         }
       : spec,
 );
-const registry = createBlockRegistry(withVariations);
+const registry = createBlockRegistry([...withVariations, feedSpec]);
 
 // Seed theme tokens so the Styles tab's token-or-custom controls have options.
 const SEED_TOKENS = {
@@ -121,6 +122,9 @@ if (root) {
           previewBanner={readOnly ? <PreviewBannerStub /> : undefined}
           previewLink="https://example.test/blog/hello?preview=demo-token"
           documentPanel={<DocumentPanelStub />}
+          onRefreshBlockLoader={(blockId) =>
+            Promise.resolve({ [blockId]: { items: { label: "refreshed" } } })
+          }
           publish={{
             onPublish: () => console.info("[playground] publish"),
             isPublished: false,

--- a/packages/admin-editor/playground/seed.ts
+++ b/packages/admin-editor/playground/seed.ts
@@ -1,6 +1,7 @@
 import type { BlockNode } from "@plumix/blocks";
 
 import type { InserterPattern } from "../src/block-catalog.js";
+import { FEED_SEED } from "./feed-block.js";
 
 /**
  * A representative tree for the playground: top-level blocks plus nested and
@@ -73,6 +74,7 @@ export const SEED_BLOCKS: readonly BlockNode[] = [
       ],
     },
   },
+  FEED_SEED,
 ];
 
 /**

--- a/packages/admin-editor/src/block-inspector.test.tsx
+++ b/packages/admin-editor/src/block-inspector.test.tsx
@@ -6,6 +6,7 @@ import { cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, beforeAll, describe, expect, test } from "vitest";
 
 import type { BlockNode, BlockRegistry } from "@plumix/blocks";
+import type { SerializedLoaderData } from "@plumix/blocks/renderer";
 import { createBlockRegistry } from "@plumix/blocks";
 
 import { BlockInspector } from "./block-inspector.js";
@@ -43,6 +44,11 @@ const registry: BlockRegistry = createBlockRegistry([
       { name: "tag", type: "text", label: "Tag" },
     ],
   },
+  {
+    name: "core/latest-posts",
+    render: () => null,
+    loaders: { posts: () => Promise.resolve([]) },
+  },
 ]);
 
 function Selector({ id }: { readonly id?: string }): ReactElement | null {
@@ -56,12 +62,16 @@ function Selector({ id }: { readonly id?: string }): ReactElement | null {
 function renderInspector(
   tree: readonly BlockNode[],
   selectId?: string,
+  onRefreshBlockLoader?: (blockId: string) => Promise<SerializedLoaderData>,
 ): ReturnType<typeof render> {
   return render(
     <I18nProvider i18n={i18n}>
       <EditorProvider initialTree={tree}>
         <Selector id={selectId} />
-        <BlockInspector registry={registry} />
+        <BlockInspector
+          registry={registry}
+          onRefreshBlockLoader={onRefreshBlockLoader}
+        />
       </EditorProvider>
     </I18nProvider>,
   );
@@ -126,5 +136,31 @@ describe("BlockInspector", () => {
     );
     expect(getByTestId("block-inspector")).toBeDefined();
     expect(queryByTestId("block-inspector-empty")).toBeNull();
+  });
+
+  test("shows the refresh-data control only for a loader-backed block", () => {
+    const { getByTestId } = renderInspector(
+      [{ id: "lp1", name: "core/latest-posts" }],
+      "lp1",
+      () => Promise.resolve({}),
+    );
+    expect(getByTestId("refresh-block-loader")).toBeDefined();
+  });
+
+  test("hides the refresh-data control for a block without loaders", () => {
+    const { queryByTestId } = renderInspector(
+      [{ id: "h1", name: "core/heading" }],
+      "h1",
+      () => Promise.resolve({}),
+    );
+    expect(queryByTestId("refresh-block-loader")).toBeNull();
+  });
+
+  test("hides the refresh-data control when no onRefreshBlockLoader is wired", () => {
+    const { queryByTestId } = renderInspector(
+      [{ id: "lp1", name: "core/latest-posts" }],
+      "lp1",
+    );
+    expect(queryByTestId("refresh-block-loader")).toBeNull();
   });
 });

--- a/packages/admin-editor/src/block-inspector.tsx
+++ b/packages/admin-editor/src/block-inspector.tsx
@@ -3,14 +3,22 @@ import { useCallback } from "react";
 import { Trans } from "@lingui/react";
 
 import type { BlockRegistry } from "@plumix/blocks";
+import type { SerializedLoaderData } from "@plumix/blocks/renderer";
+import { Button } from "@plumix/admin-ui/button";
+import { RefreshCw } from "@plumix/admin-ui/icons";
 
 import { BlockInputControl } from "./block-input-control.js";
 import { findBlock } from "./block-tree-ops.js";
-import { useEditorStore } from "./provider.js";
+import { useEditorStore, useLoaderPushRef } from "./provider.js";
 
 interface BlockInspectorProps {
   /** Core + plugin block registry; supplies each block's input schema. */
   readonly registry: BlockRegistry;
+  /** Re-run the active block's loader(s) server-side (the host's orpc call).
+   *  When set, a loader-backed block gets a "Refresh data" control. */
+  readonly onRefreshBlockLoader?: (
+    blockId: string,
+  ) => Promise<SerializedLoaderData>;
 }
 
 /**
@@ -21,10 +29,12 @@ interface BlockInspectorProps {
  */
 export function BlockInspector({
   registry,
+  onRefreshBlockLoader,
 }: BlockInspectorProps): ReactElement {
   const activeId = useEditorStore((s) => s.activeId);
   const tree = useEditorStore((s) => s.tree);
   const updateBlockAttrs = useEditorStore((s) => s.updateBlockAttrs);
+  const loaderPushRef = useLoaderPushRef();
 
   const block = activeId ? findBlock(tree, activeId) : undefined;
   const handleChange = useCallback(
@@ -33,6 +43,11 @@ export function BlockInspector({
     },
     [activeId, updateBlockAttrs],
   );
+  const handleRefresh = useCallback(async (): Promise<void> => {
+    if (!activeId || !onRefreshBlockLoader) return;
+    const data = await onRefreshBlockLoader(activeId);
+    loaderPushRef?.current?.(data);
+  }, [activeId, onRefreshBlockLoader, loaderPushRef]);
 
   if (!block) {
     return (
@@ -51,9 +66,9 @@ export function BlockInspector({
   // Slot inputs hold child block arrays, not scalar attributes — editing
   // them as a control would overwrite the children with a string. Nested
   // editing is a separate concern (canvas selection of the child block).
-  const inputs = (registry.get(block.name)?.inputs ?? []).filter(
-    (input) => input.type !== "slot",
-  );
+  const spec = registry.get(block.name);
+  const inputs = (spec?.inputs ?? []).filter((input) => input.type !== "slot");
+  const canRefresh = Boolean(onRefreshBlockLoader && spec?.loaders);
 
   return (
     <div className="flex flex-col gap-4 p-4" data-testid="block-inspector">
@@ -65,6 +80,18 @@ export function BlockInspector({
           onChange={(value) => handleChange(input.name, value)}
         />
       ))}
+      {canRefresh && (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          data-testid="refresh-block-loader"
+          onClick={() => void handleRefresh()}
+        >
+          <RefreshCw />
+          <Trans id="editor.inspector.refreshData" message="Refresh data" />
+        </Button>
+      )}
     </div>
   );
 }

--- a/packages/admin-editor/src/canvas-frame.tsx
+++ b/packages/admin-editor/src/canvas-frame.tsx
@@ -15,7 +15,11 @@ import { findBlock } from "./block-tree-ops.js";
 import { connectCanvas } from "./connect-canvas.js";
 import { dropPlacement } from "./drop-index.js";
 import { overlayBox } from "./overlay.js";
-import { useEditorStore, useEditorStoreApi } from "./provider.js";
+import {
+  useEditorStore,
+  useEditorStoreApi,
+  useLoaderPushRef,
+} from "./provider.js";
 import { SelectionToolbar } from "./selection-toolbar.js";
 import { deviceWidth } from "./store.js";
 
@@ -70,6 +74,7 @@ export function CanvasFrame({
   readOnly = false,
 }: CanvasFrameProps): ReactElement {
   const store = useEditorStoreApi();
+  const loaderPushRef = useLoaderPushRef();
   const device = useEditorStore((s) => s.device);
   const zoom = useEditorStore((s) => s.zoom);
   const breakpoints = useEditorStore((s) => s.breakpoints);
@@ -137,8 +142,13 @@ export function CanvasFrame({
         measureContent();
       },
     });
-    return () => connection.dispose();
-  }, [store, origin, measureHost, measureContent]);
+    // Expose the loader-data push to the inspector's refresh control.
+    if (loaderPushRef) loaderPushRef.current = connection.pushLoaderData;
+    return () => {
+      if (loaderPushRef) loaderPushRef.current = null;
+      connection.dispose();
+    };
+  }, [store, origin, measureHost, measureContent, loaderPushRef]);
 
   // Keep frame/container fresh when the canvas moves without a block report:
   // column scroll, window resize, and rail collapse (which resizes the inset).

--- a/packages/admin-editor/src/connect-canvas.test.ts
+++ b/packages/admin-editor/src/connect-canvas.test.ts
@@ -84,6 +84,22 @@ describe("connectCanvas", () => {
     conn.dispose();
   });
 
+  test("pushLoaderData posts host:loader-data to the canvas", () => {
+    const store = createEditorStore();
+    const { win, posted } = fakeFrame();
+    const conn = connectCanvas({ store, frameWindow: win, origin: ORIGIN });
+
+    conn.pushLoaderData({ "blk-1": { posts: ["fresh"] } });
+
+    const msg = posted
+      .map(
+        (p) => (p as { message?: { type?: string; data?: unknown } }).message,
+      )
+      .find((m) => m?.type === "host:loader-data");
+    expect(msg?.data).toEqual({ "blk-1": { posts: ["fresh"] } });
+    conn.dispose();
+  });
+
   test("re-announces hello until the canvas acks, then stops", () => {
     vi.useFakeTimers();
     try {

--- a/packages/admin-editor/src/connect-canvas.ts
+++ b/packages/admin-editor/src/connect-canvas.ts
@@ -2,6 +2,7 @@ import type {
   BlockRect,
   CanvasMessage,
   HostMessage,
+  SerializedLoaderData,
   SlotRect,
 } from "@plumix/blocks/renderer";
 import {
@@ -17,6 +18,8 @@ import type { EditorStoreApi } from "./store.js";
 export interface CanvasConnection {
   /** Resolves once the canvas has completed the handshake. */
   readonly whenReady: Promise<void>;
+  /** Push a scoped refresh's re-resolved loader data to the canvas. */
+  readonly pushLoaderData: (data: SerializedLoaderData) => void;
   readonly dispose: () => void;
 }
 
@@ -105,6 +108,8 @@ export function connectCanvas({
 
   return {
     whenReady,
+    pushLoaderData: (data) =>
+      post({ type: "host:loader-data", data } satisfies HostMessage),
     dispose: () => {
       clearInterval(retryTimer);
       window.removeEventListener("message", onMessage);

--- a/packages/admin-editor/src/connect-runtime.test.ts
+++ b/packages/admin-editor/src/connect-runtime.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import type { BlockNode } from "@plumix/blocks";
+import type { SerializedLoaderData } from "@plumix/blocks/renderer";
 import { EDITOR_BRIDGE_CHANNEL, encode } from "@plumix/blocks/renderer";
 
 import { connectRuntime } from "./connect-runtime.js";
@@ -57,6 +58,23 @@ describe("connectRuntime (canvas/iframe side)", () => {
     fromHost({ type: "host:tree", tree });
 
     expect(seen.at(-1)).toEqual(tree);
+    conn.dispose();
+  });
+
+  test("delivers a pushed loader-data map to onLoaderData", () => {
+    const seen: SerializedLoaderData[] = [];
+    const { win } = fakeParent();
+    const conn = connectRuntime({
+      parentWindow: win,
+      origin: ORIGIN,
+      onTree: () => undefined,
+      onLoaderData: (data) => seen.push(data),
+    });
+
+    const data = { "blk-1": { posts: ["fresh"] } };
+    fromHost({ type: "host:loader-data", data });
+
+    expect(seen.at(-1)).toEqual(data);
     conn.dispose();
   });
 

--- a/packages/admin-editor/src/connect-runtime.ts
+++ b/packages/admin-editor/src/connect-runtime.ts
@@ -3,6 +3,7 @@ import type {
   BlockRect,
   CanvasMessage,
   HostMessage,
+  SerializedLoaderData,
   SlotRect,
 } from "@plumix/blocks/renderer";
 import {
@@ -30,6 +31,8 @@ interface ConnectRuntimeOptions {
   readonly origin: string;
   /** Called with each tree the host pushes. */
   readonly onTree: (tree: readonly BlockNode[]) => void;
+  /** Called with a scoped refresh's re-resolved loader data (node-keyed). */
+  readonly onLoaderData?: (data: SerializedLoaderData) => void;
 }
 
 /**
@@ -42,6 +45,7 @@ export function connectRuntime({
   parentWindow,
   origin,
   onTree,
+  onLoaderData,
 }: ConnectRuntimeOptions): RuntimeConnection {
   const post = (message: object): void => {
     parentWindow.postMessage(encode(EDITOR_BRIDGE_CHANNEL, message), origin);
@@ -67,8 +71,15 @@ export function connectRuntime({
       if (message.kind === "hello") announce();
       return;
     }
-    const host = message as Partial<HostMessage>;
-    if (host.type === "host:tree" && host.tree) onTree(host.tree);
+    const host = message as HostMessage;
+    switch (host.type) {
+      case "host:tree":
+        onTree(host.tree);
+        break;
+      case "host:loader-data":
+        onLoaderData?.(host.data);
+        break;
+    }
   };
 
   window.addEventListener("message", onMessage);

--- a/packages/admin-editor/src/editor-canvas.tsx
+++ b/packages/admin-editor/src/editor-canvas.tsx
@@ -7,9 +7,13 @@ import {
   useState,
 } from "react";
 
-import type { BlockNode, BlockRegistry } from "@plumix/blocks";
+import type {
+  BlockNode,
+  BlockRegistry,
+  ResolvedBlockLoaders,
+} from "@plumix/blocks";
 import type { BlockRect, SlotRect } from "@plumix/blocks/renderer";
-import { renderBlockTree } from "@plumix/blocks";
+import { parseLoaderData, renderBlockTree } from "@plumix/blocks";
 import { PlumixProvider } from "@plumix/blocks/renderer";
 
 import type { RuntimeConnection } from "./connect-runtime.js";
@@ -36,6 +40,14 @@ export function EditorCanvas({
   initialTree = [],
 }: EditorCanvasProps): ReactElement {
   const [tree, setTree] = useState<readonly BlockNode[]>(initialTree);
+  // Seed loader data from the SSR embed once (before React replaces the mount
+  // root's children). Kept stable across tree edits so loaders never re-run on
+  // a keystroke; a scoped refresh replaces a single block's entry.
+  const [loaderData] = useState<ResolvedBlockLoaders>(() =>
+    parseLoaderData(
+      document.querySelector("[data-plumix-loader-data]")?.textContent ?? "",
+    ),
+  );
   const connectionRef = useRef<RuntimeConnection | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -128,7 +140,7 @@ export function EditorCanvas({
         {/* renderBlockTree (not BlockRenderer) so the canvas doesn't re-emit
             the SSR content-root boundary it was mounted into — just the
             per-block data-plumix-id seam for selection. */}
-        {renderBlockTree(tree, registry, { editing: true })}
+        {renderBlockTree(tree, registry, { editing: true, loaderData })}
       </div>
     </PlumixProvider>
   );

--- a/packages/admin-editor/src/editor-canvas.tsx
+++ b/packages/admin-editor/src/editor-canvas.tsx
@@ -18,6 +18,7 @@ import { PlumixProvider } from "@plumix/blocks/renderer";
 
 import type { RuntimeConnection } from "./connect-runtime.js";
 import { connectRuntime } from "./connect-runtime.js";
+import { mergeLoaderData } from "./merge-loader-data.js";
 
 interface EditorCanvasProps {
   /** Block registry for the site (core + plugin blocks). */
@@ -43,7 +44,7 @@ export function EditorCanvas({
   // Seed loader data from the SSR embed once (before React replaces the mount
   // root's children). Kept stable across tree edits so loaders never re-run on
   // a keystroke; a scoped refresh replaces a single block's entry.
-  const [loaderData] = useState<ResolvedBlockLoaders>(() =>
+  const [loaderData, setLoaderData] = useState<ResolvedBlockLoaders>(() =>
     parseLoaderData(
       document.querySelector("[data-plumix-loader-data]")?.textContent ?? "",
     ),
@@ -56,6 +57,8 @@ export function EditorCanvas({
       parentWindow: window.parent,
       origin,
       onTree: setTree,
+      onLoaderData: (data) =>
+        setLoaderData((prior) => mergeLoaderData(prior, data)),
     });
     connectionRef.current = connection;
     return () => {

--- a/packages/admin-editor/src/merge-loader-data.test.ts
+++ b/packages/admin-editor/src/merge-loader-data.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+
+import type { ResolvedBlockLoaders } from "@plumix/blocks";
+
+import { mergeLoaderData } from "./merge-loader-data.js";
+
+describe("mergeLoaderData", () => {
+  test("overlays a refreshed node onto the prior map", () => {
+    const prior: ResolvedBlockLoaders = new Map([
+      ["a", { loaders: { posts: ["old"] }, error: null }],
+      ["b", { loaders: { tags: ["x"] }, error: null }],
+    ]);
+
+    const next = mergeLoaderData(prior, { a: { posts: ["new"] } });
+
+    expect(next.get("a")).toEqual({ loaders: { posts: ["new"] }, error: null });
+    // Untouched entries stay.
+    expect(next.get("b")).toEqual({ loaders: { tags: ["x"] }, error: null });
+  });
+
+  test("adds a node not previously present", () => {
+    const prior: ResolvedBlockLoaders = new Map();
+
+    const next = mergeLoaderData(prior, { c: { items: [1, 2] } });
+
+    expect(next.get("c")).toEqual({ loaders: { items: [1, 2] }, error: null });
+  });
+
+  test("clears a prior error when fresh data arrives for that node", () => {
+    const prior: ResolvedBlockLoaders = new Map([
+      ["a", { loaders: {}, error: new Error("boom") }],
+    ]);
+
+    const next = mergeLoaderData(prior, { a: { posts: [] } });
+
+    expect(next.get("a")).toEqual({ loaders: { posts: [] }, error: null });
+  });
+
+  test("returns a new map (does not mutate the prior)", () => {
+    const prior: ResolvedBlockLoaders = new Map();
+
+    const next = mergeLoaderData(prior, { a: {} });
+
+    expect(next).not.toBe(prior);
+    expect(prior.size).toBe(0);
+  });
+});

--- a/packages/admin-editor/src/merge-loader-data.ts
+++ b/packages/admin-editor/src/merge-loader-data.ts
@@ -1,0 +1,19 @@
+import type { ResolvedBlockLoaders } from "@plumix/blocks";
+import type { SerializedLoaderData } from "@plumix/blocks/renderer";
+
+/**
+ * Overlay a scoped refresh's node-keyed loader map onto the canvas's existing
+ * loader data. Each refreshed entry replaces the prior one with fresh data and
+ * a cleared error (a successful re-resolve supersedes any earlier failure).
+ * Returns a new map; the prior one is left untouched so React sees a change.
+ */
+export function mergeLoaderData(
+  prior: ResolvedBlockLoaders,
+  data: SerializedLoaderData,
+): ResolvedBlockLoaders {
+  const next = new Map(prior);
+  for (const [nodeId, loaders] of Object.entries(data)) {
+    next.set(nodeId, { loaders, error: null });
+  }
+  return next;
+}

--- a/packages/admin-editor/src/plumix-editor.tsx
+++ b/packages/admin-editor/src/plumix-editor.tsx
@@ -8,6 +8,7 @@ import type {
   ThemeBreakpoints,
   ThemeTokens,
 } from "@plumix/blocks";
+import type { SerializedLoaderData } from "@plumix/blocks/renderer";
 import {
   Sidebar,
   SidebarContent,
@@ -71,6 +72,12 @@ interface PlumixEditorProps {
   readonly publish?: PublishActions;
   /** Host-rendered overlay (e.g. the stale-draft resolution dialog). */
   readonly overlay?: ReactNode;
+  /** Re-run the active block's loader(s) server-side (host orpc call). When set,
+   *  a loader-backed block gets a "Refresh data" control; the returned data is
+   *  pushed to the canvas. orpc lives in the app, never in this package. */
+  readonly onRefreshBlockLoader?: (
+    blockId: string,
+  ) => Promise<SerializedLoaderData>;
 }
 
 /**
@@ -94,6 +101,7 @@ export function PlumixEditor({
   documentPanel,
   publish,
   overlay,
+  onRefreshBlockLoader,
 }: PlumixEditorProps): ReactElement {
   if (readOnly) {
     return (
@@ -201,7 +209,10 @@ export function PlumixEditor({
             </SidebarHeader>
             <SidebarContent>
               <TabsContent value="block">
-                <BlockInspector registry={registry} />
+                <BlockInspector
+                  registry={registry}
+                  onRefreshBlockLoader={onRefreshBlockLoader}
+                />
               </TabsContent>
               <TabsContent value="styles">
                 <StylesTab tokens={tokens ?? {}} />

--- a/packages/admin-editor/src/provider.tsx
+++ b/packages/admin-editor/src/provider.tsx
@@ -1,14 +1,23 @@
-import type { ReactElement, ReactNode } from "react";
-import { createContext, useContext, useState } from "react";
+import type { MutableRefObject, ReactElement, ReactNode } from "react";
+import { createContext, useContext, useRef, useState } from "react";
 import { useStore } from "zustand";
 
 import type { BlockNode, ThemeBreakpoints } from "@plumix/blocks";
+import type { SerializedLoaderData } from "@plumix/blocks/renderer";
 
 import type { EditorDevice, EditorStore, EditorStoreApi } from "./store.js";
 import { EditorError } from "./errors.js";
 import { createEditorStore } from "./store.js";
 
 const EditorStoreContext = createContext<EditorStoreApi | null>(null);
+
+/** Pushes a scoped refresh's loader data to the canvas. Held in a ref so the
+ *  CanvasFrame (which owns the bridge) can populate it once connected, and the
+ *  inspector's refresh control can read it without re-rendering on connect. */
+type LoaderDataPush = (data: SerializedLoaderData) => void;
+
+const LoaderPushContext =
+  createContext<MutableRefObject<LoaderDataPush | null> | null>(null);
 
 /**
  * Creates one store per editor instance (kept stable across renders) and
@@ -31,12 +40,22 @@ export function EditorProvider({
   const [store] = useState<EditorStoreApi>(() =>
     createEditorStore({ tree: initialTree, device, zoom, breakpoints }),
   );
+  const loaderPushRef = useRef<LoaderDataPush | null>(null);
 
   return (
     <EditorStoreContext.Provider value={store}>
-      {children}
+      <LoaderPushContext.Provider value={loaderPushRef}>
+        {children}
+      </LoaderPushContext.Provider>
     </EditorStoreContext.Provider>
   );
+}
+
+/** The loader-data push channel ref. CanvasFrame sets `.current` when its
+ *  bridge connects; the inspector's refresh control calls it. Null outside an
+ *  EditorProvider (e.g. an isolated unit render) — callers no-op then. */
+export function useLoaderPushRef(): MutableRefObject<LoaderDataPush | null> | null {
+  return useContext(LoaderPushContext);
 }
 
 export function useEditorStore<T>(selector: (state: EditorStore) => T): T {

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/editor.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/editor.tsx
@@ -656,6 +656,9 @@ function BespokeEditor({
       documentPanel={documentPanel}
       publish={publishActions}
       overlay={overlay}
+      onRefreshBlockLoader={(blockId) =>
+        orpc.entry.refreshBlockLoader.call({ id, blockId }).then((r) => r.data)
+      }
     />
   );
 }

--- a/packages/blocks/src/find-block-node.test.ts
+++ b/packages/blocks/src/find-block-node.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+
+import type { BlockNode } from "./render-block-tree.js";
+import { findBlockNode } from "./find-block-node.js";
+
+const tree: readonly BlockNode[] = [
+  { id: "a", name: "core/x" },
+  {
+    id: "g",
+    name: "core/group",
+    attrs: { content: [{ id: "c", name: "core/y" }] },
+  },
+];
+
+describe("findBlockNode", () => {
+  test("finds a top-level node by id", () => {
+    expect(findBlockNode(tree, "a")?.name).toBe("core/x");
+  });
+
+  test("finds a node nested in a slot attr", () => {
+    expect(findBlockNode(tree, "c")?.name).toBe("core/y");
+  });
+
+  test("returns null when the id is absent", () => {
+    expect(findBlockNode(tree, "nope")).toBeNull();
+  });
+});

--- a/packages/blocks/src/find-block-node.ts
+++ b/packages/blocks/src/find-block-node.ts
@@ -1,0 +1,23 @@
+import type { BlockNode } from "./render-block-tree.js";
+import { isBlockNodeArray } from "./render-block-tree.js";
+
+/**
+ * Find a block node by id anywhere in the tree, descending into slot attrs
+ * (any attr whose value is a BlockNode[]). Returns null when absent. Used to
+ * isolate a single block's subtree — e.g. to re-run only its loader.
+ */
+export function findBlockNode(
+  nodes: readonly BlockNode[],
+  id: string,
+): BlockNode | null {
+  for (const node of nodes) {
+    if (node.id === id) return node;
+    if (!node.attrs) continue;
+    for (const value of Object.values(node.attrs)) {
+      if (!isBlockNodeArray(value)) continue;
+      const found = findBlockNode(value, id);
+      if (found) return found;
+    }
+  }
+  return null;
+}

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -120,6 +120,7 @@ export type {
   TokenCategory,
 } from "./styles/style-emitter.js";
 export { sanitizeCssValue } from "./styles/sanitize-css.js";
+export { parseLoaderData, serializeLoaderData } from "./loader-data.js";
 export type {
   ThemeTokenEntry,
   ThemeTokenGroup,

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -121,6 +121,7 @@ export type {
 } from "./styles/style-emitter.js";
 export { sanitizeCssValue } from "./styles/sanitize-css.js";
 export { parseLoaderData, serializeLoaderData } from "./loader-data.js";
+export { findBlockNode } from "./find-block-node.js";
 export type {
   ThemeTokenEntry,
   ThemeTokenGroup,

--- a/packages/blocks/src/island-element.test.ts
+++ b/packages/blocks/src/island-element.test.ts
@@ -602,3 +602,59 @@ describe("PlumixIslandElement prefetch/hydrate split", () => {
     expect(teardown).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("PlumixIslandElement edit-mode gate", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    delete (window as { Plumix?: unknown }).Plumix;
+  });
+
+  afterEach(() => {
+    delete document.documentElement.dataset.plumixMode;
+  });
+
+  test("does not hydrate while the page is in edit mode", async () => {
+    document.documentElement.dataset.plumixMode = "edit";
+    const strategy = vi.fn<IslandStrategy>((loadFn) => loadFn());
+    stubStrategies(strategy);
+    const el = makeIsland({
+      client: "load",
+      "chunk-url": "/chunk.js",
+      "component-export": "Search",
+      opts: "{}",
+      ssr: "",
+    });
+    document.body.appendChild(el);
+    await Promise.resolve();
+    expect(strategy).not.toHaveBeenCalled();
+  });
+
+  test("still hydrates in preview mode", async () => {
+    document.documentElement.dataset.plumixMode = "preview";
+    const strategy = vi.fn<IslandStrategy>();
+    stubStrategies(strategy);
+    const el = makeIsland({
+      client: "load",
+      "chunk-url": "/chunk.js",
+      "component-export": "Search",
+      opts: "{}",
+    });
+    document.body.appendChild(el);
+    await Promise.resolve();
+    expect(strategy).toHaveBeenCalledTimes(1);
+  });
+
+  test("renders a labeled placeholder for a client-only island while editing", async () => {
+    document.documentElement.dataset.plumixMode = "edit";
+    stubStrategies();
+    const el = makeIsland({
+      client: "only",
+      "chunk-url": "/chunk.js",
+      "component-export": "Counter",
+      opts: "{}",
+    });
+    document.body.appendChild(el);
+    await Promise.resolve();
+    expect(el.textContent).toContain("Client-only: Counter");
+  });
+});

--- a/packages/blocks/src/island-element.ts
+++ b/packages/blocks/src/island-element.ts
@@ -15,7 +15,9 @@
 
 import type { ComponentType } from "react";
 
+import type { IslandPageMode } from "./island-mode.js";
 import type { IslandRoot } from "./island-renderer.js";
+import { clientOnlyPlaceholderLabel, shouldHydrate } from "./island-mode.js";
 import { deserializeProps } from "./serialize.js";
 
 // The renderer module (`island-renderer.ts`) carries all the React +
@@ -152,6 +154,14 @@ export class PlumixIslandElement extends HTMLElement {
 
   private async start(): Promise<void> {
     if (this.hydrated) return;
+    // In edit mode the island stays as its static SSR output — selectable in
+    // the canvas, never interactive. A client-only island has no SSR output,
+    // so it shows a labeled placeholder of what it would have mounted.
+    const mode = readPageMode();
+    if (!shouldHydrate(mode)) {
+      if (this.getAttribute("client") === "only") this.renderEditPlaceholder();
+      return;
+    }
     // Top-down hydration: a nested island must NOT hydrate until its
     // closest `<plumix-island>` ancestor has cleared its `ssr` marker.
     // Without this, a parent React render that swaps the child's
@@ -304,6 +314,16 @@ export class PlumixIslandElement extends HTMLElement {
     }
   }
 
+  // A client-only island ships an empty shell (no SSR output). In edit mode it
+  // would otherwise be an invisible, unselectable box, so label it with the
+  // component it stands in for. Plain text content — no React, no hydration.
+  private renderEditPlaceholder(): void {
+    if (this.childElementCount > 0 || this.textContent.trim()) return;
+    this.textContent = clientOnlyPlaceholderLabel(
+      this.getAttribute("component-export"),
+    );
+  }
+
   private dispatchHydrationError(err: unknown): void {
     window.dispatchEvent(
       new CustomEvent("plumix:hydration-error", {
@@ -382,6 +402,14 @@ export function setRendererImport(
     loadRenderer = prev;
     rendererPromise = null;
   };
+}
+
+// The edit/preview render stamps `data-plumix-mode` on <html> (see
+// render-template). Read it here without importing the editor or renderer.
+function readPageMode(): IslandPageMode {
+  const raw = document.documentElement.dataset.plumixMode;
+  if (raw === "edit" || raw === "preview" || raw === "live") return raw;
+  return null;
 }
 
 function appendCacheBust(url: string): string {

--- a/packages/blocks/src/island-mode.test.ts
+++ b/packages/blocks/src/island-mode.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest";
+
+import { clientOnlyPlaceholderLabel, shouldHydrate } from "./island-mode.js";
+
+describe("shouldHydrate", () => {
+  test("does not hydrate in edit mode (static, selectable)", () => {
+    expect(shouldHydrate("edit")).toBe(false);
+  });
+
+  test("hydrates in preview mode", () => {
+    expect(shouldHydrate("preview")).toBe(true);
+  });
+
+  test("hydrates in live mode", () => {
+    expect(shouldHydrate("live")).toBe(true);
+  });
+
+  test("hydrates when the mode marker is absent (ordinary page)", () => {
+    expect(shouldHydrate(null)).toBe(true);
+  });
+});
+
+describe("clientOnlyPlaceholderLabel", () => {
+  test("labels the component export", () => {
+    expect(clientOnlyPlaceholderLabel("Counter")).toBe("Client-only: Counter");
+  });
+
+  test("falls back to the default export name", () => {
+    expect(clientOnlyPlaceholderLabel(null)).toBe("Client-only: default");
+  });
+});

--- a/packages/blocks/src/island-mode.ts
+++ b/packages/blocks/src/island-mode.ts
@@ -1,0 +1,19 @@
+// Pure decisions for how an island behaves under the page's render mode,
+// read by the React-free island custom element. Kept standalone so the
+// element chunk never imports the renderer (which would drag in React).
+
+/** The page render mode, mirrored from the renderer's `PlumixRenderMode`.
+ *  `null` is the ordinary page (no editor marker present). */
+export type IslandPageMode = "live" | "preview" | "edit" | null;
+
+/** In edit mode an island stays as its static SSR output — selectable, not
+ *  interactive. Every other mode (preview, live, or no marker) hydrates. */
+export function shouldHydrate(mode: IslandPageMode): boolean {
+  return mode !== "edit";
+}
+
+/** Label for the placeholder a client-only island shows while editing — it
+ *  has no SSR output to keep, so the editor shows what it would mount. */
+export function clientOnlyPlaceholderLabel(exportName: string | null): string {
+  return `Client-only: ${exportName ?? "default"}`;
+}

--- a/packages/blocks/src/loader-data.test.ts
+++ b/packages/blocks/src/loader-data.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest";
+
+import type { ResolvedBlockLoaders } from "./loaders.js";
+import { parseLoaderData, serializeLoaderData } from "./loader-data.js";
+
+describe("loader-data round trip", () => {
+  test("serializes resolved loaders to a node-keyed JSON map", () => {
+    const resolved: ResolvedBlockLoaders = new Map([
+      ["a", { loaders: { posts: [{ id: 1 }] }, error: null }],
+      ["b", { loaders: { count: 3 }, error: null }],
+    ]);
+
+    expect(JSON.parse(serializeLoaderData(resolved))).toEqual({
+      a: { posts: [{ id: 1 }] },
+      b: { count: 3 },
+    });
+  });
+
+  test("omits blocks whose loader errored (no data to seed)", () => {
+    const resolved: ResolvedBlockLoaders = new Map([
+      ["ok", { loaders: { x: 1 }, error: null }],
+      ["bad", { loaders: {}, error: new Error("boom") }],
+    ]);
+
+    expect(JSON.parse(serializeLoaderData(resolved))).toEqual({ ok: { x: 1 } });
+  });
+
+  test("parses the embedded map back into resolved loader data", () => {
+    const map = parseLoaderData('{"a":{"posts":[{"id":1}]}}');
+    expect(map.get("a")).toEqual({
+      loaders: { posts: [{ id: 1 }] },
+      error: null,
+    });
+  });
+
+  test("returns an empty map for malformed or empty input", () => {
+    expect(parseLoaderData("").size).toBe(0);
+    expect(parseLoaderData("not json").size).toBe(0);
+    expect(parseLoaderData("[1,2,3]").size).toBe(0);
+  });
+});

--- a/packages/blocks/src/loader-data.ts
+++ b/packages/blocks/src/loader-data.ts
@@ -1,0 +1,43 @@
+import type { ResolvedBlockLoaders } from "./loaders.js";
+
+/**
+ * Serialize SSR-resolved loader data to a node-keyed JSON map for embedding in
+ * the edit page. Only successful loaders are carried — an errored block has no
+ * data to seed, and the error object isn't reliably serializable. The edit
+ * runtime reads this so blocks open with real data without re-running loaders.
+ */
+export function serializeLoaderData(resolved: ResolvedBlockLoaders): string {
+  const out: Record<string, Readonly<Record<string, unknown>>> = {};
+  for (const [nodeId, data] of resolved) {
+    if (data.error === null) out[nodeId] = data.loaders;
+  }
+  return JSON.stringify(out);
+}
+
+/** Parse the embedded loader-data map back into `ResolvedBlockLoaders`.
+ *  Malformed / non-object input yields an empty map (the edit runtime then
+ *  renders blocks without seeded data rather than crashing). */
+export function parseLoaderData(json: string): ResolvedBlockLoaders {
+  const map = new Map<
+    string,
+    { loaders: Record<string, unknown>; error: null }
+  >();
+  if (json.trim() === "") return map;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return map;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+    return map;
+  for (const [nodeId, loaders] of Object.entries(parsed)) {
+    if (loaders && typeof loaders === "object") {
+      map.set(nodeId, {
+        loaders: loaders as Record<string, unknown>,
+        error: null,
+      });
+    }
+  }
+  return map;
+}

--- a/packages/blocks/src/renderer/editor-protocol.ts
+++ b/packages/blocks/src/renderer/editor-protocol.ts
@@ -7,6 +7,10 @@ import type { BlockNode } from "../render-block-tree.js";
 
 export const EDITOR_BRIDGE_CHANNEL = "plumix.editor";
 
+/** Node-keyed loader records, as serialized over the bridge — the wire form of
+ *  ResolvedBlockLoaders (a ReadonlyMap doesn't survive postMessage). */
+export type SerializedLoaderData = Record<string, Record<string, unknown>>;
+
 /** Geometry of one block, in the iframe's unscaled coordinate space. */
 export interface BlockRect {
   readonly id: string;
@@ -28,10 +32,14 @@ export interface SlotRect {
 }
 
 /** Parent (admin shell) → canvas (iframe). */
-export interface HostMessage {
-  readonly type: "host:tree";
-  readonly tree: readonly BlockNode[];
-}
+export type HostMessage =
+  | { readonly type: "host:tree"; readonly tree: readonly BlockNode[] }
+  | {
+      // A scoped refresh's re-resolved loader data, node-keyed (same shape
+      // `serializeLoaderData` emits). The canvas merges it into its loader map.
+      readonly type: "host:loader-data";
+      readonly data: SerializedLoaderData;
+    };
 
 /** Canvas (iframe) → parent (admin shell). */
 export type CanvasMessage =

--- a/packages/blocks/src/renderer/index.tsx
+++ b/packages/blocks/src/renderer/index.tsx
@@ -188,5 +188,6 @@ export type {
   CanvasMessage,
   EditorBridgeMessage,
   HostMessage,
+  SerializedLoaderData,
   SlotRect,
 } from "./editor-protocol.js";

--- a/packages/blocks/src/renderer/index.tsx
+++ b/packages/blocks/src/renderer/index.tsx
@@ -8,6 +8,7 @@ import type { ShortcodeRegistry } from "../shortcodes/types.js";
 import type { ThemeBreakpoints } from "../styles/style-emitter.js";
 import type { ThemeTokens } from "../styles/types.js";
 import type { ImageResolver, RemotePattern } from "./image-attrs.js";
+import { serializeLoaderData } from "../loader-data.js";
 import { renderBlockTree } from "../render-block-tree.js";
 import { RendererError } from "./errors.js";
 
@@ -91,8 +92,10 @@ export function BlockRenderer({
   });
   if (ctx.mode !== "edit") return tree;
   // Edit mode: wrap the content in a mount root the injected runtime renders
-  // into, and embed the tree so it can seed without a round-trip. `<` is
-  // escaped so authored content can't break out of the JSON <script>.
+  // into, and embed the tree + the SSR-resolved loader data so the edit runtime
+  // seeds both without a round-trip — blocks open with real data and keep it
+  // across edits (loaders re-run only via a scoped refresh). `<` is escaped so
+  // authored content can't break out of the JSON <script>.
   return (
     <div data-plumix-content-root="">
       <script
@@ -100,6 +103,16 @@ export function BlockRenderer({
         data-plumix-initial-tree=""
         dangerouslySetInnerHTML={{
           __html: JSON.stringify(content).replace(/</g, "\\u003c"),
+        }}
+      />
+      <script
+        type="application/json"
+        data-plumix-loader-data=""
+        dangerouslySetInnerHTML={{
+          __html: serializeLoaderData(ctx.loaderData ?? new Map()).replace(
+            /</g,
+            "\\u003c",
+          ),
         }}
       />
       {tree}

--- a/packages/core/src/route/edit-mode.render.test.ts
+++ b/packages/core/src/route/edit-mode.render.test.ts
@@ -66,4 +66,24 @@ describe("edit gate through the public render", () => {
 
     expect(await res.text()).not.toContain("data-plumix-editor");
   });
+
+  test("edit render stamps data-plumix-mode=edit on <html> (island hydration gate)", async () => {
+    const { h, editor } = await seed();
+
+    const req = await h.authenticateRequest(
+      new Request(`${URL}?plumix.edit`),
+      editor.id,
+    );
+    const body = await (await h.dispatch(req)).text();
+
+    expect(body).toMatch(/<html[^>]*data-plumix-mode="edit"/);
+  });
+
+  test("a visitor render does not stamp data-plumix-mode", async () => {
+    const { h } = await seed();
+
+    const body = await (await h.dispatch(new Request(URL))).text();
+
+    expect(body).not.toContain("data-plumix-mode");
+  });
 });

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -386,6 +386,10 @@ function renderTree({
     lang: code,
     dir: direction,
     ...document.html,
+    // The island runtime reads this off <html> to decide whether to hydrate:
+    // in edit mode islands stay static + selectable. Only stamped for the
+    // editor render so ordinary pages keep clean markup (absent ⇒ hydrate).
+    ...(editMode.mode === "edit" ? { "data-plumix-mode": editMode.mode } : {}),
   });
   const bodyAttrs = renderAttrs(document.body);
 

--- a/packages/core/src/rpc/procedures/entry/index.ts
+++ b/packages/core/src/rpc/procedures/entry/index.ts
@@ -9,6 +9,7 @@ import { duplicate } from "./duplicate.js";
 import { get } from "./get.js";
 import { list } from "./list.js";
 import { publish } from "./publish.js";
+import { refreshBlockLoader } from "./refresh-block-loader.js";
 import { restore } from "./restore.js";
 import { revisionsRouter } from "./revisions.js";
 import { trash } from "./trash.js";
@@ -27,6 +28,7 @@ export const entryRouter = {
   deletePermanentMany,
   duplicate,
   createPreviewLink,
+  refreshBlockLoader,
   publish,
   discardDraft,
   stats,

--- a/packages/core/src/rpc/procedures/entry/refresh-block-loader.test.ts
+++ b/packages/core/src/rpc/procedures/entry/refresh-block-loader.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "vitest";
+
+import { createPluginRegistry } from "../../../plugin/manifest.js";
+import { createRpcHarness } from "../../../test/rpc.js";
+
+// A registry with a public post type and a loader-backed block.
+function loaderRegistry() {
+  const registry = createPluginRegistry();
+  registry.entryTypes.set("post", {
+    name: "post",
+    registeredBy: "test",
+    label: "Posts",
+    capabilityType: "post",
+    isPublic: true,
+  });
+  registry.blockSpecs.set("test/feed", {
+    spec: {
+      name: "test/feed",
+      render: () => null,
+      loaders: {
+        // Echo an attr so the test can prove the loader actually re-ran against
+        // the block's current attrs.
+        items: ({ attrs }) => Promise.resolve({ count: attrs.count }),
+      },
+    },
+    registeredBy: "test",
+  });
+  return registry;
+}
+
+const content = (count: number) => ({
+  version: "plumix.v2" as const,
+  blocks: [{ id: "feed1", name: "test/feed", attrs: { count } }],
+});
+
+describe("entry.refreshBlockLoader", () => {
+  test("re-runs a single block's loader and returns its data", async () => {
+    const h = await createRpcHarness({
+      authAs: "editor",
+      plugins: loaderRegistry(),
+    });
+    const draft = await h.factory.draft.create({
+      authorId: h.user.id,
+      content: content(7),
+    });
+
+    const result = await h.client.entry.refreshBlockLoader({
+      id: draft.id,
+      blockId: "feed1",
+    });
+
+    expect(result.data).toEqual({ feed1: { items: { count: 7 } } });
+  });
+
+  test("404s an unknown block id", async () => {
+    const h = await createRpcHarness({
+      authAs: "editor",
+      plugins: loaderRegistry(),
+    });
+    const draft = await h.factory.draft.create({
+      authorId: h.user.id,
+      content: content(1),
+    });
+
+    await expect(
+      h.client.entry.refreshBlockLoader({ id: draft.id, blockId: "nope" }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  test("404s a draft the caller can't read", async () => {
+    const h = await createRpcHarness({
+      authAs: "contributor",
+      plugins: loaderRegistry(),
+    });
+    const other = await h.factory.user.create();
+    const draft = await h.factory.draft.create({
+      authorId: other.id,
+      content: content(1),
+    });
+
+    await expect(
+      h.client.entry.refreshBlockLoader({ id: draft.id, blockId: "feed1" }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+});

--- a/packages/core/src/rpc/procedures/entry/refresh-block-loader.ts
+++ b/packages/core/src/rpc/procedures/entry/refresh-block-loader.ts
@@ -1,0 +1,53 @@
+import {
+  findBlockNode,
+  isEntryContent,
+  resolveBlockLoaders,
+  serializeLoaderData,
+} from "@plumix/blocks";
+
+import { eq } from "../../../db/index.js";
+import { entries } from "../../../db/schema/entries.js";
+import { getAutosave } from "../../../revisions/repository.js";
+import { isReservedType } from "../../../revisions/slug-codec.js";
+import { authenticated } from "../../authenticated.js";
+import { base } from "../../base.js";
+import { canReadEntry } from "./lifecycle.js";
+import { entryRefreshBlockLoaderInputSchema } from "./schemas.js";
+
+// Re-run a single block's loader(s) on demand — the editor's scoped refresh.
+// Loaders are server functions (db / ctx), so a refresh round-trips here rather
+// than running client-side. Resolves against the caller's current content (the
+// autosave overlay when present, else live), isolated to the target block's
+// subtree so siblings' loaders don't re-run. Returns a node-keyed map of the
+// re-resolved data, which the editor merges into the canvas's loader data.
+export const refreshBlockLoader = base
+  .use(authenticated)
+  .input(entryRefreshBlockLoaderInputSchema)
+  .handler(async ({ input, context, errors }) => {
+    const live = await context.db.query.entries.findFirst({
+      where: eq(entries.id, input.id),
+    });
+    if (!live || isReservedType(live.type) || !canReadEntry(context, live)) {
+      throw errors.NOT_FOUND({ data: { kind: "entry", id: input.id } });
+    }
+
+    const autosave = await getAutosave(context.db, {
+      entryId: live.id,
+      authorId: context.user.id,
+    });
+    const content = autosave?.content ?? live.content;
+    const node = isEntryContent(content)
+      ? findBlockNode(content.blocks, input.blockId)
+      : null;
+    if (!node) {
+      throw errors.NOT_FOUND({ data: { kind: "block", id: input.blockId } });
+    }
+
+    const resolved = await resolveBlockLoaders([node], context.blocks, context);
+    return {
+      data: JSON.parse(serializeLoaderData(resolved)) as Record<
+        string,
+        Readonly<Record<string, unknown>>
+      >,
+    };
+  });

--- a/packages/core/src/rpc/procedures/entry/schemas.ts
+++ b/packages/core/src/rpc/procedures/entry/schemas.ts
@@ -227,6 +227,11 @@ export const entryDeletePermanentInputSchema = v.object({ id: idParam });
 export const entryDuplicateInputSchema = v.object({ id: idParam });
 export const entryCreatePreviewLinkInputSchema = v.object({ id: idParam });
 
+export const entryRefreshBlockLoaderInputSchema = v.object({
+  id: idParam,
+  blockId: v.pipe(v.string(), v.minLength(1)),
+});
+
 // Bulk action input. Capped at 100 ids per call so a single batched
 // `WHERE id IN (…)` stays bounded; the admin selects a page at a time.
 const bulkIdsSchema = v.object({


### PR DESCRIPTION
Completes the editor islands + dynamic-data slice of the bespoke editor (PRD #1104).

Interactive islands now render their static SSR output un-hydrated and selectable while editing, and hydrate for real interactivity in preview and on live pages. The decision is driven by a `data-plumix-mode` marker the edit render stamps on `<html>` and read by a standalone `shouldHydrate(mode)` helper, so the React-free island element chunk pulls in no renderer. A `client:only` island — which ships no SSR output — shows a labeled placeholder while editing instead of an invisible, unselectable box. Ordinary pages emit no marker, so their markup stays clean and they hydrate unchanged.

Loader-backed blocks open with the route's real SSR data (seeded over the bridge on first paint) and keep that data across edits, so loaders never re-run on a keystroke. A loader-backed block now also offers an opt-in **Refresh data** control in the inspector that re-runs just that block's loader server-side and pushes the result to the canvas via a new `host:loader-data` bridge message, merged node-by-node onto the canvas's loader data. The orpc call stays in the admin route; `@plumix/admin-editor` remains orpc-free behind an `onRefreshBlockLoader` prop.

Islands are a build-time transform, not a `renderBlockTree` concern, so the canvas re-rendering its tree on every edit never creates or destroys `<plumix-island>` elements — worth confirming when reviewing the gate. The marker-on-`<html>` approach is what keeps the gate readable from the React-free chunk. The playground gains a loader-backed fixture block so the scoped-refresh affordance has end-to-end visual e2e coverage in both light and dark themes.

Closes #1120.