### PR TITLE
fix: apply block style edits in the editor canvas

### DIFF
--- a/packages/admin-editor/src/editor-canvas.test.tsx
+++ b/packages/admin-editor/src/editor-canvas.test.tsx
@@ -1,7 +1,7 @@
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import type { BlockNode } from "@plumix/blocks";
+import type { BlockNode, ThemeTokens } from "@plumix/blocks";
 import { coreBlocks, createBlockRegistry } from "@plumix/blocks";
 import { EDITOR_BRIDGE_CHANNEL, encode } from "@plumix/blocks/renderer";
 
@@ -132,6 +132,31 @@ describe("EditorCanvas", () => {
 
     expect(container.querySelector('[data-plumix-id="seed"]')).not.toBeNull();
     expect(container.textContent).toContain("Seeded");
+  });
+
+  test("applies a block's style as emitted CSS when tokens are provided", () => {
+    const tokens: ThemeTokens = { colors: { brand: { value: "#0000ff" } } };
+    const { container } = render(
+      <EditorCanvas registry={registry} origin={ORIGIN} tokens={tokens} />,
+    );
+
+    // A style edit (here a custom text color) is pushed with the tree. The
+    // renderer only emits the per-block `<style>` when it has tokens; without
+    // them the edit is stored but never painted in the canvas.
+    pushTree([
+      {
+        id: "h1",
+        name: "core/heading",
+        attrs: { text: "Hi", level: 2 },
+        style: { large: { color: { raw: "#ff0000" } } },
+      },
+    ]);
+
+    const css = [...container.querySelectorAll("style")]
+      .map((s) => s.textContent)
+      .join(" ");
+    expect(css).toContain("plumix-block-h1");
+    expect(css).toContain("#ff0000");
   });
 
   test("hovering a block reports canvas:hover to the host", () => {

--- a/packages/admin-editor/src/editor-canvas.tsx
+++ b/packages/admin-editor/src/editor-canvas.tsx
@@ -11,6 +11,8 @@ import type {
   BlockNode,
   BlockRegistry,
   ResolvedBlockLoaders,
+  ThemeBreakpoints,
+  ThemeTokens,
 } from "@plumix/blocks";
 import type { BlockRect, SlotRect } from "@plumix/blocks/renderer";
 import { parseLoaderData, renderBlockTree } from "@plumix/blocks";
@@ -27,6 +29,12 @@ interface EditorCanvasProps {
   readonly origin: string;
   /** Seed tree for first paint, before the host pushes (from the SSR embed). */
   readonly initialTree?: readonly BlockNode[];
+  /** Theme tokens (from the SSR embed). Without them the renderer can't emit
+   *  block-style CSS, so token-or-custom style edits never reach the canvas. */
+  readonly tokens?: ThemeTokens;
+  /** Theme breakpoints (from the SSR embed), so the canvas's responsive style
+   *  CSS gates at the same widths the live render uses. */
+  readonly breakpoints?: ThemeBreakpoints;
 }
 
 /**
@@ -39,6 +47,8 @@ export function EditorCanvas({
   registry,
   origin,
   initialTree = [],
+  tokens,
+  breakpoints,
 }: EditorCanvasProps): ReactElement {
   const [tree, setTree] = useState<readonly BlockNode[]>(initialTree);
   // Seed loader data from the SSR embed once (before React replaces the mount
@@ -132,7 +142,7 @@ export function EditorCanvas({
   };
 
   return (
-    <PlumixProvider value={{ registry, mode: "edit" }}>
+    <PlumixProvider value={{ registry, mode: "edit", tokens, breakpoints }}>
       <div
         ref={containerRef}
         data-testid="plumix-editor-canvas"
@@ -142,8 +152,14 @@ export function EditorCanvas({
       >
         {/* renderBlockTree (not BlockRenderer) so the canvas doesn't re-emit
             the SSR content-root boundary it was mounted into — just the
-            per-block data-plumix-id seam for selection. */}
-        {renderBlockTree(tree, registry, { editing: true, loaderData })}
+            per-block data-plumix-id seam for selection. tokens/breakpoints feed
+            the per-block style emitter so token-or-custom edits paint live. */}
+        {renderBlockTree(tree, registry, {
+          editing: true,
+          loaderData,
+          tokens,
+          breakpoints,
+        })}
       </div>
     </PlumixProvider>
   );

--- a/packages/admin-editor/src/mount.test.tsx
+++ b/packages/admin-editor/src/mount.test.tsx
@@ -40,6 +40,45 @@ describe("mountEditorRuntime", () => {
     expect(document.body.textContent).toContain("Embedded");
   });
 
