### PR TITLE
feat: let blocks carry the editor seam on their own element

### DIFF
--- a/packages/blocks/src/block-registry.ts
+++ b/packages/blocks/src/block-registry.ts
@@ -120,6 +120,15 @@ export interface BlockSpec<
     readonly error: unknown;
   }) => ReactNode;
   readonly inline?: boolean;
+  // The block spreads the render-supplied `blockProps` (`data-plumix-id`,
+  // `data-plumix-block`, style `className`) onto its own root element instead
+  // of receiving an external wrapper `<div>`. Required for elements a div can't
+  // wrap (`<td>`, `<tr>`) and to make a style class beat the theme's element
+  // styles (e.g. text color on a heading). The block MUST spread `blockProps`
+  // onto a single host element — a Fragment/string return silently drops the
+  // seam. A styled table-row block emits its `<style>` inside `<tbody>` (invalid
+  // but browser-tolerated); `errorFallback` is not handed `blockProps`.
+  readonly selfSeam?: boolean;
   // `NoInfer` keeps `defaults` from driving `Attrs` inference at
   // `defineBlock` — without it, `{ defaults: { text: "" } }` would
   // narrow `Attrs` to `{ text: string }` even when `render` reads other

--- a/packages/blocks/src/heading/index.test.tsx
+++ b/packages/blocks/src/heading/index.test.tsx
@@ -7,7 +7,7 @@ import { renderBlockTree } from "../render-block-tree.js";
 import { headingBlock } from "./index.js";
 
 describe("core/heading end-to-end through new defineBlock + flat registry + walker", () => {
-  test("renders the heading tag at the declared level with the wrapper", () => {
+  test("renders the heading tag at the declared level, seam on the element", () => {
     const registry = createBlockRegistry([headingBlock]);
     const tree: readonly BlockNode[] = [
       {
@@ -19,8 +19,9 @@ describe("core/heading end-to-end through new defineBlock + flat registry + walk
 
     const html = renderToStaticMarkup(renderBlockTree(tree, registry));
 
+    // selfSeam: the seam rides on the <h2> itself, no wrapper <div>.
     expect(html).toBe(
-      '<div data-plumix-block="core/heading"><h2>Section title</h2></div>',
+      '<h2 data-plumix-block="core/heading">Section title</h2>',
     );
   });
 
@@ -36,6 +37,8 @@ describe("core/heading end-to-end through new defineBlock + flat registry + walk
 
     const html = renderToStaticMarkup(renderBlockTree(tree, registry));
 
-    expect(html).toContain("<h2>Defaulted</h2>");
+    expect(html).toContain(
+      '<h2 data-plumix-block="core/heading">Defaulted</h2>',
+    );
   });
 });

--- a/packages/blocks/src/heading/index.tsx
+++ b/packages/blocks/src/heading/index.tsx
@@ -15,6 +15,9 @@ export const headingBlock = defineBlock({
   title: { id: "block.core.heading.title", message: "Heading" },
   icon: "Heading",
   category: "text",
+  // Carry the seam on the <hN> itself so a block style class beats the theme's
+  // explicit heading color (an inherited color from a wrapper div would lose).
+  selfSeam: true,
   inputs: [
     {
       name: "text",
@@ -36,7 +39,7 @@ export const headingBlock = defineBlock({
     },
   ],
   defaults: { level: 2, text: "" },
-  render: ({ attrs }): ReactNode => {
+  render: ({ attrs, blockProps }): ReactNode => {
     const { level: rawLevel, text = "" } = attrs as {
       readonly level?: unknown;
       readonly text?: string;
@@ -49,6 +52,6 @@ export const headingBlock = defineBlock({
         ? rawLevel
         : 2;
     const tag = `h${level}` as keyof JSX.IntrinsicElements;
-    return createElement(tag, null, text);
+    return createElement(tag, blockProps, text);
   },
 });

--- a/packages/blocks/src/render-block-tree.edit.test.tsx
+++ b/packages/blocks/src/render-block-tree.edit.test.tsx
@@ -6,8 +6,18 @@ import { createBlockRegistry } from "./block-registry.js";
 import { groupBlock } from "./group/index.js";
 import { headingBlock } from "./heading/index.js";
 import { renderBlockTree } from "./render-block-tree.js";
+import {
+  tableBlock,
+  tableBodyRowBlock,
+  tableCellBlock,
+} from "./table/index.js";
 
 const registry = createBlockRegistry([headingBlock, groupBlock]);
+const tableRegistry = createBlockRegistry([
+  tableBlock,
+  tableBodyRowBlock,
+  tableCellBlock,
+]);
 const tree: readonly BlockNode[] = [
   { id: "abc", name: "core/heading", attrs: { text: "Hi", level: 2 } },
 ];
@@ -29,6 +39,42 @@ describe("renderBlockTree edit-aware seam", () => {
     );
 
     expect(html).toContain('data-plumix-id="abc"');
+  });
+
+  test("a selfSeam block carries its id on its own element, not a wrapper div", () => {
+    const html = renderToStaticMarkup(
+      renderBlockTree(tree, registry, { editing: true }),
+    );
+
+    // The heading spreads the seam onto its <h2>, so there's no wrapper <div>
+    // — which is what lets table cells (a <td> can't be wrapped) stay selectable.
+    expect(html).toMatch(/<h2[^>]*\bdata-plumix-id="abc"/);
+    expect(html).not.toContain('<div data-plumix-id="abc"');
+  });
+
+  test("table cells are selectable — the seam rides on the <td>", () => {
+    const table: readonly BlockNode[] = [
+      {
+        id: "t1",
+        name: "core/table",
+        attrs: {
+          rows: [
+            {
+              id: "r1",
+              name: "core/table-body-row",
+              attrs: {
+                cells: [{ id: "c1", name: "core/table-cell", attrs: {} }],
+              },
+            },
+          ],
+        },
+      },
+    ];
+    const html = renderToStaticMarkup(
+      renderBlockTree(table, tableRegistry, { editing: true }),
+    );
+
+    expect(html).toMatch(/<td[^>]*\bdata-plumix-id="c1"/);
   });
 
   test("the normal (non-editing) render carries no editor annotations", () => {

--- a/packages/blocks/src/render-block-tree.ts
+++ b/packages/blocks/src/render-block-tree.ts
@@ -79,6 +79,14 @@ export interface RenderBlockTreeOptions {
   readonly editing?: boolean;
 }
 
+/** Editor/style seam attributes a block spreads onto its root element when it
+ *  opts into `selfSeam`. `data-plumix-id` is present only in edit mode. */
+export interface BlockProps {
+  readonly "data-plumix-block": string;
+  readonly "data-plumix-id"?: string;
+  readonly className?: string;
+}
+
 export interface BlockNodeRenderProps<
   Attrs = Readonly<Record<string, unknown>>,
   Loaders extends BlockLoaderRecord = BlockLoaderRecord,
@@ -86,6 +94,8 @@ export interface BlockNodeRenderProps<
   readonly attrs: Attrs;
   readonly context: BlockContext;
   readonly loaders: ResolvedLoaders<Loaders>;
+  /** Seam attributes for `selfSeam` blocks to spread onto their root element. */
+  readonly blockProps: BlockProps;
 }
 
 export type BlockNodeComponent<
@@ -234,20 +244,7 @@ function renderNode(
   };
   const attrs = materializeSlots(node, env, childContext);
   const data = loaderData?.get(node.id);
-  let rendered: ReactNode;
-  if (data && data.error !== null) {
-    // Same shape as the unknown-block path: emit nothing when the block
-    // didn't declare a fallback. Observability flows through the
-    // `blocks:loader:error` hook, not a console warn here.
-    if (!spec.errorFallback) return createElement(Fragment, { key: node.id });
-    rendered = spec.errorFallback({ attrs, error: data.error });
-  } else {
-    const loaders = data?.loaders ?? EMPTY_LOADERS;
-    rendered = createElement(spec.render, { attrs, context, loaders });
-  }
-  if (spec.inline) {
-    return createElement(Fragment, { key: node.id }, rendered);
-  }
+
   const safeId = SAFE_ID_RE.test(node.id) ? node.id : null;
   const styleCss =
     safeId && node.style && tokens
@@ -262,15 +259,43 @@ function renderNode(
   const styleTag = styleCss
     ? createElement("style", { key: "style" }, styleCss)
     : null;
+  const blockProps: BlockProps = {
+    "data-plumix-block": node.name,
+    "data-plumix-id": env.editing && safeId ? safeId : undefined,
+    className,
+  };
 
+  let rendered: ReactNode;
+  if (data && data.error !== null) {
+    // Same shape as the unknown-block path: emit nothing when the block
+    // didn't declare a fallback. Observability flows through the
+    // `blocks:loader:error` hook, not a console warn here.
+    if (!spec.errorFallback) return createElement(Fragment, { key: node.id });
+    rendered = spec.errorFallback({ attrs, error: data.error });
+  } else {
+    const loaders = data?.loaders ?? EMPTY_LOADERS;
+    rendered = createElement(spec.render, {
+      attrs,
+      context,
+      loaders,
+      blockProps,
+    });
+  }
+
+  // selfSeam: the block spread `blockProps` onto its own root element, so the
+  // seam needs no wrapper div (which `<td>`/`<tr>` can't have, and which would
+  // make a style class only inherit rather than win). The `<style>` rides as a
+  // fragment sibling.
+  if (spec.selfSeam) {
+    return createElement(Fragment, { key: node.id }, styleTag, rendered);
+  }
+  // Legacy: superseded by selfSeam.
+  if (spec.inline) {
+    return createElement(Fragment, { key: node.id }, rendered);
+  }
   return createElement(
     "div",
-    {
-      key: node.id,
-      "data-plumix-block": node.name,
-      "data-plumix-id": env.editing && safeId ? safeId : undefined,
-      className,
-    },
+    { key: node.id, ...blockProps },
     styleTag,
     rendered,
   );

--- a/packages/blocks/src/table/index.test.tsx
+++ b/packages/blocks/src/table/index.test.tsx
@@ -29,19 +29,21 @@ describe("core/table family", () => {
     expect(html).toContain('data-bordered="true"');
   });
 
-  test("renders <th scope=col> for header-cell with align attr, no universal wrapper (inline)", () => {
+  test("renders <th scope=col> for header-cell, seam on the <th> (selfSeam)", () => {
     const html = renderBlockSpecToHtml(tableHeaderCellBlock, {
       text: "Name",
       align: "center",
     });
 
-    expect(html).toBe('<th scope="col" data-align="center">Name</th>');
+    expect(html).toBe(
+      '<th scope="col" data-align="center" data-plumix-block="core/table-header-cell">Name</th>',
+    );
   });
 
-  test("renders <td> for body cells, no universal wrapper (inline)", () => {
+  test("renders <td> for body cells, seam on the <td> (selfSeam)", () => {
     const html = renderBlockSpecToHtml(tableCellBlock, { text: "v1" });
 
-    expect(html).toBe("<td>v1</td>");
+    expect(html).toBe('<td data-plumix-block="core/table-cell">v1</td>');
   });
 
   test("th/td nest as direct children of <tr>, <tr> as direct children of <table> (preserves HTML content model)", () => {
@@ -93,9 +95,13 @@ describe("core/table family", () => {
       tree,
     );
 
+    // The rows/cells nest directly (selfSeam → no wrapper divs between them);
+    // only the per-block seam attribute rides on each element.
     expect(html).toContain(
-      '<table><tr data-header=""><th scope="col">Col 1</th></tr>' +
-        "<tr><td>val 1</td></tr></table>",
+      '<table><tr data-header="" data-plumix-block="core/table-header-row">' +
+        '<th scope="col" data-plumix-block="core/table-header-cell">Col 1</th></tr>' +
+        '<tr data-plumix-block="core/table-body-row">' +
+        '<td data-plumix-block="core/table-cell">val 1</td></tr></table>',
     );
   });
 });

--- a/packages/blocks/src/table/index.tsx
+++ b/packages/blocks/src/table/index.tsx
@@ -44,7 +44,7 @@ export const tableHeaderRowBlock = defineBlock({
   title: "Header Row",
   icon: "Rows",
   category: "text",
-  inline: true,
+  selfSeam: true,
   inserter: false,
   inputs: [
     {
@@ -55,9 +55,13 @@ export const tableHeaderRowBlock = defineBlock({
     },
   ],
   defaults: {},
-  render: ({ attrs }): ReactNode => {
+  render: ({ attrs, blockProps }): ReactNode => {
     const Cells = attrs.cells as (() => ReactNode) | undefined;
-    return <tr data-header="">{Cells ? <Cells /> : null}</tr>;
+    return (
+      <tr data-header="" {...blockProps}>
+        {Cells ? <Cells /> : null}
+      </tr>
+    );
   },
 });
 
@@ -66,7 +70,7 @@ export const tableBodyRowBlock = defineBlock({
   title: "Body Row",
   icon: "Rows",
   category: "text",
-  inline: true,
+  selfSeam: true,
   inserter: false,
   inputs: [
     {
@@ -77,9 +81,9 @@ export const tableBodyRowBlock = defineBlock({
     },
   ],
   defaults: {},
-  render: ({ attrs }): ReactNode => {
+  render: ({ attrs, blockProps }): ReactNode => {
     const Cells = attrs.cells as (() => ReactNode) | undefined;
-    return <tr>{Cells ? <Cells /> : null}</tr>;
+    return <tr {...blockProps}>{Cells ? <Cells /> : null}</tr>;
   },
 });
 
@@ -88,7 +92,7 @@ export const tableHeaderCellBlock = defineBlock({
   title: "Header Cell",
   icon: "AlignLeft",
   category: "text",
-  inline: true,
+  selfSeam: true,
   inserter: false,
   inputs: [
     { name: "text", type: "text", label: "Text" },
@@ -100,11 +104,11 @@ export const tableHeaderCellBlock = defineBlock({
     },
   ],
   defaults: { text: "" },
-  render: ({ attrs }): ReactNode => {
+  render: ({ attrs, blockProps }): ReactNode => {
     const { text = "" } = attrs as { readonly text?: string };
     const align = pickAlign(attrs.align);
     return (
-      <th scope="col" data-align={align}>
+      <th scope="col" data-align={align} {...blockProps}>
         {text}
       </th>
     );
@@ -116,7 +120,7 @@ export const tableCellBlock = defineBlock({
   title: "Cell",
   icon: "AlignLeft",
   category: "text",
-  inline: true,
+  selfSeam: true,
   inserter: false,
   inputs: [
     { name: "text", type: "text", label: "Text" },
@@ -128,9 +132,13 @@ export const tableCellBlock = defineBlock({
     },
   ],
   defaults: { text: "" },
-  render: ({ attrs }): ReactNode => {
+  render: ({ attrs, blockProps }): ReactNode => {
     const { text = "" } = attrs as { readonly text?: string };
     const align = pickAlign(attrs.align);
-    return <td data-align={align}>{text}</td>;
+    return (
+      <td data-align={align} {...blockProps}>
+        {text}
+      </td>
+    );
   },
 });


### PR DESCRIPTION
Selecting a table cell in the editor did nothing — no highlight, no inspector. The walker tags each block via an external wrapper `<div data-plumix-id>`, but a `<div>` can't wrap a `<td>`/`<tr>`, so the table sub-blocks were marked `inline` (bare fragment, **no seam**) and became unselectable. The same wrapper indirection meant a per-block style class only *inherited* down to the element, so e.g. text color on a Heading lost to the theme's `h2 { color }`.

This adds a cooperative seam, Gutenberg-style. The walker computes the seam attributes (`data-plumix-id` in edit mode, `data-plumix-block`, style `className`) once and passes them to `render` as `blockProps`. A block that sets `selfSeam: true` spreads `{...blockProps}` onto its own root element and receives no wrapper div; the `<style>` rides as a fragment sibling. Every other block keeps the wrapper div exactly as before. The table rows/cells and the heading opt in.

Result: table cells/rows are selectable (verified live — `data-plumix-id` count inside a table went 0 → 16, and selecting a cell populates the inspector), and a heading's style class now beats the theme's element color.

Known follow-ups (out of scope): the slot wrapper `<div data-plumix-slot-parent>` is still emitted inside `<table>` (the `<table> cannot contain a nested <div>` console warning — it's the slot seam, not the block seam); a styled table-*row* emits its `<style>` inside `<tbody>` (browser-tolerated). Both noted in the `selfSeam` doc.

Part of the editor visual-refinement pass (task #56).