### PR TITLE
perf(admin-editor): drop starter-kit for an explicit tiptap extension set

### DIFF
--- a/packages/admin-editor/package.json
+++ b/packages/admin-editor/package.json
@@ -32,8 +32,13 @@
     "@plumix/blocks": "workspace:*",
     "@plumix/core": "workspace:*",
     "@tiptap/core": "catalog:tiptap",
+    "@tiptap/extension-document": "catalog:tiptap",
+    "@tiptap/extension-hard-break": "catalog:tiptap",
+    "@tiptap/extension-list": "catalog:tiptap",
+    "@tiptap/extension-paragraph": "catalog:tiptap",
+    "@tiptap/extension-text": "catalog:tiptap",
+    "@tiptap/extensions": "catalog:tiptap",
     "@tiptap/react": "catalog:tiptap",
-    "@tiptap/starter-kit": "catalog:tiptap",
     "zustand": "^5.0.14"
   },
   "peerDependencies": {

--- a/packages/admin-editor/src/rich-text-extensions.test.ts
+++ b/packages/admin-editor/src/rich-text-extensions.test.ts
@@ -5,8 +5,8 @@ import { richTextExtensions } from "./rich-text-extensions.js";
 
 describe("richTextExtensions", () => {
   // getSchema throws on a duplicate extension name, so a clean build proves the
-  // core marks and StarterKit's bundled marks don't collide.
-  test("builds one schema from StarterKit nodes + the core marks", () => {
+  // explicit nodes and the core marks don't collide.
+  test("builds one schema from the explicit nodes + the core marks", () => {
     const schema = getSchema([...richTextExtensions()]);
 
     expect(Object.keys(schema.marks)).toEqual(

--- a/packages/admin-editor/src/rich-text-extensions.ts
+++ b/packages/admin-editor/src/rich-text-extensions.ts
@@ -1,27 +1,54 @@
 import type { Extensions } from "@tiptap/core";
-import StarterKit from "@tiptap/starter-kit";
+import { Document } from "@tiptap/extension-document";
+import { HardBreak } from "@tiptap/extension-hard-break";
+import {
+  BulletList,
+  ListItem,
+  ListKeymap,
+  OrderedList,
+} from "@tiptap/extension-list";
+import { Paragraph } from "@tiptap/extension-paragraph";
+import { Text } from "@tiptap/extension-text";
+import {
+  Dropcursor,
+  Gapcursor,
+  TrailingNode,
+  UndoRedo,
+} from "@tiptap/extensions";
 
 import { coreMarkExtensions } from "@plumix/blocks";
 
 /**
- * Tiptap extensions for the rich-text rail: StarterKit's block nodes
- * (paragraph, lists, …) plus `@plumix/blocks`' 13 canonical marks. Headings are
- * disabled — structural headings are the dedicated Heading block, so rich text
- * stays prose-only. StarterKit's own marks are disabled so they don't
- * double-register with the shared core marks — the editor and the renderer then
- * speak the same mark vocabulary.
+ * Tiptap extensions for the rich-text rail. We import the exact set the body
+ * uses instead of `@tiptap/starter-kit`: StarterKit bundles ~16 extensions but
+ * we activated only these — the rest were either marks we replace with
+ * `@plumix/blocks`' shared marks (bold/italic/…) or nodes that are standalone
+ * blocks (heading, quote, code, separator). `configure({ bold: false })` would
+ * disable but still bundle them, so the explicit list is what actually drops
+ * them from the editor chunk.
+ *
+ * Kept (the set StarterKit had active here): document/paragraph/text (schema),
+ * hard break (shift-enter), bullet + ordered lists (toolbar buttons) with
+ * list-item + keymap, undo/redo (in-field history — the host toolbar bails
+ * inside contenteditable, so the field owns its own), drop/gap cursors, and the
+ * trailing node (keeps an empty paragraph after a trailing list so the caret
+ * can escape it). Marks come from `coreMarkExtensions` so the editor and
+ * renderer share one vocabulary.
  */
 export function richTextExtensions(): Extensions {
   return [
-    StarterKit.configure({
-      heading: false,
-      bold: false,
-      italic: false,
-      strike: false,
-      code: false,
-      link: false,
-      underline: false,
-    }),
+    Document,
+    Paragraph,
+    Text,
+    HardBreak,
+    BulletList,
+    OrderedList,
+    ListItem,
+    ListKeymap,
+    UndoRedo,
+    Dropcursor,
+    Gapcursor,
+    TrailingNode,
     ...coreMarkExtensions,
   ];
 }

--- a/packages/admin-editor/src/rich-text-field.tsx
+++ b/packages/admin-editor/src/rich-text-field.tsx
@@ -50,8 +50,9 @@ interface ActiveState {
 }
 
 /**
- * Right-rail rich-text editor: a Tiptap instance over StarterKit nodes + the
- * shared core marks, serializing to the HTML string the block stores and
+ * Right-rail rich-text editor: a Tiptap instance over the explicit node set
+ * (see richTextExtensions) + the shared core marks, serializing to the HTML
+ * string the block stores and
  * renders. The editor identity is stable — `useEditor` is created once and
  * external value changes are pushed in without emitting an update — so typing
  * never loses focus across the live patch loop's re-renders.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,10 +203,25 @@ catalogs:
     '@tiptap/core':
       specifier: ^3.27.1
       version: 3.27.1
-    '@tiptap/react':
+    '@tiptap/extension-document':
       specifier: ^3.27.1
       version: 3.27.1
-    '@tiptap/starter-kit':
+    '@tiptap/extension-hard-break':
+      specifier: ^3.27.1
+      version: 3.27.1
+    '@tiptap/extension-list':
+      specifier: ^3.27.1
+      version: 3.27.1
+    '@tiptap/extension-paragraph':
+      specifier: ^3.27.1
+      version: 3.27.1
+    '@tiptap/extension-text':
+      specifier: ^3.27.1
+      version: 3.27.1
+    '@tiptap/extensions':
+      specifier: ^3.27.1
+      version: 3.27.1
+    '@tiptap/react':
       specifier: ^3.27.1
       version: 3.27.1
   vite:
@@ -537,12 +552,27 @@ importers:
       '@tiptap/core':
         specifier: catalog:tiptap
         version: 3.27.1(@tiptap/pm@3.23.4)
+      '@tiptap/extension-document':
+        specifier: catalog:tiptap
+        version: 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/extension-hard-break':
+        specifier: catalog:tiptap
+        version: 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/extension-list':
+        specifier: catalog:tiptap
+        version: 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
+      '@tiptap/extension-paragraph':
+        specifier: catalog:tiptap
+        version: 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/extension-text':
+        specifier: catalog:tiptap
+        version: 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
+      '@tiptap/extensions':
+        specifier: catalog:tiptap
+        version: 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
       '@tiptap/react':
         specifier: catalog:tiptap
         version: 3.27.1(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tiptap/starter-kit':
-        specifier: catalog:tiptap
-        version: 3.27.1
       zustand:
         specifier: ^5.0.14
         version: 5.0.14(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
@@ -4517,47 +4547,16 @@ packages:
     peerDependencies:
       '@tiptap/pm': 3.23.4
 
-  '@tiptap/extension-blockquote@3.27.1':
-    resolution: {integrity: sha512-VMF7xJx6qEGiX6DTKNiL31NLqypOcd/4sNjFSe8rb41PwejBJh/nOqVIbBvWkiT6NMGFLxMhj7zJ8/zPo1hXeg==}
-    peerDependencies:
-      '@tiptap/core': 3.27.1
-
-  '@tiptap/extension-bold@3.27.1':
-    resolution: {integrity: sha512-TlC5bsS+pqETTrlz4CZz9RO/cKBYtELGIxwtKeivUn3eNfnOxQbbu4WDsiwIfzRFyd0OMnKl6BPM2KnYEehoEQ==}
-    peerDependencies:
-      '@tiptap/core': 3.27.1
-
   '@tiptap/extension-bubble-menu@3.27.1':
     resolution: {integrity: sha512-j/j8Qp9Z5nViade2m7zjrO/CYH/Ca80Qj7aqo0eUaei6FZQ5izlF9o4XQU5EFMAutV6mwynsPUp8FVo5sCuYfw==}
     peerDependencies:
       '@tiptap/core': 3.27.1
       '@tiptap/pm': 3.23.4
 
-  '@tiptap/extension-bullet-list@3.27.1':
-    resolution: {integrity: sha512-faCUHnRP47o9Zh9VZZX6EX/569udw9Vopm2PgEKPWuKLE2qaS5WBuUVU0iItdJmKUqaWiOZkpoW4jvnDmj0dfg==}
-    peerDependencies:
-      '@tiptap/extension-list': 3.27.1
-
-  '@tiptap/extension-code-block@3.27.1':
-    resolution: {integrity: sha512-pHlzmZx2OlHfyQ0yRlT5UL4mGokz947DthZuYefN1OleVqOkHpWBG+2JQwqoNq6bmzMne92zbH32rhcJUEYSjA==}
-    peerDependencies:
-      '@tiptap/core': 3.27.1
-      '@tiptap/pm': 3.23.4
-
-  '@tiptap/extension-code@3.27.1':
-    resolution: {integrity: sha512-epOUpFfEmBzjvnqvjv2qHX7NAuLo5dlOGV690lWu+sAYMjibuJBeVvAiKPyFCfRCCTUxdbDB3jbaOA1yEcEJ7w==}
-    peerDependencies:
-      '@tiptap/core': 3.27.1
-
   '@tiptap/extension-document@3.27.1':
     resolution: {integrity: sha512-8FbBTkfnRP4iVaoj+2h3iWa+H0eGDD3yTyVCwrmue/sQTkqUNUoSuAZa3GDG4Sd41xdPwTJxl9nUWGgM1qDCnw==}
     peerDependencies:
       '@tiptap/core': 3.27.1
-
-  '@tiptap/extension-dropcursor@3.27.1':
-    resolution: {integrity: sha512-blFf9x9RG0Qr7P3FoAH/033ffa+mMLZn34trVs8Vi0Ppk6FmJAg5HpYFOtmYoeREdNDJ5rHJKV7SoACbOHgskQ==}
-    peerDependencies:
-      '@tiptap/extensions': 3.27.1
 
   '@tiptap/extension-floating-menu@3.27.1':
     resolution: {integrity: sha512-BmJF1VqB7dSJkgAalrpVFj88WLhxKjcWPuWHOqf2ITrUU2832BhKLXKmxjWUy1gqV8PfNNVWtGfIERy7I0y0+Q==}
@@ -4566,47 +4565,10 @@ packages:
       '@tiptap/core': 3.27.1
       '@tiptap/pm': 3.23.4
 
-  '@tiptap/extension-gapcursor@3.27.1':
-    resolution: {integrity: sha512-QoezN0wdvXIwLQ4ee2ccWDaX3RG0lzgQpIMpMz55oPDhpUVax1+19ApsS53LkcktpS4EbnPL4xO4DaJk0Vp7PQ==}
-    peerDependencies:
-      '@tiptap/extensions': 3.27.1
-
   '@tiptap/extension-hard-break@3.27.1':
     resolution: {integrity: sha512-iv/m9hzl6jfSj9Q8UEjAxONvCoUDaP7M9SRCPx3PaLNxA230TTD6RE0Ye4zFJ8ze7ZVoJJMAqg9Qpq1iYg2JOQ==}
     peerDependencies:
       '@tiptap/core': 3.27.1
-
-  '@tiptap/extension-heading@3.27.1':
-    resolution: {integrity: sha512-SrC4l1kEIyv9ZXFaI/8LQqU2MyMmjczw7XXsWUQOTN4YXv0JyVgMNR3cI/wz0d2xsTfBdZ1N85Tdng+Ga1t0Sg==}
-    peerDependencies:
-      '@tiptap/core': 3.27.1
-
-  '@tiptap/extension-horizontal-rule@3.27.1':
-    resolution: {integrity: sha512-QlKE7qn5qMnIGVGhXQlvYedvLtNJ9z0dmit5w8vPb8tKzW4Spk6M7N2kruprrDA8GBwHfeR5wmF+njfUm34qxg==}
-    peerDependencies:
-      '@tiptap/core': 3.27.1
-      '@tiptap/pm': 3.23.4
-
-  '@tiptap/extension-italic@3.27.1':
-    resolution: {integrity: sha512-jGGeyn9uRUnNjSTHpbqhiGsp6KaYTSbV09jDXPJI9cDwfV9hpugLvpaCZd0BMBbhU1B1W6kOfX0BE15qX/HQfA==}
-    peerDependencies:
-      '@tiptap/core': 3.27.1
-
-  '@tiptap/extension-link@3.27.1':
-    resolution: {integrity: sha512-/2jBfsxBZUDGJmpZifqRQPz7f1E5qpS1BckTZ39TADzUJX+feKy7RJ3DtQ02+8y6SSMzvP9loGVjrk6zEMTk4g==}
-    peerDependencies:
-      '@tiptap/core': 3.27.1
-      '@tiptap/pm': 3.23.4
-
-  '@tiptap/extension-list-item@3.27.1':
-    resolution: {integrity: sha512-zwRl01ETfCkWUvtvK5fw9bXtAajMPkvlkE3Cq6JvH3LF7XXJwDtNj5Tj7exacMpCaSZmlNc43vFb2rAYnrnwMA==}
-    peerDependencies:
-      '@tiptap/extension-list': 3.27.1
-
-  '@tiptap/extension-list-keymap@3.27.1':
-    resolution: {integrity: sha512-OIMZNlzPSO8WRd4ic73Fxckzl4N1tesjjLL2XApaNA/uMpO0LoF6WSRPAWv+Z24Wp92ARRJAnRP7iZoI5+Jxig==}
-    peerDependencies:
-      '@tiptap/extension-list': 3.27.1
 
   '@tiptap/extension-list@3.27.1':
     resolution: {integrity: sha512-c2Upru7lj0/ZV/Ibww6cNz6sUS8m6Dp/9uygFhYcZOd3X8M0xBIEk42c6m6SQehkPziVA8QOgNJz7sMqsbz1OQ==}
@@ -4614,28 +4576,13 @@ packages:
       '@tiptap/core': 3.27.1
       '@tiptap/pm': 3.23.4
 
-  '@tiptap/extension-ordered-list@3.27.1':
-    resolution: {integrity: sha512-GYrKqD//9nHJ2r80uXqbDMzRnFpGzbaEQRTSGaO/SH7DvXWFMow8evkOdjQ7PCQO07jNjJo75+A85Jwu3Ov3AA==}
-    peerDependencies:
-      '@tiptap/extension-list': 3.27.1
-
   '@tiptap/extension-paragraph@3.27.1':
     resolution: {integrity: sha512-7K7eo1gruOgAsnbK+GCV23AUVUI0cL1bTig8HaPneoFMVbig7vddk8jNLKBWO8TXVbG7TuHdnDN4F98vdtwh5Q==}
     peerDependencies:
       '@tiptap/core': 3.27.1
 
-  '@tiptap/extension-strike@3.27.1':
-    resolution: {integrity: sha512-Y3DW1jlSlCNCyMGHP3+3qBNNPS83wuFz4RTYGjZtvRRTCRh7apZme9XRWMq1rN5mJ2Cr7fKocA2/5Bs13KgN6Q==}
-    peerDependencies:
-      '@tiptap/core': 3.27.1
-
   '@tiptap/extension-text@3.27.1':
     resolution: {integrity: sha512-6ZwaZwSrDh+KFFv6V1J79oO37yPs7y1bFxvk1/9Ih2rn3Xr5AWz+eMS+n8RpH3djBVVAQpdIAeYQgcn+VCSsTg==}
-    peerDependencies:
-      '@tiptap/core': 3.27.1
-
-  '@tiptap/extension-underline@3.27.1':
-    resolution: {integrity: sha512-N889J4nXN/TPfVt8uF9N1A0SY82E90zwc1y26lqOcw6KWNLmQrlhMh/9OD4ikLDbekmFpOBq/UicpHf/6S8hbQ==}
     peerDependencies:
       '@tiptap/core': 3.27.1
 
@@ -4657,9 +4604,6 @@ packages:
       '@types/react-dom': ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@tiptap/starter-kit@3.27.1':
-    resolution: {integrity: sha512-vfxRsqW8rCc0k4pzo0ilU3wobVi2wqVj88VZI2SlgZlNnUAkrDGDIAph7CTa9k9fshV+O1ivpEgPC5yC046jow==}
 
   '@turbo/darwin-64@2.9.18':
     resolution: {integrity: sha512-9f27peFu16ur8c0v9nUFUEyBnbKuuFsUTjHFWfmwGfzySBXbHwzU44QhZon6Mznz0cHsIr3984NQj/bVrnGSRw==}
@@ -6473,9 +6417,6 @@ packages:
 
   linkify-it@5.0.1:
     resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
-
-  linkifyjs@4.3.3:
-    resolution: {integrity: sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -10375,14 +10316,6 @@ snapshots:
     dependencies:
       '@tiptap/pm': 3.23.4
 
-  '@tiptap/extension-blockquote@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
-
-  '@tiptap/extension-bold@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
-
   '@tiptap/extension-bubble-menu@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)':
     dependencies:
       '@floating-ui/dom': 1.7.6
@@ -10390,26 +10323,9 @@ snapshots:
       '@tiptap/pm': 3.23.4
     optional: true
 
-  '@tiptap/extension-bullet-list@3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4))':
-    dependencies:
-      '@tiptap/extension-list': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
-
-  '@tiptap/extension-code-block@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
-      '@tiptap/pm': 3.23.4
-
-  '@tiptap/extension-code@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
-
   '@tiptap/extension-document@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))':
     dependencies:
       '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
-
-  '@tiptap/extension-dropcursor@3.27.1(@tiptap/extensions@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4))':
-    dependencies:
-      '@tiptap/extensions': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
 
   '@tiptap/extension-floating-menu@3.27.1(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)':
     dependencies:
@@ -10418,63 +10334,20 @@ snapshots:
       '@tiptap/pm': 3.23.4
     optional: true
 
-  '@tiptap/extension-gapcursor@3.27.1(@tiptap/extensions@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4))':
-    dependencies:
-      '@tiptap/extensions': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
-
   '@tiptap/extension-hard-break@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))':
     dependencies:
       '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
-
-  '@tiptap/extension-heading@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
-
-  '@tiptap/extension-horizontal-rule@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
-      '@tiptap/pm': 3.23.4
-
-  '@tiptap/extension-italic@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
-
-  '@tiptap/extension-link@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
-      '@tiptap/pm': 3.23.4
-      linkifyjs: 4.3.3
-
-  '@tiptap/extension-list-item@3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4))':
-    dependencies:
-      '@tiptap/extension-list': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
-
-  '@tiptap/extension-list-keymap@3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4))':
-    dependencies:
-      '@tiptap/extension-list': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
 
   '@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)':
     dependencies:
       '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
       '@tiptap/pm': 3.23.4
 
-  '@tiptap/extension-ordered-list@3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4))':
-    dependencies:
-      '@tiptap/extension-list': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
-
   '@tiptap/extension-paragraph@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))':
     dependencies:
       '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
 
-  '@tiptap/extension-strike@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
-
   '@tiptap/extension-text@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
-
-  '@tiptap/extension-underline@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))':
     dependencies:
       '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
 
@@ -10514,33 +10387,6 @@ snapshots:
       '@tiptap/extension-floating-menu': 3.27.1(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
     transitivePeerDependencies:
       - '@floating-ui/dom'
-
-  '@tiptap/starter-kit@3.27.1':
-    dependencies:
-      '@tiptap/core': 3.27.1(@tiptap/pm@3.23.4)
-      '@tiptap/extension-blockquote': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
-      '@tiptap/extension-bold': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
-      '@tiptap/extension-bullet-list': 3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4))
-      '@tiptap/extension-code': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
-      '@tiptap/extension-code-block': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
-      '@tiptap/extension-document': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
-      '@tiptap/extension-dropcursor': 3.27.1(@tiptap/extensions@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4))
-      '@tiptap/extension-gapcursor': 3.27.1(@tiptap/extensions@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4))
-      '@tiptap/extension-hard-break': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
-      '@tiptap/extension-heading': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
-      '@tiptap/extension-horizontal-rule': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
-      '@tiptap/extension-italic': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
-      '@tiptap/extension-link': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
-      '@tiptap/extension-list': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
-      '@tiptap/extension-list-item': 3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4))
-      '@tiptap/extension-list-keymap': 3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4))
-      '@tiptap/extension-ordered-list': 3.27.1(@tiptap/extension-list@3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4))
-      '@tiptap/extension-paragraph': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
-      '@tiptap/extension-strike': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
-      '@tiptap/extension-text': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
-      '@tiptap/extension-underline': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))
-      '@tiptap/extensions': 3.27.1(@tiptap/core@3.27.1(@tiptap/pm@3.23.4))(@tiptap/pm@3.23.4)
-      '@tiptap/pm': 3.23.4
 
   '@turbo/darwin-64@2.9.18':
     optional: true
@@ -12423,8 +12269,6 @@ snapshots:
   linkify-it@5.0.1:
     dependencies:
       uc.micro: 2.1.0
-
-  linkifyjs@4.3.3: {}
 
   locate-path@6.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -68,7 +68,17 @@ catalogs:
   tiptap:
     "@tiptap/core": ^3.27.1
     "@tiptap/react": ^3.27.1
-    "@tiptap/starter-kit": ^3.27.1
+    # Explicit extension set for the rich-text rail instead of starter-kit,
+    # which bundles ~16 extensions but we activate only these (the rest are
+    # disabled marks we replace with @plumix/blocks marks, or nodes that are
+    # standalone blocks). All pinned in lockstep with @tiptap/core so a single
+    # prosemirror/core copy is bundled.
+    "@tiptap/extension-document": ^3.27.1
+    "@tiptap/extension-hard-break": ^3.27.1
+    "@tiptap/extension-list": ^3.27.1
+    "@tiptap/extension-paragraph": ^3.27.1
+    "@tiptap/extension-text": ^3.27.1
+    "@tiptap/extensions": ^3.27.1
   orpc:
     "@orpc/client": ^1.14.6
     "@orpc/openapi": ^1.14.6


### PR DESCRIPTION
The rich-text rail imported `@tiptap/starter-kit`, which bundles ~16 extensions — but we activated only ~6. The rest were either marks we replace with `@plumix/blocks`' shared marks (bold, italic, strike, code, underline, link) or nodes that are standalone blocks in our system (heading, quote, code, separator). The catch: `configure({ bold: false })` *disables* an extension but still **bundles** its code, so the only way to actually drop them from the editor chunk is to stop importing StarterKit.

This imports the exact set the body uses: `Document`, `Paragraph`, `Text`, `HardBreak`, bullet + ordered lists (`BulletList`/`OrderedList`/`ListItem`/`ListKeymap`), `UndoRedo`, `Dropcursor`, `Gapcursor`, `TrailingNode` — i.e. everything StarterKit had active here — plus the shared `coreMarkExtensions`. The new extension packages go in the `tiptap` catalog in lockstep with `@tiptap/core` so a single prosemirror engine is bundled.

## Result

| | raw | gzip |
|---|---:|---:|
| before | 462,973 B | 146,127 B |
| after | 379,279 B | 117,948 B |
| **Δ** | **−83,694 B (−18%)** | **−28,179 B (−19%)** |

Single `@tiptap/core@3.27.1` + `@tiptap/pm@3.23.4` in the chunk (no duplicate engine).

## Why these and not StarterKit's marks

The marks are defined once in `@plumix/blocks` (`coreMarks`) and drive three consumers from one source: the editor schema, the **DOM-less SSR renderer**'s mark→tag map (`render-inline.tsx`, runs on the worker without ProseMirror), and richtext validation. StarterKit's Bold/Italic are editor-only and would drift from the renderer, so they're replaced, not used.

## Notes / verification

- `UndoRedo` is **kept** — the host toolbar's undo bails inside contenteditable, so the field owns its own history (removing it would break Cmd-Z in the rail).
- `TrailingNode` is **kept** for parity — StarterKit v3 enables it by default and our old `configure` left it on.
- Behavior unchanged: lint, 236 admin-editor unit tests, and 21 editor playground e2e (which exercise the rich-text rail: select block → bold/italic/lists/link/clear) all pass.

Item 3 of #1193. The remaining ~230 KB is the prosemirror engine itself — a follow-up could lazy-load the rich-text editor so that cost is deferred until a rich-text block is actually edited.

Refs #1193