+  test("seeds the canvas with the embedded style env so styles paint", () => {
+    const content = {
+      version: "plumix.v2",
+      blocks: [
+        {
+          id: "e1",
+          name: "core/heading",
+          attrs: { text: "Styled", level: 2 },
+          style: { large: { color: { raw: "#ff0000" } } },
+        },
+      ],
+    };
+    const styleEnv = {
+      tokens: { colors: { brand: { value: "#0000ff" } } },
+      breakpoints: { tablet: 991, mobile: 640 },
+    };
+    document.body.innerHTML =
+      `<div data-plumix-content-root>` +
+      `<script type="application/json" data-plumix-initial-tree>${JSON.stringify(content)}</script>` +
+      `<script type="application/json" data-plumix-style-env>${JSON.stringify(styleEnv)}</script>` +
+      `<div>ssr</div></div>`;
+
+    act(() => {
+      mountEditorRuntime({
+        doc: document,
+        registry,
+        origin: "http://localhost",
+      });
+    });
+
+    const css = [
+      ...document.querySelectorAll("[data-plumix-content-root] style"),
+    ]
+      .map((s) => s.textContent)
+      .join(" ");
+    expect(css).toContain("plumix-block-e1");
+    expect(css).toContain("#ff0000");
+  });
+
   test("does nothing on a page with no content root", () => {
     document.body.innerHTML = "<main>plain page</main>";
 

--- a/packages/admin-editor/src/mount.ts
+++ b/packages/admin-editor/src/mount.ts
@@ -1,7 +1,12 @@
 import { createElement } from "react";
 import { createRoot } from "react-dom/client";
 
-import type { BlockNode, BlockRegistry } from "@plumix/blocks";
+import type {
+  BlockNode,
+  BlockRegistry,
+  ThemeBreakpoints,
+  ThemeTokens,
+} from "@plumix/blocks";
 import { isEntryContent } from "@plumix/blocks";
 
 import { EditorCanvas } from "./editor-canvas.js";
@@ -29,9 +34,16 @@ export function mountEditorRuntime({
   if (!(root instanceof Element)) return null;
 
   const initialTree = readInitialTree(doc);
+  const { tokens, breakpoints } = readStyleEnv(doc);
   const reactRoot = createRoot(root);
   reactRoot.render(
-    createElement(EditorCanvas, { registry, origin, initialTree }),
+    createElement(EditorCanvas, {
+      registry,
+      origin,
+      initialTree,
+      tokens,
+      breakpoints,
+    }),
   );
   return () => reactRoot.unmount();
 }
@@ -44,5 +56,26 @@ function readInitialTree(doc: Document): readonly BlockNode[] {
     return isEntryContent(parsed) ? parsed.blocks : [];
   } catch {
     return [];
+  }
+}
+
+// The SSR embeds the theme's tokens + breakpoints so the canvas — a fresh
+// React tree with no server context — can emit per-block style CSS. Missing or
+// malformed env leaves them undefined; the renderer then skips style emission
+// (the pre-fix behavior) rather than crashing.
+function readStyleEnv(doc: Document): {
+  readonly tokens?: ThemeTokens;
+  readonly breakpoints?: ThemeBreakpoints;
+} {
+  const script = doc.querySelector("[data-plumix-style-env]");
+  if (!script?.textContent) return {};
+  try {
+    const parsed = JSON.parse(script.textContent) as {
+      tokens?: ThemeTokens;
+      breakpoints?: ThemeBreakpoints;
+    };
+    return { tokens: parsed.tokens, breakpoints: parsed.breakpoints };
+  } catch {
+    return {};
   }
 }

--- a/packages/blocks/src/renderer/block-renderer-edit.test.tsx
+++ b/packages/blocks/src/renderer/block-renderer-edit.test.tsx
@@ -27,6 +27,28 @@ describe("BlockRenderer edit-mode mount boundary", () => {
     expect(html).toContain("Hi"); // still renders the content for first paint
   });
 
+  test("embeds the style env (tokens + breakpoints) for the canvas runtime", () => {
+    const html = renderToStaticMarkup(
+      <PlumixProvider
+        value={{
+          registry,
+          mode: "edit",
+          tokens: { colors: { brand: { value: "#0000ff" } } },
+          breakpoints: { tablet: 900, mobile: 600 },
+        }}
+      >
+        <BlockRenderer content={content} />
+      </PlumixProvider>,
+    );
+
+    // The canvas runtime renders in a fresh React tree with no SSR context, so
+    // it can only emit block-style CSS if tokens + breakpoints ride along in the
+    // embed. Without them, token-or-custom style edits never paint.
+    expect(html).toContain("data-plumix-style-env");
+    expect(html).toContain("brand");
+    expect(html).toContain("900");
+  });
+
   test("live render has no editor mount root or embedded tree", () => {
     const html = renderToStaticMarkup(
       <PlumixProvider value={{ registry }}>

--- a/packages/blocks/src/renderer/index.tsx
+++ b/packages/blocks/src/renderer/index.tsx
@@ -115,6 +115,16 @@ export function BlockRenderer({
           ),
         }}
       />
+      <script
+        type="application/json"
+        data-plumix-style-env=""
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            tokens: ctx.tokens,
+            breakpoints: ctx.breakpoints,
+          }).replace(/</g, "\\u003c"),
+        }}
+      />
       {tree}
     </div>
   );


### PR DESCRIPTION
Editing a block's style in the right-sidebar Styles tab did nothing visible in the canvas. The edit was recorded on the block tree, but the canvas re-rendered the tree without theme tokens, so the per-block style emitter — gated on `node.style && tokens` — produced no CSS. Token-or-custom style values were stored and never painted.

The canvas runs inside the editor iframe as a fresh React tree with no server context, so it can't reach the theme tokens the live render uses. This embeds the theme's `tokens` + `breakpoints` in the edit-mode SSR output via a `data-plumix-style-env` script (alongside the existing initial-tree and loader-data embeds). The mount step reads it and threads both into `EditorCanvas`, which feeds them to the `PlumixProvider` value and the `renderBlockTree` options — the same wiring the live-render `BlockRenderer` already uses.

Verified live: editing a block's background now emits `.plumix-block-<id> { background: ... }` and paints immediately. Covered end-to-end by tests at each layer (renderer embed, mount read, canvas paint).

Part of the editor visual-refinement pass (task #56).