### PR TITLE
fix: suppress the front-end admin bar inside the editor canvas

### DIFF
--- a/packages/core/src/route/render/render-template.test.tsx
+++ b/packages/core/src/route/render/render-template.test.tsx
@@ -745,6 +745,41 @@ describe("resolvePublicRoute — single entry through theme", () => {
     expect(body).toContain('data-testid="plumix-admin-bar"');
   });
 
+  test("edit-mode render does NOT carry the PlumixAdminBar", async () => {
+    const theme = defineTheme({
+      templates: {
+        index: () => null,
+        single: ({ data }) => <article>{data.entry.title}</article>,
+      },
+    });
+    const h = await createDispatcherHarness({ plugins: [blogPlugin], theme });
+    const author = await h.seedUser("admin");
+    await h.factory.entry.create({
+      type: "post",
+      slug: "public",
+      title: "Public",
+      content: null,
+      status: "published",
+      authorId: author.id,
+      publishedAt: new Date(),
+    });
+
+    // The editor canvas loads the real route with `?plumix.edit`. The author
+    // is authenticated (so the bar would otherwise render), but inside the
+    // canvas the front-end admin bar is redundant chrome — and its injected
+    // `body { padding-top }` drives a runaway height loop against the theme's
+    // `min-h-screen`. It must be suppressed in edit mode.
+    const request = await h.authenticateRequest(
+      new Request("https://cms.example/post/public?plumix.edit"),
+      author.id,
+    );
+    const response = await h.dispatch(request);
+    const body = await response.text();
+
+    expect(body).toContain('data-plumix-mode="edit"');
+    expect(body).not.toContain('data-testid="plumix-admin-bar"');
+  });
+
   test("anonymous public render does NOT carry the PlumixAdminBar", async () => {
     const theme = defineTheme({
       templates: {

--- a/packages/core/src/route/render/render-template.tsx
+++ b/packages/core/src/route/render/render-template.tsx
@@ -366,14 +366,20 @@ function renderTree({
         imageRemotePatterns: ctx.imageRemotePatterns,
       },
     },
-    createElement(PlumixAdminBar, {
-      hooks: ctx.hooks,
-      request: ctx.request,
-      siteName: ctx.siteName ?? "Site",
-      auth: ctx.auth,
-      queriedEntryDetails,
-      entryTypes: ctx.plugins.entryTypes,
-    }),
+    // Edit mode drops the front-end admin bar: redundant under the editor's
+    // own toolbar, and its injected `body { padding-top }` ratchets the
+    // auto-sized canvas iframe against the theme's `min-h-screen` into a
+    // runaway height loop. Live/preview renders keep it.
+    editMode.mode === "edit"
+      ? null
+      : createElement(PlumixAdminBar, {
+          hooks: ctx.hooks,
+          request: ctx.request,
+          siteName: ctx.siteName ?? "Site",
+          auth: ctx.auth,
+          queriedEntryDetails,
+          entryTypes: ctx.plugins.entryTypes,
+        }),
     createElement(TemplateAdapter),
   );
   const rendered = renderToString(templateTree);


### PR DESCRIPTION
The editor canvas loads the entry's real route with `?plumix.edit`, and that render unconditionally mounted `PlumixAdminBar`. Inside the canvas the front-end admin bar is redundant chrome stacked under the editor's own toolbar — and it also drove a runaway scrollbar that made the page impossible to scroll.

The root cause of the scroll bug: the admin bar injects `body { padding-top: 36px }`. The canvas iframe auto-sizes its height to its own `documentElement.scrollHeight`, so against the theme's `min-h-screen` wrapper each measurement grew the document by the padding, which grew `100vh`, which grew the next measurement — an unbounded height loop.

The bar is now gated on render mode: dropped when mode is `edit`, kept on live and preview renders (the shareable preview link opens in a normal tab, where the bar belongs and self-suppresses for anonymous viewers). Verified live in the editor — the bar is gone from the canvas and the iframe height holds stable instead of growing — and covered by a new core test asserting an authenticated `?plumix.edit` render omits the bar.

Part of the editor visual-refinement pass (task #56).