### PR TITLE
feat: drop heading levels from the rich-text block

### DIFF
--- a/packages/admin-editor/src/block-input-control.test.tsx
+++ b/packages/admin-editor/src/block-input-control.test.tsx
@@ -153,14 +153,15 @@ describe("BlockInputControl", () => {
   });
 
   test("richtext renders the Tiptap toolbar and editable surface", () => {
-    const { getByTestId } = renderControl(
+    const { getByTestId, queryByTestId } = renderControl(
       { name: "body", type: "richtext", label: "Body" },
       "<p>Hello</p>",
     );
     // The toolbar's formatting controls and the contenteditable surface mount.
     expect(getByTestId("block-input-body-bold")).toBeDefined();
-    expect(getByTestId("block-input-body-h2")).toBeDefined();
     expect(getByTestId("block-input-body-clear")).toBeDefined();
+    // Headings are the dedicated Heading block, so rich text offers no h2–h4.
+    expect(queryByTestId("block-input-body-h2")).toBeNull();
     const editor = getByTestId("block-input-body-editor");
     expect(editor.getAttribute("contenteditable")).toBe("true");
     expect(editor.textContent).toContain("Hello");

--- a/packages/admin-editor/src/rich-text-extensions.test.ts
+++ b/packages/admin-editor/src/rich-text-extensions.test.ts
@@ -1,7 +1,7 @@
 import { getSchema } from "@tiptap/core";
 import { describe, expect, test } from "vitest";
 
-import { HEADING_LEVELS, richTextExtensions } from "./rich-text-extensions.js";
+import { richTextExtensions } from "./rich-text-extensions.js";
 
 describe("richTextExtensions", () => {
   // getSchema throws on a duplicate extension name, so a clean build proves the
@@ -23,7 +23,6 @@ describe("richTextExtensions", () => {
     expect(Object.keys(schema.nodes)).toEqual(
       expect.arrayContaining([
         "paragraph",
-        "heading",
         "bulletList",
         "orderedList",
         "listItem",
@@ -31,9 +30,11 @@ describe("richTextExtensions", () => {
     );
   });
 
-  test("restricts headings to h2–h4, matching the render sanitizer", () => {
-    // h1/h5/h6 are stripped by the block's sanitizer, so the editor must not
-    // offer them. The constant gates both the schema and the toolbar.
-    expect(HEADING_LEVELS).toEqual([2, 3, 4]);
+  test("registers no heading node — headings live in the Heading block", () => {
+    // Rich text is prose only; structural headings are a separate block, so the
+    // editor must neither offer nor produce heading nodes.
+    const schema = getSchema([...richTextExtensions()]);
+
+    expect(Object.keys(schema.nodes)).not.toContain("heading");
   });
 });

--- a/packages/admin-editor/src/rich-text-extensions.ts
+++ b/packages/admin-editor/src/rich-text-extensions.ts
@@ -3,21 +3,18 @@ import StarterKit from "@tiptap/starter-kit";
 
 import { coreMarkExtensions } from "@plumix/blocks";
 
-// The render sanitizer only permits h2–h4, so the editor must not produce other
-// heading levels. Gates both the schema and the toolbar's heading buttons.
-export const HEADING_LEVELS = [2, 3, 4] as const;
-
 /**
  * Tiptap extensions for the rich-text rail: StarterKit's block nodes
- * (paragraph, heading, lists, …) plus `@plumix/blocks`' 13 canonical marks.
- * StarterKit's own marks are disabled so they don't double-register with the
- * shared core marks — the editor and the renderer then speak the same mark
- * vocabulary.
+ * (paragraph, lists, …) plus `@plumix/blocks`' 13 canonical marks. Headings are
+ * disabled — structural headings are the dedicated Heading block, so rich text
+ * stays prose-only. StarterKit's own marks are disabled so they don't
+ * double-register with the shared core marks — the editor and the renderer then
+ * speak the same mark vocabulary.
  */
 export function richTextExtensions(): Extensions {
   return [
     StarterKit.configure({
-      heading: { levels: [...HEADING_LEVELS] },
+      heading: false,
       bold: false,
       italic: false,
       strike: false,

--- a/packages/admin-editor/src/rich-text-field.tsx
+++ b/packages/admin-editor/src/rich-text-field.tsx
@@ -7,9 +7,6 @@ import { EditorContent, useEditor, useEditorState } from "@tiptap/react";
 import { Button } from "@plumix/admin-ui/button";
 import {
   Bold,
-  Heading2,
-  Heading3,
-  Heading4,
   Highlighter,
   Italic,
   Link2,
@@ -21,7 +18,7 @@ import {
 } from "@plumix/admin-ui/icons";
 import { Toggle } from "@plumix/admin-ui/toggle";
 
-import { HEADING_LEVELS, richTextExtensions } from "./rich-text-extensions.js";
+import { richTextExtensions } from "./rich-text-extensions.js";
 
 interface RichTextFieldProps {
   /** The block's body as an HTML string. */
@@ -50,14 +47,7 @@ interface ActiveState {
   readonly link: boolean;
   readonly bulletList: boolean;
   readonly orderedList: boolean;
-  readonly headings: Readonly<Record<number, boolean>>;
 }
-
-const HEADING_ICON: Record<number, typeof Heading2> = {
-  2: Heading2,
-  3: Heading3,
-  4: Heading4,
-};
 
 /**
  * Right-rail rich-text editor: a Tiptap instance over StarterKit nodes + the
@@ -113,12 +103,6 @@ export function RichTextField({
             link: editor.isActive("link"),
             bulletList: editor.isActive("bulletList"),
             orderedList: editor.isActive("orderedList"),
-            headings: Object.fromEntries(
-              HEADING_LEVELS.map((level) => [
-                level,
-                editor.isActive("heading", { level }),
-              ]),
-            ),
           }
         : null,
   });
@@ -126,22 +110,6 @@ export function RichTextField({
   return (
     <div className="flex flex-col gap-1.5" data-testid={testId}>
       <div className="flex flex-wrap items-center gap-0.5" role="toolbar">
-        {HEADING_LEVELS.map((level) => {
-          const Icon = HEADING_ICON[level] ?? Heading2;
-          return (
-            <ToolbarToggle
-              key={level}
-              testId={`${testId}-h${String(level)}`}
-              pressed={active?.headings[level] ?? false}
-              disabled={!editor}
-              onToggle={() =>
-                editor?.chain().focus().toggleHeading({ level }).run()
-              }
-            >
-              <Icon />
-            </ToolbarToggle>
-          );
-        })}
         {MARKS.map(({ name, icon: Icon, testId: suffix }) => (
           <ToolbarToggle
             key={name}


### PR DESCRIPTION
Rich text becomes prose-only: structural headings now come exclusively from the dedicated Heading block, removing the overlap between the two. StarterKit's heading node is disabled (`heading: false`) and the toolbar's H2/H3/H4 buttons and their active-state are removed.

The public render path is unaffected — stored HTML still renders verbatim and the sanitizer keeps allowing `h2`–`h4`, so existing headings continue to display. The one consequence: a legacy inline heading inside a rich-text body flattens to a paragraph if that block is re-edited and saved (the text is preserved). A content migration that lifts inline headings into adjacent Heading blocks could follow if that matters.

Part of the editor visual-refinement pass (task #56).