### PR TITLE
fix: keep the editor publish button clickable at narrow widths

### DIFF
--- a/packages/admin-editor/src/editor-toolbar.tsx
+++ b/packages/admin-editor/src/editor-toolbar.tsx
@@ -73,31 +73,36 @@ export function EditorToolbar({
       className="bg-background flex items-center gap-1 border-b p-2"
       data-testid="plumix-editor-toolbar"
     >
-      {/* Collapses both rails for a focused canvas (also Cmd/Ctrl+B). */}
-      <SidebarTrigger data-testid="plumix-rails-toggle" />
-      {inserter}
-      <DeviceZoomControls />
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        data-testid="plumix-undo"
-        disabled={!undoAvailable}
-        onClick={undo}
-      >
-        <Trans id="editor.toolbar.undo" message="Undo" />
-      </Button>
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        data-testid="plumix-redo"
-        disabled={!redoAvailable}
-        onClick={redo}
-      >
-        <Trans id="editor.toolbar.redo" message="Redo" />
-      </Button>
-      {previewLink ? <CopyPreviewLink url={previewLink} /> : null}
+      {/* Left controls take the flexible, scrollable space; the publish action
+          is pinned outside it so it always sits at the inset's right edge and
+          never overflows under the right rail at narrow widths. */}
+      <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
+        {/* Collapses both rails for a focused canvas (also Cmd/Ctrl+B). */}
+        <SidebarTrigger data-testid="plumix-rails-toggle" />
+        {inserter}
+        <DeviceZoomControls />
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          data-testid="plumix-undo"
+          disabled={!undoAvailable}
+          onClick={undo}
+        >
+          <Trans id="editor.toolbar.undo" message="Undo" />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          data-testid="plumix-redo"
+          disabled={!redoAvailable}
+          onClick={redo}
+        >
+          <Trans id="editor.toolbar.redo" message="Redo" />
+        </Button>
+        {previewLink ? <CopyPreviewLink url={previewLink} /> : null}
+      </div>
       {publish ? <PublishControls publish={publish} /> : null}
     </header>
   );
@@ -214,7 +219,7 @@ function PublishControls({
     const busy =
       draftMode.isSaving || draftMode.isPublishing || draftMode.isDiscarding;
     return (
-      <div className="ms-auto flex items-center gap-2">
+      <div className="flex shrink-0 items-center gap-2">
         {draftMode.hasPendingDraft ? (
           <span
             className="text-muted-foreground text-xs"
@@ -260,7 +265,7 @@ function PublishControls({
   }
   const { isPublishing = false, isPublished = false } = publish;
   return (
-    <div className="ms-auto">
+    <div className="shrink-0">
       <Button
         type="button"
         size="sm"

--- a/packages/plugins/blog/e2e/blog.spec.ts
+++ b/packages/plugins/blog/e2e/blog.spec.ts
@@ -62,7 +62,7 @@ test.describe.serial("@plumix/plugin-blog — worker-driven happy path", () => {
   // (target resolves at mouse-up), and the publish wiring is covered by the
   // admin mock e2e ("clicking the Publish button POSTs entry.update"). Re-enable
   // once the editor re-render/zoom-fit stability is fixed in the refinement pass.
-  test.fixme("edit the draft → publish → status persists across reload", async ({
+  test("edit the draft → publish → status persists across reload", async ({
     page,
   }) => {
     await page.goto("entries/posts");


### PR DESCRIPTION
The editor toolbar packed all its controls into a single non-wrapping flex row. At narrow canvas widths (two 288px rails on a 1280px viewport leaves the inset ~700px) the controls overflowed the inset, and the right-aligned **Publish** button slid out from under the toolbar and underneath the inspector rail. The rail (higher in the stacking order) then intercepted any click aimed at Publish, so the button was effectively unclickable below a certain width — it only worked on wide viewports.

This was the real cause of the "toolbar feels janky / publish doesn't respond" symptom and of the worker-driven blog publish e2e that appeared flaky: the click never reached the handler because it landed on the rail, not the button. (Confirmed with `elementFromPoint` at the button's center returning the sidebar content div, not the button.)

The fix puts the toolbar's left controls in a flexible, horizontally-scrollable region and pins the publish action outside it, so Publish always sits at the inset's right edge and stays clickable at any width. The previously-`fixme`'d blog publish e2e is re-enabled and now passes with a plain click.

This is a targeted functional fix; the broader editor visual density is still tracked for the refinement pass.