### PR TITLE
perf: lazy-load the rich-text editor so the engine isn't in the editor shell

### DIFF
--- a/packages/admin-editor/src/block-input-control.test.tsx
+++ b/packages/admin-editor/src/block-input-control.test.tsx
@@ -152,13 +152,15 @@ describe("BlockInputControl", () => {
     expect(onChange).toHaveBeenCalledWith("custom");
   });
 
-  test("richtext renders the Tiptap toolbar and editable surface", () => {
-    const { getByTestId, queryByTestId } = renderControl(
+  test("richtext lazy-loads the Tiptap toolbar and editable surface", async () => {
+    const { findByTestId, getByTestId, queryByTestId } = renderControl(
       { name: "body", type: "richtext", label: "Body" },
       "<p>Hello</p>",
     );
-    // The toolbar's formatting controls and the contenteditable surface mount.
-    expect(getByTestId("block-input-body-bold")).toBeDefined();
+    // The editor (Tiptap + ProseMirror) is a lazy chunk; the skeleton shows
+    // until it resolves, then the toolbar + contenteditable surface mount.
+    expect(getByTestId("block-input-body-loading")).toBeDefined();
+    expect(await findByTestId("block-input-body-bold")).toBeDefined();
     expect(getByTestId("block-input-body-clear")).toBeDefined();
     // Headings are the dedicated Heading block, so rich text offers no h2–h4.
     expect(queryByTestId("block-input-body-h2")).toBeNull();

--- a/packages/admin-editor/src/block-input-control.tsx
+++ b/packages/admin-editor/src/block-input-control.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from "react";
-import { useId } from "react";
+import { lazy, Suspense, useId } from "react";
 import { useLingui } from "@lingui/react";
 
 import type { BlockInput, BlockInputOption } from "@plumix/blocks";
@@ -8,7 +8,11 @@ import { Input } from "@plumix/admin-ui/input";
 import { Label } from "@plumix/admin-ui/label";
 import { resolveLabel } from "@plumix/core/i18n";
 
-import { RichTextField } from "./rich-text-field.js";
+// Lazy so the Tiptap + ProseMirror engine (~230 KB) splits into its own chunk,
+// fetched only when a rich-text block is selected.
+const RichTextField = lazy(() =>
+  import("./rich-text-field.js").then((m) => ({ default: m.RichTextField })),
+);
 
 interface BlockInputControlProps {
   readonly input: BlockInput;
@@ -112,11 +116,13 @@ export function BlockInputControl({
         );
       case "richtext":
         return (
-          <RichTextField
-            value={asString(value)}
-            onChange={onChange}
-            testId={testId}
-          />
+          <Suspense fallback={<RichTextFieldSkeleton testId={testId} />}>
+            <RichTextField
+              value={asString(value)}
+              onChange={onChange}
+              testId={testId}
+            />
+          </Suspense>
         );
       case "combobox": {
         const listId = `${id}-list`;
@@ -157,6 +163,34 @@ export function BlockInputControl({
         {label}
       </Label>
       {control}
+    </div>
+  );
+}
+
+/**
+ * Placeholder shown while the lazy `RichTextField` chunk loads. Mirrors the
+ * field's footprint (toolbar row + content box + hint) so the panel doesn't
+ * jump when the real editor swaps in. Pure skeleton — no copy, so no new i18n.
+ */
+function RichTextFieldSkeleton({
+  testId,
+}: {
+  readonly testId: string;
+}): ReactElement {
+  return (
+    <div
+      className="flex flex-col gap-1.5"
+      data-testid={`${testId}-loading`}
+      aria-busy="true"
+    >
+      <div className="flex flex-wrap items-center gap-0.5">
+        {/* ~one placeholder per toolbar control (marks + lists + link + clear) */}
+        {Array.from({ length: 9 }, (_, i) => (
+          <div key={i} className="bg-muted size-8 animate-pulse rounded-md" />
+        ))}
+      </div>
+      <div className="border-input bg-muted/40 min-h-32 w-full animate-pulse rounded-md border" />
+      <div className="bg-muted h-3 w-48 animate-pulse rounded" />
     </div>
   );
 }

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "//sideEffects": "Everything is pure except the island runtime, which calls registerIslandElement() at module load and is imported purely for that side effect (import \"@plumix/blocks/island-runtime\"). Marking the rest side-effect-free lets bundlers drop unused barrel re-exports — notably the Tiptap mark/node schemas (unknownBlockSchema, coreMarkExtensions) so ProseMirror tree-shakes out of consumers that only use coreBlocks/render.",
+  "sideEffects": [
+    "**/island-runtime.js"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
The Tiptap + ProseMirror engine (~230 KB) loaded eagerly when the editor opened — but it's only needed when a rich-text block is actually selected. This defers it to its own chunk, fetched on first rich-text edit.

Two changes are required (the first alone isn't enough):

1. **`block-input-control`** — render `RichTextField` via `React.lazy` + `Suspense`, with a skeleton fallback that mirrors the field's footprint (toolbar row + content box + hint) so the inspector panel doesn't jump. `RichTextField` is the sole eager Tiptap import, so the dynamic import moves `@tiptap/react` + extensions behind the boundary.
2. **`@plumix/blocks` `sideEffects`** — was unset, so the bundler couldn't tree-shake unused barrel re-exports; `unknownBlockSchema` + `coreMarkExtensions` (both pull `@tiptap/core` → ProseMirror) stayed in the eager graph via the `coreBlocks` import. Setting `sideEffects: ["**/island-runtime.js"]` (the only module with a load-time effect — it registers the `<plumix-island>` custom element) lets ProseMirror move entirely into the lazy chunk.

## Result

| | raw | gzip |
|---|---:|---:|
| eager editor (before) | 379 KB | 118 KB |
| **eager editor (after)** | **~110 KB** | **~38 KB** |
| lazy rich-text chunk (on first edit) | 343 KB | 104 KB |

ProseMirror is confirmed absent from the editor entry's eager imports (only in the lazy `rich-text-field` chunk). The skeleton shows on the first rich-text edit, then the chunk caches.

## Verification

- Full test suite (44 tasks) and full e2e (39 tasks) pass — including plugin-media/blog **island hydration** (which exercises the `import "@plumix/blocks/island-runtime"` side effect end-to-end, proving the `sideEffects` list is correct) and the bespoke-editor rich-text rail.
- The richtext unit test now asserts the loading skeleton renders, then awaits the lazy editor.
- senpai confirmed the `sideEffects` scope is correct/sufficient and the lazy boundary is complete; SSR is unaffected (block-input-control is client-only).

## Cumulative (editor chunk, across #1192 / #1194 / #1195 / this)

Original **1,294 KB eager → ~110 KB eager** (the engine now loads on demand). The "300 KB for bold/italic" is now paid only when you actually edit rich text.

Closes #1193.