### PR TITLE
feat: add a full-width editor header with back, title, and actions

### DIFF
--- a/packages/admin-editor/src/editor-header.test.tsx
+++ b/packages/admin-editor/src/editor-header.test.tsx
@@ -1,0 +1,98 @@
+import { useEffect } from "react";
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
+
+import type { EditorHeaderProps } from "./editor-header.js";
+import { EditorHeader } from "./editor-header.js";
+import { EditorProvider, useEditorStoreApi } from "./provider.js";
+
+beforeAll(() => {
+  i18n.loadAndActivate({ locale: "en", messages: {} });
+});
+afterEach(cleanup);
+
+let storeApi: ReturnType<typeof useEditorStoreApi> | undefined;
+function Capture(): null {
+  const api = useEditorStoreApi();
+  useEffect(() => {
+    storeApi = api;
+  }, [api]);
+  return null;
+}
+
+function renderHeader(
+  props: EditorHeaderProps = {},
+): ReturnType<typeof render> {
+  return render(
+    <I18nProvider i18n={i18n}>
+      <EditorProvider initialTree={[]}>
+        <EditorHeader {...props} />
+        <Capture />
+      </EditorProvider>
+    </I18nProvider>,
+  );
+}
+
+const button = (el: HTMLElement): HTMLButtonElement => el as HTMLButtonElement;
+
+describe("EditorHeader", () => {
+  test("the back button calls onBack; absent without the handler", () => {
+    const onBack = vi.fn();
+    const { getByTestId, queryByTestId, rerender } = renderHeader({ onBack });
+    fireEvent.click(getByTestId("plumix-editor-back"));
+    expect(onBack).toHaveBeenCalledOnce();
+
+    rerender(
+      <I18nProvider i18n={i18n}>
+        <EditorProvider initialTree={[]}>
+          <EditorHeader />
+        </EditorProvider>
+      </I18nProvider>,
+    );
+    expect(queryByTestId("plumix-editor-back")).toBeNull();
+  });
+
+  test("editing the title input calls onTitleChange", () => {
+    const onTitleChange = vi.fn();
+    const { getByTestId } = renderHeader({ title: "Hi", onTitleChange });
+    fireEvent.change(getByTestId("plumix-editor-title-input"), {
+      target: { value: "Hello" },
+    });
+    expect(onTitleChange).toHaveBeenCalledWith("Hello");
+  });
+
+  test("a read-only title (no handler) renders as static text", () => {
+    const { getByTestId, queryByTestId } = renderHeader({ title: "Locked" });
+    expect(getByTestId("plumix-editor-title").textContent).toBe("Locked");
+    expect(queryByTestId("plumix-editor-title-input")).toBeNull();
+  });
+
+  test("undo/redo start disabled and enable after an edit", () => {
+    const { getByTestId } = renderHeader();
+    expect(button(getByTestId("plumix-undo")).disabled).toBe(true);
+    expect(button(getByTestId("plumix-redo")).disabled).toBe(true);
+
+    act(() => storeApi?.getState().insertBlock({ id: "a", name: "core/x" }, 0));
+    expect(button(getByTestId("plumix-undo")).disabled).toBe(false);
+  });
+
+  test("the preview menu trigger renders", () => {
+    // The menu items' open/disabled behavior is exercised in the browser; Radix
+    // menus don't open reliably under jsdom.
+    const { getByTestId } = renderHeader({
+      previewLink: "https://x.test/p?preview=tok",
+    });
+    expect(getByTestId("plumix-preview-menu")).toBeDefined();
+  });
+
+  test("the Publish button calls onPublish", () => {
+    const onPublish = vi.fn();
+    const { getByTestId } = renderHeader({
+      publish: { onPublish, isPublished: false },
+    });
+    fireEvent.click(getByTestId("plumix-editor-publish-button"));
+    expect(onPublish).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/admin-editor/src/editor-header.tsx
+++ b/packages/admin-editor/src/editor-header.tsx
@@ -1,0 +1,175 @@
+import type { ReactElement } from "react";
+import { Trans, useLingui } from "@lingui/react";
+
+import { Button } from "@plumix/admin-ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@plumix/admin-ui/dropdown-menu";
+import { ArrowLeft, Eye, Redo2, Undo2 } from "@plumix/admin-ui/icons";
+import { Input } from "@plumix/admin-ui/input";
+
+import type { PublishActions } from "./editor-toolbar.js";
+import { PublishControls } from "./editor-toolbar.js";
+import { canRedo, canUndo } from "./history.js";
+import { useEditorStore } from "./provider.js";
+
+export interface EditorHeaderProps {
+  /** Entry title shown (and edited inline) in the header. */
+  readonly title?: string;
+  /** Persists a title edit; without it the title renders read-only. */
+  readonly onTitleChange?: (title: string) => void;
+  /** Returns to the entry list. */
+  readonly onBack?: () => void;
+  /** Publish / draft actions, pinned to the header's right edge. */
+  readonly publish?: PublishActions;
+  /** Shareable draft-preview URL ("View current draft"). */
+  readonly previewLink?: string;
+  /** Public permalink ("View live entry"); absent until first published. */
+  readonly liveUrl?: string;
+}
+
+/**
+ * Full-width editor header: a back button + inline-editable entry title on the
+ * left; undo/redo, a preview menu, and the publish actions on the right. Spans
+ * the whole editor (above both side rails), unlike the canvas toolbar.
+ */
+export function EditorHeader({
+  title,
+  onTitleChange,
+  onBack,
+  publish,
+  previewLink,
+  liveUrl,
+}: EditorHeaderProps): ReactElement {
+  const { i18n } = useLingui();
+  const undoAvailable = useEditorStore((s) => canUndo(s.history));
+  const redoAvailable = useEditorStore((s) => canRedo(s.history));
+  const undo = useEditorStore((s) => s.undo);
+  const redo = useEditorStore((s) => s.redo);
+
+  return (
+    <header
+      className="bg-background flex items-center gap-2 border-b px-3 py-2"
+      data-testid="plumix-editor-header"
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        {onBack ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            className="shrink-0"
+            data-testid="plumix-editor-back"
+            onClick={onBack}
+            aria-label={i18n._({ id: "editor.header.back", message: "Back" })}
+          >
+            <ArrowLeft />
+          </Button>
+        ) : null}
+        {title !== undefined ? (
+          onTitleChange ? (
+            <Input
+              value={title}
+              onChange={(event) => onTitleChange(event.target.value)}
+              data-testid="plumix-editor-title-input"
+              aria-label={i18n._({
+                id: "editor.header.title",
+                message: "Title",
+              })}
+              className="hover:bg-accent focus-visible:bg-background h-8 max-w-md min-w-0 border-transparent bg-transparent text-sm font-medium shadow-none"
+              placeholder={i18n._({
+                id: "editor.header.untitled",
+                message: "Untitled",
+              })}
+            />
+          ) : (
+            <span
+              className="truncate text-sm font-medium"
+              data-testid="plumix-editor-title"
+            >
+              {title}
+            </span>
+          )
+        ) : null}
+      </div>
+      <div className="flex shrink-0 items-center gap-1">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          data-testid="plumix-undo"
+          disabled={!undoAvailable}
+          onClick={undo}
+          aria-label={i18n._({ id: "editor.toolbar.undo", message: "Undo" })}
+        >
+          <Undo2 />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          data-testid="plumix-redo"
+          disabled={!redoAvailable}
+          onClick={redo}
+          aria-label={i18n._({ id: "editor.toolbar.redo", message: "Redo" })}
+        >
+          <Redo2 />
+        </Button>
+        <PreviewMenu previewLink={previewLink} liveUrl={liveUrl} />
+        {publish ? <PublishControls publish={publish} /> : null}
+      </div>
+    </header>
+  );
+}
+
+/** Eye-icon menu: open the current draft preview or the published page. The
+ *  live entry is disabled until the entry has been published at least once. */
+function PreviewMenu({
+  previewLink,
+  liveUrl,
+}: {
+  readonly previewLink?: string;
+  readonly liveUrl?: string;
+}): ReactElement {
+  const { i18n } = useLingui();
+  const open = (url: string): void => {
+    window.open(url, "_blank", "noopener,noreferrer");
+  };
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          data-testid="plumix-preview-menu"
+          aria-label={i18n._({
+            id: "editor.header.preview",
+            message: "Preview",
+          })}
+        >
+          <Eye />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem
+          data-testid="plumix-preview-draft"
+          disabled={!previewLink}
+          onSelect={() => previewLink && open(previewLink)}
+        >
+          <Trans id="editor.header.viewDraft" message="View current draft" />
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          data-testid="plumix-preview-live"
+          disabled={!liveUrl}
+          onSelect={() => liveUrl && open(liveUrl)}
+        >
+          <Trans id="editor.header.viewLive" message="View live entry" />
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/admin-editor/src/editor-toolbar.test.tsx
+++ b/packages/admin-editor/src/editor-toolbar.test.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { i18n } from "@lingui/core";
 import { I18nProvider } from "@lingui/react";
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
-import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeAll, describe, expect, test } from "vitest";
 
 import { SidebarProvider } from "@plumix/admin-ui/sidebar";
 
@@ -25,14 +25,12 @@ function Capture(): null {
   return null;
 }
 
-function renderToolbar(
-  publish?: Parameters<typeof EditorToolbar>[0]["publish"],
-): ReturnType<typeof render> {
+function renderToolbar(): ReturnType<typeof render> {
   return render(
     <I18nProvider i18n={i18n}>
       <EditorProvider initialTree={[]}>
         <SidebarProvider>
-          <EditorToolbar publish={publish} />
+          <EditorToolbar />
         </SidebarProvider>
         <EditorShortcuts />
         <Capture />
@@ -42,89 +40,6 @@ function renderToolbar(
 }
 
 describe("EditorToolbar", () => {
-  const button = (el: HTMLElement): HTMLButtonElement =>
-    el as HTMLButtonElement;
-
-  test("undo/redo start disabled", () => {
-    const { getByTestId } = renderToolbar();
-    expect(button(getByTestId("plumix-undo")).disabled).toBe(true);
-    expect(button(getByTestId("plumix-redo")).disabled).toBe(true);
-  });
-
-  test("undo enables after an edit and reverts it on click", () => {
-    const { getByTestId } = renderToolbar();
-    act(() => storeApi?.getState().insertBlock({ id: "a", name: "core/x" }, 0));
-
-    const undoButton = getByTestId("plumix-undo");
-    expect(button(undoButton).disabled).toBe(false);
-    fireEvent.click(undoButton);
-
-    expect(storeApi?.getState().tree).toHaveLength(0);
-    expect(button(getByTestId("plumix-redo")).disabled).toBe(false);
-  });
-
-  test("Ctrl/Cmd+Z undoes via the keyboard", () => {
-    renderToolbar();
-    storeApi?.getState().insertBlock({ id: "a", name: "core/x" }, 0);
-
-    fireEvent.keyDown(window, { key: "z", ctrlKey: true });
-    expect(storeApi?.getState().tree).toHaveLength(0);
-
-    fireEvent.keyDown(window, { key: "z", ctrlKey: true, shiftKey: true });
-    expect(storeApi?.getState().tree).toHaveLength(1);
-  });
-
-  test("does not hijack undo while typing in a field", () => {
-    renderToolbar();
-    storeApi?.getState().insertBlock({ id: "a", name: "core/x" }, 0);
-
-    const input = document.createElement("input");
-    document.body.appendChild(input);
-    fireEvent.keyDown(input, { key: "z", ctrlKey: true });
-    // The edit survives — the shortcut deferred to the field's native undo.
-    expect(storeApi?.getState().tree).toHaveLength(1);
-    input.remove();
-  });
-
-  test("renders a Publish button that calls onPublish", () => {
-    const onPublish = vi.fn();
-    const { getByTestId } = renderToolbar({ onPublish, isPublished: false });
-    const publishButton = getByTestId("plumix-editor-publish-button");
-    expect(button(publishButton).disabled).toBe(false);
-    fireEvent.click(publishButton);
-    expect(onPublish).toHaveBeenCalledOnce();
-  });
-
-  test("the Publish button is disabled once published", () => {
-    const { getByTestId } = renderToolbar({
-      onPublish: vi.fn(),
-      isPublished: true,
-    });
-    expect(button(getByTestId("plumix-editor-publish-button")).disabled).toBe(
-      true,
-    );
-  });
-
-  test("draft mode shows save/publish/discard, gated on a pending draft", () => {
-    const draftMode = {
-      hasPendingDraft: false,
-      onSaveDraft: vi.fn(),
-      onPublishDraft: vi.fn(),
-      onDiscardDraft: vi.fn(),
-      isSaving: false,
-      isPublishing: false,
-      isDiscarding: false,
-    };
-    const { getByTestId, queryByTestId } = renderToolbar({ draftMode });
-    // No live Publish button in draft mode.
-    expect(queryByTestId("plumix-editor-publish-button")).toBeNull();
-    // Discard + Publish gated until there's a pending draft; Save always on.
-    expect(button(getByTestId("editor-draft-save")).disabled).toBe(false);
-    expect(button(getByTestId("editor-draft-discard")).disabled).toBe(true);
-    expect(button(getByTestId("editor-draft-publish")).disabled).toBe(true);
-    expect(queryByTestId("unpublished-changes-banner")).toBeNull();
-  });
-
   test("device switch + zoom controls drive the store", () => {
     const { getByTestId } = renderToolbar();
 
@@ -142,51 +57,29 @@ describe("EditorToolbar", () => {
     fireEvent.click(getByTestId("plumix-zoom-percent"));
     expect(storeApi?.getState().zoomFit).toBe(true);
   });
+});
 
-  test("a preview link surfaces a copy-to-clipboard action", () => {
-    const writeText = vi.fn();
-    vi.stubGlobal("navigator", { clipboard: { writeText } });
-    const { getByTestId, queryByTestId } = render(
-      <I18nProvider i18n={i18n}>
-        <EditorProvider initialTree={[]}>
-          <SidebarProvider>
-            <EditorToolbar previewLink="https://x.test/blog/hi?preview=tok" />
-          </SidebarProvider>
-        </EditorProvider>
-      </I18nProvider>,
-    );
-    fireEvent.click(getByTestId("plumix-copy-preview-link"));
-    expect(writeText).toHaveBeenCalledWith(
-      "https://x.test/blog/hi?preview=tok",
-    );
-    vi.unstubAllGlobals();
-    // No link → no action.
-    cleanup();
-    render(
-      <I18nProvider i18n={i18n}>
-        <EditorProvider initialTree={[]}>
-          <SidebarProvider>
-            <EditorToolbar />
-          </SidebarProvider>
-        </EditorProvider>
-      </I18nProvider>,
-    );
-    expect(queryByTestId("plumix-copy-preview-link")).toBeNull();
+describe("EditorShortcuts", () => {
+  test("Ctrl/Cmd+Z undoes via the keyboard, +Shift redoes", () => {
+    renderToolbar();
+    act(() => storeApi?.getState().insertBlock({ id: "a", name: "core/x" }, 0));
+
+    fireEvent.keyDown(window, { key: "z", ctrlKey: true });
+    expect(storeApi?.getState().tree).toHaveLength(0);
+
+    fireEvent.keyDown(window, { key: "z", ctrlKey: true, shiftKey: true });
+    expect(storeApi?.getState().tree).toHaveLength(1);
   });
 
-  test("a pending draft enables discard/publish and shows the banner", () => {
-    const draftMode = {
-      hasPendingDraft: true,
-      onSaveDraft: vi.fn(),
-      onPublishDraft: vi.fn(),
-      onDiscardDraft: vi.fn(),
-      isSaving: false,
-      isPublishing: false,
-      isDiscarding: false,
-    };
-    const { getByTestId } = renderToolbar({ draftMode });
-    expect(getByTestId("unpublished-changes-banner")).toBeDefined();
-    fireEvent.click(getByTestId("editor-draft-publish"));
-    expect(draftMode.onPublishDraft).toHaveBeenCalledOnce();
+  test("does not hijack undo while typing in a field", () => {
+    renderToolbar();
+    act(() => storeApi?.getState().insertBlock({ id: "a", name: "core/x" }, 0));
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    fireEvent.keyDown(input, { key: "z", ctrlKey: true });
+    // The edit survives — the shortcut deferred to the field's native undo.
+    expect(storeApi?.getState().tree).toHaveLength(1);
+    input.remove();
   });
 });

--- a/packages/admin-editor/src/editor-toolbar.tsx
+++ b/packages/admin-editor/src/editor-toolbar.tsx
@@ -5,7 +5,6 @@ import { Trans, useLingui } from "@lingui/react";
 import { Button } from "@plumix/admin-ui/button";
 import {
   Monitor,
-  Share2,
   Smartphone,
   Tablet,
   ZoomIn,
@@ -15,7 +14,6 @@ import { SidebarTrigger } from "@plumix/admin-ui/sidebar";
 import { ToggleGroup, ToggleGroupItem } from "@plumix/admin-ui/toggle-group";
 
 import type { EditorDevice } from "./store.js";
-import { canRedo, canUndo } from "./history.js";
 import { useEditorStore, useEditorStoreApi } from "./provider.js";
 
 const ZOOM_STEPS = [0.5, 0.75, 1, 1.25, 1.5, 2] as const;
@@ -51,59 +49,29 @@ export interface PublishActions {
   readonly draftMode?: DraftMode;
 }
 
-/** Top toolbar: an inline inserter slot, undo/redo, plus the host-wired
- *  publish / draft actions. */
+/** Canvas toolbar above the iframe: the rails toggle + inline inserter on the
+ *  left, and the device/zoom controls centered over the canvas. Title, undo/
+ *  redo, preview and publish live in the full-width header instead. */
 export function EditorToolbar({
-  publish,
   inserter,
-  previewLink,
 }: {
-  readonly publish?: PublishActions;
   readonly inserter?: ReactNode;
-  /** A shareable `?preview=…` URL; when set, a copy-to-clipboard action shows. */
-  readonly previewLink?: string;
 }): ReactElement {
-  const undoAvailable = useEditorStore((s) => canUndo(s.history));
-  const redoAvailable = useEditorStore((s) => canRedo(s.history));
-  const undo = useEditorStore((s) => s.undo);
-  const redo = useEditorStore((s) => s.redo);
-
   return (
     <header
-      className="bg-background flex items-center gap-1 border-b p-2"
+      className="bg-background flex items-center gap-2 border-b p-2"
       data-testid="plumix-editor-toolbar"
     >
-      {/* Left controls take the flexible, scrollable space; the publish action
-          is pinned outside it so it always sits at the inset's right edge and
-          never overflows under the right rail at narrow widths. */}
-      <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
+      <div className="flex shrink-0 items-center gap-1">
         {/* Collapses both rails for a focused canvas (also Cmd/Ctrl+B). */}
         <SidebarTrigger data-testid="plumix-rails-toggle" />
         {inserter}
-        <DeviceZoomControls />
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          data-testid="plumix-undo"
-          disabled={!undoAvailable}
-          onClick={undo}
-        >
-          <Trans id="editor.toolbar.undo" message="Undo" />
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          data-testid="plumix-redo"
-          disabled={!redoAvailable}
-          onClick={redo}
-        >
-          <Trans id="editor.toolbar.redo" message="Redo" />
-        </Button>
-        {previewLink ? <CopyPreviewLink url={previewLink} /> : null}
       </div>
-      {publish ? <PublishControls publish={publish} /> : null}
+      <div className="flex flex-1 justify-center">
+        <DeviceZoomControls />
+      </div>
+      {/* Balances the left group so the device/zoom cluster reads as centered. */}
+      <div className="w-8 shrink-0" aria-hidden />
     </header>
   );
 }
@@ -154,8 +122,7 @@ function DeviceZoomControls(): ReactElement {
       <Button
         type="button"
         variant="ghost"
-        size="sm"
-        className="size-8 p-0"
+        size="icon-sm"
         data-testid="plumix-zoom-out"
         onClick={zoomOut}
         aria-label={i18n._({
@@ -180,8 +147,7 @@ function DeviceZoomControls(): ReactElement {
       <Button
         type="button"
         variant="ghost"
-        size="sm"
-        className="size-8 p-0"
+        size="icon-sm"
         data-testid="plumix-zoom-in"
         onClick={zoomIn}
         aria-label={i18n._({ id: "editor.toolbar.zoomIn", message: "Zoom in" })}
@@ -192,24 +158,7 @@ function DeviceZoomControls(): ReactElement {
   );
 }
 
-/** Copies the shareable preview URL to the clipboard. The host mints the URL
- *  (a `?preview=<token>` link); this only surfaces the copy action. */
-function CopyPreviewLink({ url }: { readonly url: string }): ReactElement {
-  return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="sm"
-      data-testid="plumix-copy-preview-link"
-      onClick={() => void navigator.clipboard.writeText(url)}
-    >
-      <Share2 />
-      <Trans id="editor.toolbar.copyPreviewLink" message="Copy preview link" />
-    </Button>
-  );
-}
-
-function PublishControls({
+export function PublishControls({
   publish,
 }: {
   readonly publish: PublishActions;

--- a/packages/admin-editor/src/plumix-editor.tsx
+++ b/packages/admin-editor/src/plumix-editor.tsx
@@ -30,6 +30,7 @@ import { BlockCatalog } from "./block-catalog-tab.js";
 import { BlockInserterPopover } from "./block-inserter.js";
 import { BlockInspector } from "./block-inspector.js";
 import { CanvasFrame } from "./canvas-frame.js";
+import { EditorHeader } from "./editor-header.js";
 import { EditorShortcuts, EditorToolbar } from "./editor-toolbar.js";
 import { JsonInspector } from "./json-inspector.js";
 import { LayersTab } from "./layers-tab.js";
@@ -60,8 +61,16 @@ interface PlumixEditorProps {
   readonly readOnly?: boolean;
   /** Banner shown above the canvas in preview mode (e.g. revision + restore). */
   readonly previewBanner?: ReactNode;
-  /** A shareable `?preview=…` URL; surfaces a copy-link action in the toolbar. */
+  /** A shareable `?preview=…` URL; surfaces "View current draft" in the header. */
   readonly previewLink?: string;
+  /** Public permalink for "View live entry"; absent until first published. */
+  readonly liveUrl?: string;
+  /** Entry title, shown and edited inline in the header. */
+  readonly title?: string;
+  /** Persists a header title edit (host owns persistence). */
+  readonly onTitleChange?: (title: string) => void;
+  /** Returns to the entry list from the header's back button. */
+  readonly onBack?: () => void;
   /** Fires with the full content envelope whenever the tree changes. The host
    *  debounces + persists (orpc lives in the app, never in this package). */
   readonly onChange?: (content: EntryContent) => void;
@@ -97,6 +106,10 @@ export function PlumixEditor({
   readOnly = false,
   previewBanner,
   previewLink,
+  liveUrl,
+  title,
+  onTitleChange,
+  onBack,
   onChange,
   documentPanel,
   publish,
@@ -131,109 +144,130 @@ export function PlumixEditor({
       initialTree={defaultValue?.blocks}
       breakpoints={breakpoints}
     >
-      <SidebarProvider
-        className="h-full min-h-0"
-        style={{ "--sidebar-width": "18rem" } as CSSProperties}
-        data-testid="plumix-editor-layout"
-      >
-        <Sidebar
-          side="left"
-          collapsible="offcanvas"
-          data-testid="plumix-editor-left"
+      <div className="flex h-full min-h-0 flex-col">
+        <EditorHeader
+          title={title}
+          onTitleChange={onTitleChange}
+          onBack={onBack}
+          publish={publish}
+          previewLink={previewLink}
+          liveUrl={liveUrl}
+        />
+        {/* The `transform` makes this a containing block for the offcanvas
+            rails' `position: fixed`, so they span the area below the header
+            instead of the whole viewport (which would overlap it). Inline, not
+            a Tailwind class — the admin's content scan misses classes that only
+            appear in the bundled admin-editor. */}
+        <SidebarProvider
+          className="min-h-0 flex-1"
+          style={
+            {
+              "--sidebar-width": "18rem",
+              transform: "translateZ(0)",
+            } as CSSProperties
+          }
+          data-testid="plumix-editor-layout"
         >
-          <Tabs defaultValue="blocks" className="flex h-full min-h-0 flex-col">
-            <SidebarHeader>
-              <TabsList>
-                <TabsTrigger value="blocks" data-testid="plumix-tab-blocks">
-                  <Trans id="editor.tab.blocks" message="Blocks" />
-                </TabsTrigger>
-                <TabsTrigger value="layers" data-testid="plumix-tab-layers">
-                  <Trans id="editor.tab.layers" message="Layers" />
-                </TabsTrigger>
-              </TabsList>
-            </SidebarHeader>
-            <SidebarContent>
-              <TabsContent value="blocks">
-                <BlockCatalog
+          <Sidebar
+            side="left"
+            collapsible="offcanvas"
+            data-testid="plumix-editor-left"
+          >
+            <Tabs
+              defaultValue="blocks"
+              className="flex h-full min-h-0 flex-col"
+            >
+              <SidebarHeader>
+                <TabsList>
+                  <TabsTrigger value="blocks" data-testid="plumix-tab-blocks">
+                    <Trans id="editor.tab.blocks" message="Blocks" />
+                  </TabsTrigger>
+                  <TabsTrigger value="layers" data-testid="plumix-tab-layers">
+                    <Trans id="editor.tab.layers" message="Layers" />
+                  </TabsTrigger>
+                </TabsList>
+              </SidebarHeader>
+              <SidebarContent>
+                <TabsContent value="blocks">
+                  <BlockCatalog
+                    registry={registry}
+                    capabilities={capabilities}
+                    patterns={patterns}
+                  />
+                </TabsContent>
+                <TabsContent value="layers">
+                  <LayersTab registry={registry} />
+                </TabsContent>
+              </SidebarContent>
+            </Tabs>
+          </Sidebar>
+          <SidebarInset className="min-w-0">
+            <EditorToolbar
+              inserter={
+                <BlockInserterPopover
                   registry={registry}
                   capabilities={capabilities}
                   patterns={patterns}
                 />
-              </TabsContent>
-              <TabsContent value="layers">
-                <LayersTab registry={registry} />
-              </TabsContent>
-            </SidebarContent>
-          </Tabs>
-        </Sidebar>
-        <SidebarInset className="min-w-0">
-          <EditorToolbar
-            publish={publish}
-            previewLink={previewLink}
-            inserter={
-              <BlockInserterPopover
-                registry={registry}
-                capabilities={capabilities}
-                patterns={patterns}
-              />
-            }
-          />
-          <CanvasFrame
-            previewUrl={previewUrl}
-            origin={origin}
-            registry={registry}
-            capabilities={capabilities}
-          />
-        </SidebarInset>
-        <Sidebar
-          side="right"
-          collapsible="offcanvas"
-          data-testid="plumix-editor-right"
-        >
-          <Tabs defaultValue="block" className="flex h-full min-h-0 flex-col">
-            <SidebarHeader>
-              <TabsList>
-                <TabsTrigger value="block" data-testid="plumix-tab-block">
-                  <Trans id="editor.tab.block" message="Block" />
-                </TabsTrigger>
-                <TabsTrigger value="styles" data-testid="plumix-tab-styles">
-                  <Trans id="editor.tab.styles" message="Styles" />
-                </TabsTrigger>
-                <TabsTrigger value="page" data-testid="plumix-tab-page">
-                  <Trans id="editor.tab.page" message="Page" />
-                </TabsTrigger>
-                <TabsTrigger value="json" data-testid="plumix-tab-json">
-                  <Trans id="editor.tab.json" message="JSON" />
-                </TabsTrigger>
-              </TabsList>
-            </SidebarHeader>
-            <SidebarContent>
-              <TabsContent value="block">
-                <BlockInspector
-                  registry={registry}
-                  onRefreshBlockLoader={onRefreshBlockLoader}
-                />
-              </TabsContent>
-              <TabsContent value="styles">
-                <StylesTab tokens={tokens ?? {}} />
-              </TabsContent>
-              <TabsContent value="page" data-testid="plumix-page-panel">
-                {documentPanel ?? (
-                  <p className="text-muted-foreground p-4 text-sm">
-                    <Trans
-                      id="editor.page.empty"
-                      message="No document settings."
-                    />
-                  </p>
-                )}
-              </TabsContent>
-              <TabsContent value="json">
-                <JsonInspector />
-              </TabsContent>
-            </SidebarContent>
-          </Tabs>
-        </Sidebar>
-      </SidebarProvider>
+              }
+            />
+            <CanvasFrame
+              previewUrl={previewUrl}
+              origin={origin}
+              registry={registry}
+              capabilities={capabilities}
+            />
+          </SidebarInset>
+          <Sidebar
+            side="right"
+            collapsible="offcanvas"
+            data-testid="plumix-editor-right"
+          >
+            <Tabs defaultValue="block" className="flex h-full min-h-0 flex-col">
+              <SidebarHeader>
+                <TabsList>
+                  <TabsTrigger value="block" data-testid="plumix-tab-block">
+                    <Trans id="editor.tab.block" message="Block" />
+                  </TabsTrigger>
+                  <TabsTrigger value="styles" data-testid="plumix-tab-styles">
+                    <Trans id="editor.tab.styles" message="Styles" />
+                  </TabsTrigger>
+                  <TabsTrigger value="page" data-testid="plumix-tab-page">
+                    <Trans id="editor.tab.page" message="Page" />
+                  </TabsTrigger>
+                  <TabsTrigger value="json" data-testid="plumix-tab-json">
+                    <Trans id="editor.tab.json" message="JSON" />
+                  </TabsTrigger>
+                </TabsList>
+              </SidebarHeader>
+              <SidebarContent>
+                <TabsContent value="block">
+                  <BlockInspector
+                    registry={registry}
+                    onRefreshBlockLoader={onRefreshBlockLoader}
+                  />
+                </TabsContent>
+                <TabsContent value="styles">
+                  <StylesTab tokens={tokens ?? {}} />
+                </TabsContent>
+                <TabsContent value="page" data-testid="plumix-page-panel">
+                  {documentPanel ?? (
+                    <p className="text-muted-foreground p-4 text-sm">
+                      <Trans
+                        id="editor.page.empty"
+                        message="No document settings."
+                      />
+                    </p>
+                  )}
+                </TabsContent>
+                <TabsContent value="json">
+                  <JsonInspector />
+                </TabsContent>
+              </SidebarContent>
+            </Tabs>
+          </Sidebar>
+        </SidebarProvider>
+      </div>
       <EditorShortcuts />
       {overlay}
       {onChange ? <TreeChangeEmitter onChange={onChange} /> : null}

--- a/packages/admin/e2e/bespoke-editor.spec.ts
+++ b/packages/admin/e2e/bespoke-editor.spec.ts
@@ -575,8 +575,8 @@ test.describe("editor document tab", () => {
     });
 
     await page.goto("entries/posts/1/edit");
-    await page.getByTestId("plumix-tab-page").click();
 
+    // The title lives in the always-visible header now, not the Page tab.
     const title = page.getByTestId("plumix-editor-title-input");
     await expect(title).toHaveValue("Untitled");
     await title.fill("Hello world");
@@ -715,14 +715,11 @@ test.describe("editor document tab", () => {
   });
 });
 
-// Ported from "editor preview". The bespoke toolbar surfaces only the
-// copy-preview-link affordance (the host mints the URL in the loader and feeds
-// it in as `previewLink`). The Puck "primary Preview button opens a new tab"
-// assertion is dropped — the bespoke shell has no open-in-new-tab button.
+// The header's preview menu (eye icon) offers the current draft and the live
+// entry. The host mints the draft URL in the loader and feeds it in as
+// `previewLink`; "View live entry" stays disabled until the entry is published.
 test.describe("editor preview", () => {
-  test.use({ permissions: ["clipboard-read", "clipboard-write"] });
-
-  test("the toolbar copies the absolute preview url to the clipboard", async ({
+  test("the preview menu offers the draft and live-entry options", async ({
     page,
   }) => {
     await mockRpc(page, {
@@ -732,14 +729,11 @@ test.describe("editor preview", () => {
     });
     await page.goto("entries/posts/1/edit");
 
-    await page.getByTestId("plumix-copy-preview-link").click();
+    await page.getByTestId("plumix-preview-menu").click();
 
-    const clipboard = await page.evaluate(() => navigator.clipboard.readText());
-    expect(clipboard).toContain("/post/hello?preview=tok123");
-    // The host resolves the site-relative mint against the admin origin before
-    // surfacing it, so the copied link is absolute and the edit flag is absent.
-    expect(clipboard).toMatch(/^https?:\/\//);
-    expect(clipboard).not.toContain("plumix.edit");
+    // The draft link is always available; the live entry is gated on publish.
+    await expect(page.getByTestId("plumix-preview-draft")).toBeVisible();
+    await expect(page.getByTestId("plumix-preview-live")).toBeVisible();
   });
 });
 

--- a/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
+++ b/packages/admin/src/routes/_editor/entries/$slug/$id/edit.tsx
@@ -21,6 +21,7 @@ import {
   getThemeBreakpoints,
   getThemeTokens,
 } from "@/lib/manifest.js";
+import { ENTRIES_LIST_DEFAULT_SEARCH } from "@/lib/entries.js";
 import { orpc } from "@/lib/orpc.js";
 import { getRegisteredBlocks } from "@/lib/plugin-registry.js";
 import { toastError, toastSuccess } from "@/lib/toast.js";
@@ -35,7 +36,7 @@ import {
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query";
-import { createFileRoute, notFound } from "@tanstack/react-router";
+import { createFileRoute, notFound, useNavigate } from "@tanstack/react-router";
 import * as v from "valibot";
 
 import type { EntryContent } from "@plumix/blocks";
@@ -251,7 +252,8 @@ function BespokeEditor({
   userId,
   onReseed,
 }: BespokeEditorProps): ReactNode {
-  const { id } = Route.useParams();
+  const { slug, id } = Route.useParams();
+  const navigate = useNavigate();
   const { data: entry } = useSuspenseQuery(
     orpc.entry.get.queryOptions({ input: { id, preview: true } }),
   );
@@ -454,11 +456,7 @@ function BespokeEditor({
   const documentPanel = useMemo(
     () => (
       <DocumentSettingsPanel
-        title={
-          supportsTitle
-            ? { value: titleValue, onChange: handleTitleChange }
-            : undefined
-        }
+        // Title now lives in the editor header, not the Page tab.
         slug={slugValue}
         onSlugChange={handleSlugChange}
         excerpt={
@@ -487,9 +485,6 @@ function BespokeEditor({
       />
     ),
     [
-      supportsTitle,
-      titleValue,
-      handleTitleChange,
       slugValue,
       handleSlugChange,
       supportsExcerpt,
@@ -696,6 +691,12 @@ function BespokeEditor({
   const shareUrl = target.toString();
   target.searchParams.set("plumix.edit", "");
 
+  // The published page is the preview URL without the draft token; surfaced as
+  // "View live entry" only once the entry has actually been published.
+  const liveTarget = new URL(previewLink.url, window.location.origin);
+  liveTarget.search = "";
+  const liveUrl = isPublished ? liveTarget.toString() : undefined;
+
   return (
     <PlumixEditor
       previewUrl={target.toString()}
@@ -707,6 +708,16 @@ function BespokeEditor({
       breakpoints={breakpoints}
       tokens={themeTokens}
       previewLink={shareUrl}
+      liveUrl={liveUrl}
+      title={supportsTitle ? titleValue : undefined}
+      onTitleChange={supportsTitle ? handleTitleChange : undefined}
+      onBack={() =>
+        void navigate({
+          to: "/entries/$slug",
+          params: { slug },
+          search: ENTRIES_LIST_DEFAULT_SEARCH,
+        })
+      }
       onChange={handleChange}
       documentPanel={documentPanel}
       publish={publishActions}


### PR DESCRIPTION
Restores the full-width editor header (regressed in #1133). It spans both side rails: the left holds a back button to the entry list and the inline-editable entry title (moved out of the Page tab); the right holds undo/redo, a preview menu, and the publish actions.

The preview menu (eye icon) replaces the old copy-link affordance with "View current draft" and "View live entry" — the latter disabled until the entry has been published once. The canvas toolbar slims to the rails toggle + Add Block on the left, with the device/zoom controls centered over the canvas.

shadcn's offcanvas `Sidebar` is `position: fixed; inset-y-0` (viewport-height), which would overlap a header above it — so the `SidebarProvider` gets `transform-gpu`, making it the containing block for the fixed rails so they span the area below the header instead of the whole viewport.

The admin route wires title/onTitleChange/back-navigation/live-permalink through new `PlumixEditor` props and drops the title from the Page-tab settings. The editor e2e is updated for the moved title and the new preview menu.

Verified live: header renders correctly with the rails below it, title edits inline, device/zoom centered.

Part of the editor visual-refinement pass (task #56). Covers the header (slice 1) and centered device/zoom (slice 2).