### PR TITLE
perf(blocks): ship a DOMPurify sanitizer to the browser editor bundle

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -25,6 +25,10 @@
       "default": "./dist/island-renderer.js"
     }
   },
+  "//browser": "Browser-only sanitizer swap. The editor + islands run in the DOM, where sanitize-html's bundled HTML parser + entity tables + postcss (~230 KB) are redundant; bundlers building for the browser remap it to the DOMPurify shim (~45 KB, native DOMParser). The worker/SSR build is DOM-less and keeps the real sanitize-html.",
+  "browser": {
+    "sanitize-html": "./dist/html/dompurify-shim.js"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "clean": "git clean -xdf .cache .turbo dist node_modules",
@@ -35,6 +39,7 @@
   },
   "dependencies": {
     "@tiptap/core": "catalog:tiptap",
+    "dompurify": "^3.4.11",
     "sanitize-html": "^2.17.5"
   },
   "peerDependencies": {

--- a/packages/blocks/src/html/dompurify-shim.test.ts
+++ b/packages/blocks/src/html/dompurify-shim.test.ts
@@ -1,0 +1,160 @@
+// The browser editor / islands bundle swaps `sanitize-html` for this
+// DOMPurify-backed shim (via this package's `browser` field). It MUST enforce
+// the same security guarantees as the server engine for the same allowlist —
+// these tests assert security *properties* rather than exact serialization,
+// since DOMPurify and sanitize-html emit byte-different (but security-
+// equivalent) markup.
+import { describe, expect, test } from "vitest";
+
+import sanitize from "./dompurify-shim.js";
+import { BASELINE_HTML_ALLOWLIST } from "./sanitize.js";
+
+// Mirror how `sanitizeHtml` normalizes the allowlist into the option shape the
+// engine (sanitize-html / this shim) consumes.
+const opts = {
+  allowedTags: [...BASELINE_HTML_ALLOWLIST.allowedTags],
+  allowedAttributes: Object.fromEntries(
+    Object.entries(BASELINE_HTML_ALLOWLIST.allowedAttributes).map(
+      ([tag, attrs]) => [tag, [...attrs]],
+    ),
+  ),
+  allowedSchemes: [...(BASELINE_HTML_ALLOWLIST.allowedSchemes ?? [])],
+  allowProtocolRelative: BASELINE_HTML_ALLOWLIST.allowProtocolRelative ?? false,
+};
+
+function run(raw: unknown): string {
+  return sanitize(raw, opts);
+}
+
+function parse(html: string): HTMLElement {
+  const el = document.createElement("div");
+  el.innerHTML = html;
+  return el;
+}
+
+describe("dompurify-shim — baseline allowlist parity", () => {
+  test("strips <script> tags AND their content", () => {
+    const out = run("<p>hi</p><script>alert(1)</script>");
+    expect(out).not.toMatch(/script/i);
+    expect(out).not.toContain("alert(1)");
+    expect(parse(out).querySelector("p")?.textContent).toBe("hi");
+  });
+
+  test("strips on* event-handler attributes", () => {
+    const a = parse(run('<a href="/x" onmouseover="evil()">x</a>'));
+    expect(a.querySelector("a")?.getAttribute("onmouseover")).toBeNull();
+    expect(a.querySelector("a")?.getAttribute("href")).toBe("/x");
+    const p = parse(run('<p onclick="alert(1)">hi</p>'));
+    expect(p.querySelector("p")?.getAttribute("onclick")).toBeNull();
+  });
+
+  test("strips javascript: and data: hrefs", () => {
+    for (const href of [
+      "javascript:alert(1)",
+      "data:text/html,<script>alert(1)</script>",
+    ]) {
+      const a = parse(run(`<a href="${href}">x</a>`)).querySelector("a");
+      expect(a).not.toBeNull();
+      expect(a?.getAttribute("href")).toBeNull();
+    }
+  });
+
+  test("strips case- / whitespace- / entity-obfuscated javascript: schemes", () => {
+    for (const href of [
+      "JaVaScRiPt:alert(1)",
+      "java\tscript:alert(1)",
+      "javas&#99;ript:alert(1)",
+      " javascript:alert(1)",
+    ]) {
+      const out = run(`<a href="${href}">x</a>`);
+      expect(out.toLowerCase()).not.toContain("javascript:");
+    }
+  });
+
+  test("strips protocol-relative hrefs (allowProtocolRelative: false)", () => {
+    const a = parse(run('<a href="//evil.example/x">x</a>')).querySelector("a");
+    expect(a?.getAttribute("href")).toBeNull();
+  });
+
+  test("preserves root-relative, fragment, and query-only hrefs", () => {
+    for (const href of ["/internal", "#section", "?page=2"]) {
+      const a = parse(run(`<a href="${href}">x</a>`)).querySelector("a");
+      expect(a?.getAttribute("href")).toBe(href);
+    }
+  });
+
+  test("strips target / rel from anchors", () => {
+    const a = parse(
+      run('<a href="https://x.example" target="_blank" rel="opener">x</a>'),
+    ).querySelector("a");
+    expect(a?.getAttribute("target")).toBeNull();
+    expect(a?.getAttribute("rel")).toBeNull();
+    expect(a?.getAttribute("href")).toBe("https://x.example");
+  });
+
+  test("enforces per-tag attributes (href only on <a>, not on <span>)", () => {
+    const span = parse(
+      run('<span href="https://evil.example">x</span>'),
+    ).querySelector("span");
+    expect(span?.getAttribute("href")).toBeNull();
+  });
+
+  test("strips data-* on <span>", () => {
+    const span = parse(
+      run('<span data-onclick="alert(1)" data-controller="evil">x</span>'),
+    ).querySelector("span");
+    expect(span?.attributes.length).toBe(0);
+  });
+
+  test("strips <iframe>, <object>, <embed>, <svg>, <math>", () => {
+    for (const html of [
+      '<iframe src="//evil"></iframe>hi',
+      '<object data="//evil"></object>hi',
+      '<embed src="//evil">hi',
+      "<svg><script>alert(1)</script></svg>hi",
+      '<math><mglyph href="javascript:alert(1)">x</mglyph></math>hi',
+    ]) {
+      const out = run(html);
+      expect(out).not.toMatch(/iframe|object|embed|svg|math|script/i);
+      expect(out.toLowerCase()).not.toContain("javascript");
+    }
+  });
+
+  test("strips non-allowlisted heading levels to text", () => {
+    for (const tag of ["h1", "h5", "h6"]) {
+      const out = run(`<${tag}>title</${tag}>`);
+      expect(out).not.toContain(`<${tag}`);
+      expect(parse(out).textContent).toBe("title");
+    }
+  });
+
+  test("strips <style> blocks and their content", () => {
+    const out = run(
+      "<style>body { background: url(javascript:alert(1)) }</style>hi",
+    );
+    expect(out).not.toMatch(/style/i);
+    expect(out).not.toContain("javascript");
+  });
+
+  test("preserves safe formatting, heading, and list structure", () => {
+    const safe = parse(
+      run(
+        '<h2>Title</h2><p><strong>Bold</strong> <em>i</em> <a href="https://example.com">l</a></p><ul><li>one</li></ul>',
+      ),
+    );
+    expect(safe.querySelector("h2")?.textContent).toBe("Title");
+    expect(safe.querySelector("strong")?.textContent).toBe("Bold");
+    expect(safe.querySelector("em")?.textContent).toBe("i");
+    expect(safe.querySelector("a")?.getAttribute("href")).toBe(
+      "https://example.com",
+    );
+    expect(safe.querySelector("li")?.textContent).toBe("one");
+  });
+
+  test("non-string and empty input returns empty string", () => {
+    expect(run(undefined)).toBe("");
+    expect(run(null)).toBe("");
+    expect(run(42)).toBe("");
+    expect(run("")).toBe("");
+  });
+});

--- a/packages/blocks/src/html/dompurify-shim.ts
+++ b/packages/blocks/src/html/dompurify-shim.ts
@@ -1,0 +1,119 @@
+import DOMPurify from "dompurify";
+
+/**
+ * Drop-in replacement for the subset of `sanitize-html` that `sanitizeHtml`
+ * (./sanitize.ts) calls. This package's `browser` field remaps `sanitize-html`
+ * to this module, so bundlers targeting the browser (the editor + islands
+ * chunks) ship DOMPurify (~45 KB, native DOMParser) instead of sanitize-html's
+ * pure-JS parser, the full HTML entity tables, and postcss (~230 KB). The
+ * worker/SSR build is DOM-less and keeps the real `sanitize-html`.
+ *
+ * Security parity is the contract: for a given allowlist this must enforce the
+ * same guarantees as the server engine — same tags, same per-tag attributes,
+ * same URL-scheme policy. Verified by dompurify-shim.test.ts against the same
+ * attack corpus as the server engine.
+ */
+interface SanitizeOptions {
+  readonly allowedTags?: readonly string[];
+  /** Per-tag attribute allowlist, keyed by lowercase tag name. */
+  readonly allowedAttributes?: Readonly<Record<string, readonly string[]>>;
+  readonly allowedSchemes?: readonly string[];
+  readonly allowProtocolRelative?: boolean;
+}
+
+const DEFAULT_SCHEMES = ["http", "https", "mailto", "tel"];
+
+// Attributes whose value is a URL and therefore subject to the scheme policy.
+// The per-tag allowlist already drops everything else; this is the set we
+// additionally scheme-check when an attribute IS allowed for its tag.
+const URI_ATTRS = new Set([
+  "href",
+  "src",
+  "action",
+  "formaction",
+  "xlink:href",
+  "poster",
+  "data",
+]);
+
+/**
+ * Mirror sanitize-html's URL policy: relative URLs (path / `#frag` / `?query`)
+ * pass; protocol-relative `//host` passes only when allowed; absolute URLs pass
+ * only when their scheme is allowlisted. The DOM has already entity-decoded the
+ * value, so obfuscation like `javas&#99;ript:` arrives as `javascript:`; we
+ * additionally strip control/whitespace chars browsers ignore so `java\tscript:`
+ * can't smuggle a scheme past the check.
+ */
+function isAllowedUri(
+  value: string,
+  schemes: readonly string[],
+  allowProtocolRelative: boolean,
+): boolean {
+  // eslint-disable-next-line no-control-regex -- strip C0 controls + space browsers ignore in URLs
+  const normalized = value.replace(/[\u0000-\u0020]+/g, "").toLowerCase();
+  if (normalized === "") return true;
+  if (normalized.startsWith("//")) return allowProtocolRelative;
+  const proto = /^([a-z][a-z0-9+.-]*):/.exec(normalized)?.[1];
+  if (proto === undefined) return true; // no scheme matched → relative URL
+  return schemes.includes(proto);
+}
+
+export default function sanitize(
+  dirty: unknown,
+  options: SanitizeOptions = {},
+): string {
+  if (typeof dirty !== "string" || dirty === "") return "";
+
+  const allowedTags = [...(options.allowedTags ?? [])];
+  const perTag = options.allowedAttributes ?? {};
+  const schemes = (options.allowedSchemes ?? DEFAULT_SCHEMES).map((s) =>
+    s.toLowerCase(),
+  );
+  const allowProtocolRelative = options.allowProtocolRelative ?? false;
+
+  // DOMPurify's ALLOWED_ATTR is a flat (tag-agnostic) set; the union here is
+  // only the coarse pass. The hook below does the authoritative per-tag check.
+  const attrUnion = new Set<string>();
+  const perTagLower: Record<string, Set<string>> = {};
+  for (const [tag, attrs] of Object.entries(perTag)) {
+    const set = new Set(attrs.map((a) => a.toLowerCase()));
+    perTagLower[tag.toLowerCase()] = set;
+    for (const a of set) attrUnion.add(a);
+  }
+
+  const hook = (
+    node: Element,
+    data: { attrName: string; attrValue: string; keepAttr: boolean },
+  ): void => {
+    const tag = node.tagName.toLowerCase();
+    const attr = data.attrName.toLowerCase();
+    const allowed = perTagLower[tag];
+    if (!allowed?.has(attr)) {
+      data.keepAttr = false;
+      return;
+    }
+    if (
+      URI_ATTRS.has(attr) &&
+      !isAllowedUri(data.attrValue, schemes, allowProtocolRelative)
+    ) {
+      data.keepAttr = false;
+    }
+  };
+
+  // The hook is global on the DOMPurify singleton. Safe because every caller
+  // runs this synchronously from React render and DOMPurify.sanitize is
+  // synchronous, so add → sanitize → remove is atomic; `finally` restores
+  // state even if a vector makes the hook throw. Don't call sanitizeHtml
+  // re-entrantly from inside a hook — that would tear down this registration.
+  DOMPurify.addHook("uponSanitizeAttribute", hook);
+  try {
+    return DOMPurify.sanitize(dirty, {
+      ALLOWED_TAGS: allowedTags,
+      ALLOWED_ATTR: [...attrUnion],
+      ALLOW_DATA_ATTR: false,
+      ALLOW_ARIA_ATTR: false,
+    });
+  } finally {
+    DOMPurify.removeHook("uponSanitizeAttribute");
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -698,6 +698,9 @@ importers:
       '@tiptap/core':
         specifier: catalog:tiptap
         version: 3.27.1(@tiptap/pm@3.23.4)
+      dompurify:
+        specifier: ^3.4.11
+        version: 3.4.11
       sanitize-html:
         specifier: ^2.17.5
         version: 2.17.5
@@ -4750,6 +4753,9 @@ packages:
   '@types/sanitize-html@2.16.1':
     resolution: {integrity: sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
@@ -5490,6 +5496,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -10614,6 +10623,9 @@ snapshots:
     dependencies:
       htmlparser2: 10.1.0
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/use-sync-external-store@0.0.6': {}
 
   '@types/whatwg-mimetype@3.0.2':
@@ -10871,7 +10883,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -11377,6 +11389,10 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.4.11:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:


### PR DESCRIPTION
The rich-text/html block renderers sanitize at render time in *both* the Cloudflare worker (SSR) and the browser (editor canvas + hydrated islands) through `sanitize-html`. To run DOM-less on the worker, sanitize-html bundles its own HTML parser, the full HTML entity tables, and postcss — ~230 KB the browser doesn't need, since it already ships a spec-compliant `DOMParser`.

This adds a DOMPurify-backed shim and remaps `sanitize-html` to it via the package's `browser` field, so browser builds (the editor + islands chunks) get DOMPurify (~45 KB) while the worker keeps the real `sanitize-html`. The editor chunk drops **1,294 → 1,090 KB raw (~80 KB gzip)**.

## Security is the contract, not an afterthought

The worker/SSR path — the durable trust boundary that protects *other* users from stored XSS — is byte-for-byte unchanged. Only the browser engine swaps, and it enforces the **same** guarantees as `sanitize-html` for a given allowlist:

- `ALLOWED_TAGS` from the allowlist; everything else stripped (svg/math/iframe/script removed, their script content dropped).
- An `uponSanitizeAttribute` hook does authoritative **per-tag** attribute enforcement (DOMPurify's flat `ALLOWED_ATTR` is only a coarse pre-pass) — `href` only on `<a>`, `data-language` only on `<code>`, all `on*`/`style`/`data-*` dropped.
- A URL scheme / protocol-relative policy mirroring sanitize-html's: blocks `javascript:`/`data:`/`vbscript:` (incl. case-, whitespace-, and entity-obfuscated forms) and protocol-relative `//host`; preserves relative/fragment/query hrefs.

Parity is covered by a 14-case attack corpus mirroring the server engine's `sanitize.test.ts`. The server suite (19 exact-output tests) is untouched and still green, confirming Node/SSR keeps sanitize-html.

## How the split is guaranteed safe

The worker has no DOM, so DOMPurify must never resolve into it. The `browser` field is only honored by Vite's `client` environment; `@cloudflare/vite-plugin`'s worker environment resolves with `["node","import"]` + `workerd` (no `browser` condition), so it's skipped there. Verified by build inspection of the blog example:

- **editor chunk** → contains DOMPurify, **no** `sanitize-html`/`entities`/`postcss`.
- **worker chunk** → contains `sanitize-html`, **no** DOMPurify.

Editor e2e (21) and public-render e2e (blog/pages/media) pass.

## Scope

This is one of two editor-size wins. The larger one — ~613 KB of `lucide-react` pulled in whole by a dynamic icon-by-name lookup, plus TipTap/ProseMirror optimization — is documented separately (see #1191 and the bundle-breakdown issue) and intentionally kept out of this security-sensitive change.

Refs #1191