### PR TITLE
perf: curate the editor icon set instead of bundling all of lucide

### DIFF
--- a/packages/admin-editor/src/block-icon.tsx
+++ b/packages/admin-editor/src/block-icon.tsx
@@ -1,18 +1,18 @@
-import type { ComponentType, ReactElement } from "react";
+import type { ReactElement } from "react";
 
-import * as LucideIcons from "@plumix/admin-ui/icons";
+import type { LucideIcon } from "@plumix/admin-ui/icons";
+import { blockIcons, fallbackBlockIcon } from "@plumix/admin-ui/icons";
 
-type IconComponent = ComponentType<{ readonly className?: string }>;
+// `blockIcons` has literal keys; widen to a string index so a runtime block
+// name can address it.
+const Icons: Record<string, LucideIcon> = blockIcons;
 
-// Blocks declare `icon` as a lucide name (e.g. "Heading"); resolve it off the
-// shared icon barrel so core and plugin blocks alike render their own glyph.
-const ICONS = LucideIcons as unknown as Record<
-  string,
-  IconComponent | undefined
->;
-const Fallback = ICONS.Square ?? (() => null);
-
-/** Renders a block's declared lucide icon, falling back to a generic square. */
+/**
+ * Renders a block's declared icon by its `icon: "Heading"` name, resolved
+ * against admin-ui's curated `blockIcons` map (the single owner of the set).
+ * Unknown names fall back to a generic square — that's the path a third-party
+ * block hits when it names an icon plumix doesn't ship.
+ */
 export function BlockIcon({
   name,
   className,
@@ -20,6 +20,6 @@ export function BlockIcon({
   readonly name?: string;
   readonly className?: string;
 }): ReactElement {
-  const Icon = (name ? ICONS[name] : undefined) ?? Fallback;
+  const Icon = (name ? Icons[name] : undefined) ?? fallbackBlockIcon;
   return <Icon className={className} />;
 }

--- a/packages/admin-ui/src/icons.ts
+++ b/packages/admin-ui/src/icons.ts
@@ -1,6 +1,138 @@
-// The shared icon set. Re-exports lucide-react so every consumer (admin,
-// admin-editor, themes) pulls icons from one place at one catalog-pinned
-// version, instead of each depending on lucide directly and drifting. lucide
-// ships per-icon ESM modules, so `export *` stays tree-shakeable — bundlers
-// keep only the icons a consumer actually imports.
-export * from "lucide-react";
+// The shared icon set — the single owner of which lucide icons ship in the
+// admin/editor bundle. We deliberately DON'T `export *`: a namespace re-export
+// plus the runtime name→component lookup in <BlockIcon> defeats tree-shaking
+// and pulls the entire ~3,900-icon library (~600 KB) into the editor chunk.
+// Instead every icon is named explicitly, so bundlers keep only these.
+//
+// Two access shapes, one curated list:
+//   1. Named re-exports below — `import { Trash2 } from "@plumix/admin-ui/icons"`
+//      for components that reference an icon statically. The compiler enforces
+//      this set: importing an un-exported icon is a build error.
+//   2. `blockIcons` — the name→component map <BlockIcon> resolves a block's
+//      `icon: "Heading"` string against, since that name is only known at
+//      runtime and can't be statically imported per-use.
+import type { LucideIcon } from "lucide-react";
+// Bindings for the blockIcons map (block-declared icons, resolved by string).
+import {
+  AlignLeft,
+  ChevronDown,
+  Code,
+  Columns,
+  File,
+  Group,
+  Heading,
+  Image,
+  Images,
+  List,
+  ListOrdered,
+  Megaphone,
+  Minus,
+  MousePointerClick,
+  Music,
+  Quote,
+  Rows,
+  Square,
+  Table,
+  Type,
+  Video,
+} from "lucide-react";
+
+export type { LucideIcon };
+
+// Statically-referenced icons (admin + admin-editor components).
+export {
+  AlertTriangle,
+  AlignCenter,
+  AlignLeft,
+  AlignRight,
+  ArrowDown,
+  ArrowLeft,
+  ArrowRight,
+  ArrowUp,
+  ArrowUpDown,
+  Bold,
+  Calendar,
+  Check,
+  ChevronDownIcon,
+  ChevronLeft,
+  ChevronRight,
+  ChevronsUpDown,
+  Code2,
+  Copy,
+  CornerLeftUp,
+  Eye,
+  EyeIcon,
+  FileText,
+  Folder,
+  Globe,
+  GripVertical,
+  Highlighter,
+  Image,
+  Italic,
+  Key,
+  Layout,
+  LayoutDashboard,
+  Link2,
+  Link2Icon,
+  List,
+  ListOrdered,
+  LogOut,
+  Mail,
+  MessageCircle,
+  MessageCircleMore,
+  Monitor,
+  Pencil,
+  Play,
+  Plus,
+  PlusIcon,
+  Puzzle,
+  Redo2,
+  RefreshCw,
+  RemoveFormatting,
+  Search,
+  Settings,
+  SettingsIcon,
+  Smartphone,
+  Square,
+  Strikethrough,
+  Tablet,
+  Tag,
+  Trash2,
+  TriangleAlert,
+  Tv,
+  Underline,
+  Undo2,
+  User,
+  UserPlus,
+  Users,
+  Watch,
+  ZoomIn,
+  ZoomOut,
+} from "lucide-react";
+
+// Block-declared icons. <BlockIcon> looks names up here at render time. Add an
+// entry when a block ships a new `icon: "..."`.
+export const blockIcons = {
+  AlignLeft,
+  ChevronDown,
+  Code,
+  Columns,
+  File,
+  Group,
+  Heading,
+  Image,
+  Images,
+  List,
+  ListOrdered,
+  Megaphone,
+  Minus,
+  MousePointerClick,
+  Music,
+  Quote,
+  Rows,
+  Table,
+  Type,
+  Video,
+} satisfies Record<string, LucideIcon>;
+
+export const fallbackBlockIcon = Square;


### PR DESCRIPTION
The editor chunk was dominated by icons, not the editor. `@plumix/admin-ui/icons` did `export * from "lucide-react"`, and `<BlockIcon>` resolved a block's `icon: "Heading"` string through a namespace import (`import * as LucideIcons` + `Icons[name]`) — a runtime lookup the bundler can't tree-shake, so all ~3,900 lucide icons shipped (**613 KB, 58% of the chunk**).

This makes admin-ui the single owner of an explicit icon set:
- **Named re-exports** for icons referenced statically (`import { Trash2 }`). The compiler enforces this set — importing an un-exported icon is now a build error, so the list can't silently rot.
- A **`blockIcons` name→component map** for the icons blocks declare by string. `<BlockIcon>` resolves against it and keeps its string-name API; unknown names fall back to a square (the path a third-party block hits when it names an icon plumix doesn't ship).

The editor maintains no icon list of its own — it consumes admin-ui's map.

## Benchmark (blog example editor chunk)

| | raw | gzip |
|---|---:|---:|
| before | 1,090,628 B | 303,418 B |
| after | 462,973 B | 146,127 B |
| **Δ** | **−627,655 B (−58%)** | **−157,291 B (−52%)** |

From the original pre-optimization baseline (before the sanitizer swap too) that's **1,294 → 463 KB, ~64% smaller**.

## Verification

- Whole-repo typecheck passes (every static icon import resolves) and a one-time cross-check confirmed all 20 `BlockSpec.icon` strings are present as `blockIcons` keys.
- 21 editor playground e2e + 477 blocks + 236 admin-editor unit tests pass.
- **Real-browser check** (fresh build, chrome-devtools): the editor renders every block's distinct glyph — Heading (H), Rich text (T), Quote, Separator, Code (`<>`), Table, Columns, Details, Callout (megaphone), Buttons/Button — and toolbar/chrome icons render too. Only the uncategorized playground block shows the intended `Square` fallback. No JS/module errors.

Item 2 of #1193 (item 1, the sanitizer, shipped in #1192).

Refs #1193