### PR TITLE
feat(admin-editor): free pan/zoom canvas (figma-style stage)

### DIFF
--- a/packages/admin-editor/e2e/editor-visual.spec.ts
+++ b/packages/admin-editor/e2e/editor-visual.spec.ts
@@ -387,6 +387,67 @@ test.describe("editor playground", () => {
     expect(desktop).toBe(1280);
   });
 
+  test("device switch keeps the frame centered and on-screen", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const container = page.getByTestId("plumix-canvas-frame");
+    const iframe = page.locator(CANVAS_FRAME);
+
+    // The thing this guards: a narrower device must re-land centered and fully
+    // visible, never pinned to a corner or pushed off-stage.
+    for (const device of ["mobile", "tablet", "desktop"]) {
+      await page.getByTestId(`plumix-device-${device}`).click();
+      const c = await container.boundingBox();
+      const f = await iframe.boundingBox();
+      expect(c && f).toBeTruthy();
+      if (!c || !f) continue;
+      // Within the viewport horizontally (allow 1px rounding).
+      expect(f.x).toBeGreaterThanOrEqual(c.x - 1);
+      expect(f.x + f.width).toBeLessThanOrEqual(c.x + c.width + 1);
+      // Centered: equal left/right margins.
+      const leftMargin = f.x - c.x;
+      const rightMargin = c.x + c.width - (f.x + f.width);
+      expect(Math.abs(leftMargin - rightMargin)).toBeLessThan(2);
+    }
+  });
+
+  test("wheel pans the canvas (no scrollbars, free stage)", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const iframe = page.locator(CANVAS_FRAME);
+    const before = await iframe.boundingBox();
+    expect(before).toBeTruthy();
+
+    await page.getByTestId("plumix-canvas-frame").hover();
+    await page.mouse.wheel(0, 240); // scroll down → content pans up
+
+    await expect
+      .poll(async () => (await iframe.boundingBox())?.y ?? 0)
+      .toBeLessThan((before?.y ?? 0) - 20);
+  });
+
+  test("zoom to selection (Shift+2) frames the active block", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const canvas = page.frameLocator(CANVAS_FRAME);
+    const overlay = page.getByTestId("plumix-overlay-selected");
+
+    // The heading sits at the top in fit mode; framing it should recenter it
+    // vertically. ("Shift+2" emits code "Digit2", which the handler keys off.)
+    await canvas.locator('[data-plumix-id="heading-1"]').click();
+    await expect(overlay).toBeVisible();
+    const before = await overlay.boundingBox();
+    expect(before).toBeTruthy();
+
+    await page.keyboard.press("Shift+2");
+    await expect
+      .poll(async () => (await overlay.boundingBox())?.y ?? 0)
+      .toBeGreaterThan((before?.y ?? 0) + 30);
+  });
+
   test("zoom controls show a percentage and re-fit to width", async ({
     page,
   }) => {

--- a/packages/admin-editor/src/canvas-frame.test.tsx
+++ b/packages/admin-editor/src/canvas-frame.test.tsx
@@ -1,9 +1,9 @@
 import type { ReactElement, ReactNode } from "react";
-import { useEffect } from "react";
+import { Profiler, useEffect } from "react";
 import { i18n } from "@lingui/core";
 import { I18nProvider } from "@lingui/react";
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
-import { afterEach, beforeAll, describe, expect, test } from "vitest";
+import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
 
 import type { BlockNode, BlockSpec } from "@plumix/blocks";
 import { createBlockRegistry } from "@plumix/blocks";
@@ -147,6 +147,78 @@ describe("CanvasFrame", () => {
     });
 
     expect(queryByTestId("plumix-selection-toolbar")).not.toBeNull();
+  });
+
+  test("a wheel burst pans live without a render or store commit per event", () => {
+    vi.useFakeTimers();
+    try {
+      let storeApi: ReturnType<typeof useEditorStoreApi> | undefined;
+      function Capture(): null {
+        const api = useEditorStoreApi();
+        useEffect(() => {
+          storeApi = api;
+        }, [api]);
+        return null;
+      }
+      let renders = 0;
+      const { container } = render(
+        <I18nProvider i18n={i18n}>
+          <EditorProvider>
+            <Profiler
+              id="cf"
+              onRender={() => {
+                renders++;
+              }}
+            >
+              <CanvasFrame
+                previewUrl="about:blank"
+                origin={ORIGIN}
+                registry={registry}
+                capabilities={NO_CAPS}
+              />
+            </Profiler>
+            <Capture />
+          </EditorProvider>
+        </I18nProvider>,
+      );
+      // A geometry report populates the container box the wheel handler needs.
+      fromCanvas({ type: "canvas:geometry", rects: [] });
+
+      const canvas = container.querySelector<HTMLElement>(
+        '[data-testid="plumix-canvas-frame"]',
+      );
+      const stage = canvas?.firstElementChild as HTMLElement;
+      const before = stage.style.transform;
+
+      renders = 0;
+      // A trackpad pan = a burst of wheel events.
+      act(() => {
+        for (let i = 0; i < 6; i++) {
+          canvas?.dispatchEvent(
+            new WheelEvent("wheel", {
+              deltaY: 20,
+              bubbles: true,
+              cancelable: true,
+            }),
+          );
+        }
+      });
+
+      // The transform moved live (imperative DOM write)...
+      expect(stage.style.transform).not.toBe(before);
+      // ...but the whole burst caused at most one render (the gesture-start
+      // flag), not one per event — and nothing committed to the store yet.
+      expect(renders).toBeLessThanOrEqual(1);
+      expect(storeApi?.getState().zoomFit).toBe(true);
+
+      // The store commits exactly once when the gesture settles.
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+      expect(storeApi?.getState().zoomFit).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("empty-state affordance inserts the first catalog block", () => {

--- a/packages/admin-editor/src/canvas-frame.tsx
+++ b/packages/admin-editor/src/canvas-frame.tsx
@@ -1,10 +1,17 @@
 import type { ReactElement } from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { Trans } from "@lingui/react";
 
 import type { BlockRegistry } from "@plumix/blocks";
 import type { BlockRect, SlotRect } from "@plumix/blocks/renderer";
 
+import type { View } from "./canvas-view.js";
 import type { FrameOffset, OverlayBox } from "./overlay.js";
 import {
   createNodeFromEntry,
@@ -109,6 +116,17 @@ export function CanvasFrame({
   // Space held → ready to pan-drag (grab cursor; the iframe goes click-through
   // so the host receives the drag).
   const [panReady, setPanReady] = useState(false);
+  // Live pan/zoom path. During a continuous gesture (wheel / space-drag) the
+  // transform is written straight to the stage DOM node and the live view is
+  // kept in a ref — zero React renders per frame. The store (canonical) is
+  // committed once when the gesture settles. `gesturing` only flips twice per
+  // gesture (start/end): it hides the overlays and switches the rendered
+  // transform to read the ref, so an incidental re-render can't clobber it.
+  const stageRef = useRef<HTMLDivElement>(null);
+  const liveViewRef = useRef<View>({ zoom, panX, panY });
+  const gesturingRef = useRef(false);
+  const [gesturing, setGesturing] = useState(false);
+  const commitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Latest key handler, so the bridge's forwarded keys (iframe focus) and the
   // window listener (shell focus) both reach the same logic without
   // re-subscribing the bridge.
@@ -140,10 +158,66 @@ export function CanvasFrame({
     };
   }, []);
 
-  // The free-canvas pan/zoom gesture, shared by the host's own wheel (over the
+  // Commit the live gesture view to the store (one render) and end the gesture.
+  const commitLive = useCallback((): void => {
+    if (commitTimerRef.current) {
+      clearTimeout(commitTimerRef.current);
+      commitTimerRef.current = null;
+    }
+    if (!gesturingRef.current) return;
+    gesturingRef.current = false;
+    setGesturing(false);
+    store.getState().setView(liveViewRef.current);
+  }, [store]);
+
+  // Apply a view live: write the transform straight to the DOM (no render),
+  // track it in the ref, and debounce a single commit when the gesture idles.
+  const applyLive = useCallback(
+    (view: View): void => {
+      liveViewRef.current = view;
+      const el = stageRef.current;
+      if (el) {
+        el.style.transform = `translate(${String(view.panX)}px, ${String(view.panY)}px) scale(${String(view.zoom)})`;
+      }
+      if (!gesturingRef.current) {
+        gesturingRef.current = true;
+        setGesturing(true);
+      }
+      if (commitTimerRef.current) clearTimeout(commitTimerRef.current);
+      commitTimerRef.current = setTimeout(commitLive, 150);
+    },
+    [commitLive],
+  );
+
+  // Keep the live ref in sync with the store between gestures, so discrete
+  // actions (toolbar zoom, device switch, shortcuts) seed the next gesture.
+  useEffect(() => {
+    if (!gesturingRef.current) liveViewRef.current = { zoom, panX, panY };
+  }, [zoom, panX, panY]);
+
+  // Don't leave a pending commit dangling on unmount.
+  useEffect(
+    () => () => {
+      if (commitTimerRef.current) clearTimeout(commitTimerRef.current);
+    },
+    [],
+  );
+
+  // While a gesture is live, re-assert the imperative transform after every
+  // render (before paint) so an incidental re-render can't flash the stale
+  // committed value. The per-frame writes happen in applyLive; this only covers
+  // renders. Runs every render by design — the body is a cheap no-op otherwise.
+  useLayoutEffect(() => {
+    if (gesturingRef.current && stageRef.current) {
+      const v = liveViewRef.current;
+      stageRef.current.style.transform = `translate(${String(v.panX)}px, ${String(v.panY)}px) scale(${String(v.zoom)})`;
+    }
+  });
+
+  // The free-canvas wheel gesture, shared by the host's own wheel (over the
   // margins) and the iframe-forwarded wheel (over the canvas). `cx/cy` are the
-  // cursor in container space. Reads live state so the bridge wiring stays
-  // subscribed once; scaled frame dims come straight off the iframe rect.
+  // cursor in container space; the base view is the live ref so consecutive
+  // events accumulate, and the iframe rect reflects the live transform.
   const handleWheel = useCallback(
     (
       deltaX: number,
@@ -156,7 +230,7 @@ export function CanvasFrame({
       const box = geometryRef.current.container;
       if (!iframe || !box) return;
       const rect = iframe.getBoundingClientRect();
-      const { panX, panY, zoom } = store.getState();
+      const { panX, panY, zoom } = liveViewRef.current;
       if (zoomIntent) {
         const nextZoom = clampZoom(zoom * Math.exp(-deltaY * 0.0015));
         if (nextZoom === zoom) return;
@@ -164,7 +238,7 @@ export function CanvasFrame({
         const view = zoomToCursor({ zoom, panX, panY }, nextZoom, cx, cy);
         const baseW = rect.width / zoom;
         const baseH = rect.height / zoom;
-        store.getState().setView({
+        applyLive({
           zoom: view.zoom,
           ...clampPanToFrame(
             view.panX,
@@ -176,18 +250,20 @@ export function CanvasFrame({
           ),
         });
       } else {
-        const p = clampPanToFrame(
-          panX - deltaX,
-          panY - deltaY,
-          rect.width,
-          rect.height,
-          box.width,
-          box.height,
-        );
-        store.getState().setPan(p.panX, p.panY);
+        applyLive({
+          zoom,
+          ...clampPanToFrame(
+            panX - deltaX,
+            panY - deltaY,
+            rect.width,
+            rect.height,
+            box.width,
+            box.height,
+          ),
+        });
       }
     },
-    [store],
+    [applyLive],
   );
 
   useEffect(() => {
@@ -393,9 +469,8 @@ export function CanvasFrame({
       dragging = true;
       startX = e.clientX;
       startY = e.clientY;
-      const s = store.getState();
-      startPanX = s.panX;
-      startPanY = s.panY;
+      startPanX = liveViewRef.current.panX;
+      startPanY = liveViewRef.current.panY;
     };
     const onPointerMove = (e: PointerEvent): void => {
       if (!dragging) return;
@@ -403,17 +478,21 @@ export function CanvasFrame({
       const iframe = iframeRef.current;
       if (!box || !iframe) return;
       const r = iframe.getBoundingClientRect();
-      const p = clampPanToFrame(
-        startPanX + (e.clientX - startX),
-        startPanY + (e.clientY - startY),
-        r.width,
-        r.height,
-        box.width,
-        box.height,
-      );
-      store.getState().setPan(p.panX, p.panY);
+      // Live (imperative) — no per-frame render.
+      applyLive({
+        zoom: liveViewRef.current.zoom,
+        ...clampPanToFrame(
+          startPanX + (e.clientX - startX),
+          startPanY + (e.clientY - startY),
+          r.width,
+          r.height,
+          box.width,
+          box.height,
+        ),
+      });
     };
     const onPointerUp = (): void => {
+      if (dragging) commitLive();
       dragging = false;
     };
     window.addEventListener("keydown", onKeyDown);
@@ -430,7 +509,7 @@ export function CanvasFrame({
       keyHandlerRef.current = null;
       exitPan();
     };
-  }, [store, zoomToSelection]);
+  }, [store, zoomToSelection, applyLive, commitLive]);
 
   // Canvas drag, shared by two sources: a catalog block being inserted
   // (dragSpec) and an existing block being moved (movingId). The iframe is
@@ -675,12 +754,16 @@ export function CanvasFrame({
           transform does the panning + zooming, and the overlays track it by
           re-reading the iframe's live on-screen rect. */}
       <div
+        ref={stageRef}
         style={{
           position: "absolute",
           top: 0,
           left: 0,
           width: frameWidth,
           height: contentHeight ?? CANVAS_HEIGHT,
+          // Committed transform. During a gesture the live transform is written
+          // imperatively (applyLive) and re-asserted after any incidental render
+          // by the layout effect below, so this stale value never paints.
           transform: `translate(${String(panX)}px, ${String(panY)}px) scale(${String(zoom)})`,
           transformOrigin: "top left",
         }}
@@ -718,8 +801,11 @@ export function CanvasFrame({
       </div>
       {/* Clip layer pinned over the visible canvas column. Its overflow:hidden
           keeps the absolutely-positioned overlays + toolbar from spilling onto
-          the side rails when the iframe renders wider than the column. */}
-      {!readOnly && container && (
+          the side rails when the iframe renders wider than the column. Hidden
+          mid-gesture: the overlays read stale geometry while the transform is
+          live, and re-measuring per frame is the cost we're avoiding. They snap
+          back on commit. */}
+      {!readOnly && container && !gesturing && (
         <div
           data-testid="plumix-overlay-clip"
           style={{

--- a/packages/admin-editor/src/canvas-frame.tsx
+++ b/packages/admin-editor/src/canvas-frame.tsx
@@ -12,6 +12,13 @@ import {
   slotAllowedBlocks,
 } from "./block-catalog.js";
 import { findBlock } from "./block-tree-ops.js";
+import {
+  clampPanToFrame,
+  clampZoom,
+  fitView,
+  frameSelection,
+  zoomToCursor,
+} from "./canvas-view.js";
 import { connectCanvas } from "./connect-canvas.js";
 import { dropPlacement } from "./drop-index.js";
 import { overlayBox } from "./overlay.js";
@@ -77,6 +84,8 @@ export function CanvasFrame({
   const loaderPushRef = useLoaderPushRef();
   const device = useEditorStore((s) => s.device);
   const zoom = useEditorStore((s) => s.zoom);
+  const panX = useEditorStore((s) => s.panX);
+  const panY = useEditorStore((s) => s.panY);
   const breakpoints = useEditorStore((s) => s.breakpoints);
   const zoomFit = useEditorStore((s) => s.zoomFit);
   const frameWidth = deviceWidth(device, breakpoints);
@@ -97,6 +106,15 @@ export function CanvasFrame({
   // Mirror geometry for the drag handler so it reads fresh rects without
   // re-subscribing the window listeners on every geometry report.
   const geometryRef = useRef<Geometry>(geometry);
+  // Space held → ready to pan-drag (grab cursor; the iframe goes click-through
+  // so the host receives the drag).
+  const [panReady, setPanReady] = useState(false);
+  // Latest key handler, so the bridge's forwarded keys (iframe focus) and the
+  // window listener (shell focus) both reach the same logic without
+  // re-subscribing the bridge.
+  const keyHandlerRef = useRef<
+    ((down: boolean, code: string, shiftKey: boolean) => void) | null
+  >(null);
   const [dropY, setDropY] = useState<number | null>(null);
   const [dropSlot, setDropSlot] = useState<SlotDrop | null>(null);
   // The iframe's own document height (same-origin), so the frame sizes to its
@@ -122,6 +140,56 @@ export function CanvasFrame({
     };
   }, []);
 
+  // The free-canvas pan/zoom gesture, shared by the host's own wheel (over the
+  // margins) and the iframe-forwarded wheel (over the canvas). `cx/cy` are the
+  // cursor in container space. Reads live state so the bridge wiring stays
+  // subscribed once; scaled frame dims come straight off the iframe rect.
+  const handleWheel = useCallback(
+    (
+      deltaX: number,
+      deltaY: number,
+      zoomIntent: boolean,
+      cx: number,
+      cy: number,
+    ): void => {
+      const iframe = iframeRef.current;
+      const box = geometryRef.current.container;
+      if (!iframe || !box) return;
+      const rect = iframe.getBoundingClientRect();
+      const { panX, panY, zoom } = store.getState();
+      if (zoomIntent) {
+        const nextZoom = clampZoom(zoom * Math.exp(-deltaY * 0.0015));
+        if (nextZoom === zoom) return;
+        // Zoom toward the cursor, then clamp so the frame stays reachable.
+        const view = zoomToCursor({ zoom, panX, panY }, nextZoom, cx, cy);
+        const baseW = rect.width / zoom;
+        const baseH = rect.height / zoom;
+        store.getState().setView({
+          zoom: view.zoom,
+          ...clampPanToFrame(
+            view.panX,
+            view.panY,
+            baseW * view.zoom,
+            baseH * view.zoom,
+            box.width,
+            box.height,
+          ),
+        });
+      } else {
+        const p = clampPanToFrame(
+          panX - deltaX,
+          panY - deltaY,
+          rect.width,
+          rect.height,
+          box.width,
+          box.height,
+        );
+        store.getState().setPan(p.panX, p.panY);
+      }
+    },
+    [store],
+  );
+
   useEffect(() => {
     const frameWindow = iframeRef.current?.contentWindow;
     if (!frameWindow) return;
@@ -141,6 +209,21 @@ export function CanvasFrame({
         // may have shifted too.
         measureContent();
       },
+      // Forwarded from the iframe: clientX/Y are iframe-local (unscaled), so the
+      // cursor in container space is the frame's pan offset plus the scaled
+      // local position.
+      onWheel: ({ deltaX, deltaY, zoomIntent, clientX, clientY }) => {
+        const { panX, panY, zoom } = store.getState();
+        handleWheel(
+          deltaX,
+          deltaY,
+          zoomIntent,
+          panX + clientX * zoom,
+          panY + clientY * zoom,
+        );
+      },
+      onKey: ({ down, code, shiftKey }) =>
+        keyHandlerRef.current?.(down, code, shiftKey),
     });
     // Expose the loader-data push to the inspector's refresh control.
     if (loaderPushRef) loaderPushRef.current = connection.pushLoaderData;
@@ -148,7 +231,7 @@ export function CanvasFrame({
       if (loaderPushRef) loaderPushRef.current = null;
       connection.dispose();
     };
-  }, [store, origin, measureHost, measureContent, loaderPushRef]);
+  }, [store, origin, measureHost, measureContent, loaderPushRef, handleWheel]);
 
   // Keep frame/container fresh when the canvas moves without a block report:
   // column scroll, window resize, and rail collapse (which resizes the inset).
@@ -174,21 +257,186 @@ export function CanvasFrame({
     };
   }, [measureHost]);
 
-  // Fit-to-width: while in fit mode, scale the frame so its full width fits the
-  // canvas column (never upscaling past 100%). A manual zoom turns fit off; a
-  // device switch turns it back on, so the new width refits.
+  // Fit-and-center: while in fit mode, scale the frame to the viewport width
+  // (never past 100%) AND center it. This is what a device switch lands on
+  // (setDevice re-enables fit), so the frame is always on-screen and centered
+  // instead of pinned to the top-left. A manual pan/zoom leaves fit mode.
+  const containerWidth = geometry.container?.width;
+  const containerHeight = geometry.container?.height;
   useEffect(() => {
-    if (!zoomFit) return;
-    const columnWidth = geometry.container?.width;
-    if (!columnWidth) return;
-    const fit = Math.min(1, columnWidth / frameWidth);
-    if (fit !== store.getState().zoom) store.getState().applyFitZoom(fit);
-  }, [zoomFit, frameWidth, geometry.container?.width, store]);
+    if (!zoomFit || !containerWidth || !containerHeight) return;
+    const next = fitView(
+      frameWidth,
+      contentHeight ?? CANVAS_HEIGHT,
+      containerWidth,
+      containerHeight,
+    );
+    const s = store.getState();
+    if (s.zoom !== next.zoom || s.panX !== next.panX || s.panY !== next.panY) {
+      s.applyFitView(next);
+    }
+  }, [
+    zoomFit,
+    frameWidth,
+    contentHeight,
+    containerWidth,
+    containerHeight,
+    store,
+  ]);
+
+  // The stage transform moves the iframe without firing scroll, so re-measure
+  // the frame/container rects after a pan/zoom paints — the overlays read the
+  // iframe's live on-screen box and must track it.
+  useEffect(() => {
+    const id = requestAnimationFrame(() => {
+      const next = { ...geometryRef.current, ...measureHost() };
+      geometryRef.current = next;
+      setGeometry(next);
+      // Keep the frame reachable after a manual zoom (e.g. the toolbar +/-,
+      // which zoom from the center and could otherwise drift it off-stage). The
+      // fit effect owns pan while in fit mode, so only clamp manual views.
+      const iframe = iframeRef.current;
+      const s = store.getState();
+      if (next.container && iframe && !s.zoomFit) {
+        const r = iframe.getBoundingClientRect();
+        const p = clampPanToFrame(
+          s.panX,
+          s.panY,
+          r.width,
+          r.height,
+          next.container.width,
+          next.container.height,
+        );
+        if (p.panX !== s.panX || p.panY !== s.panY) s.setPan(p.panX, p.panY);
+      }
+    });
+    return () => cancelAnimationFrame(id);
+  }, [panX, panY, zoom, frameWidth, contentHeight, measureHost, store]);
+
+  // Mirror the viewport size into the store so toolbar zoom-to-center has the
+  // dims it needs without reaching into the DOM.
+  useEffect(() => {
+    if (containerWidth && containerHeight) {
+      store.getState().setViewport(containerWidth, containerHeight);
+    }
+  }, [containerWidth, containerHeight, store]);
+
+  // Frame the active block in the viewport (Shift+2) — the move that makes a
+  // free canvas genuinely better for editing, not just nicer to look at.
+  const zoomToSelection = useCallback((): void => {
+    const s = store.getState();
+    const box = geometryRef.current.container;
+    const rect = s.activeId
+      ? geometryRef.current.rects.get(s.activeId)
+      : undefined;
+    if (!box || !rect || rect.width === 0 || rect.height === 0) return;
+    s.setView(frameSelection(rect, box.width, box.height));
+  }, [store]);
+
+  // Space-to-pan + view shortcuts. Keys arrive natively (shell focus) and
+  // forwarded from the iframe (canvas focus) — both routed through one handler.
+  useEffect(() => {
+    let spaceHeld = false;
+    let dragging = false;
+    let startX = 0;
+    let startY = 0;
+    let startPanX = 0;
+    let startPanY = 0;
+    // The iframe's click-through is owned declaratively by the render (it's
+    // none while a block drag OR a space-pan is active), so this just tracks
+    // the space state — no imperative pointerEvents toggling to desync.
+    const exitPan = (): void => {
+      spaceHeld = false;
+      dragging = false;
+      setPanReady(false);
+    };
+    const handleKey = (
+      down: boolean,
+      code: string,
+      shiftKey: boolean,
+    ): void => {
+      if (!down) {
+        if (code === "Space") exitPan();
+        return;
+      }
+      if (code === "Space") {
+        if (!spaceHeld) {
+          spaceHeld = true;
+          setPanReady(true);
+        }
+        return;
+      }
+      if (!shiftKey) return;
+      if (code === "Digit1") store.getState().enableZoomFit();
+      else if (code === "Digit2") zoomToSelection();
+      else if (code === "Digit0") store.getState().zoomToCenter(1);
+    };
+    keyHandlerRef.current = handleKey;
+
+    const isTyping = (t: EventTarget | null): boolean =>
+      t instanceof HTMLElement &&
+      (t.isContentEditable || /^(INPUT|TEXTAREA|SELECT)$/.test(t.tagName));
+    const isViewKey = (e: KeyboardEvent): boolean =>
+      e.code === "Space" ||
+      (e.shiftKey &&
+        (e.code === "Digit0" || e.code === "Digit1" || e.code === "Digit2"));
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (isTyping(e.target) || !isViewKey(e)) return;
+      if (e.code === "Space") e.preventDefault();
+      handleKey(true, e.code, e.shiftKey);
+    };
+    const onKeyUp = (e: KeyboardEvent): void => {
+      if (e.code === "Space") handleKey(false, e.code, false);
+    };
+    const onPointerDown = (e: PointerEvent): void => {
+      if (!spaceHeld) return;
+      dragging = true;
+      startX = e.clientX;
+      startY = e.clientY;
+      const s = store.getState();
+      startPanX = s.panX;
+      startPanY = s.panY;
+    };
+    const onPointerMove = (e: PointerEvent): void => {
+      if (!dragging) return;
+      const box = geometryRef.current.container;
+      const iframe = iframeRef.current;
+      if (!box || !iframe) return;
+      const r = iframe.getBoundingClientRect();
+      const p = clampPanToFrame(
+        startPanX + (e.clientX - startX),
+        startPanY + (e.clientY - startY),
+        r.width,
+        r.height,
+        box.width,
+        box.height,
+      );
+      store.getState().setPan(p.panX, p.panY);
+    };
+    const onPointerUp = (): void => {
+      dragging = false;
+    };
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("keyup", onKeyUp);
+    window.addEventListener("pointerdown", onPointerDown);
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerup", onPointerUp);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("keyup", onKeyUp);
+      window.removeEventListener("pointerdown", onPointerDown);
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", onPointerUp);
+      keyHandlerRef.current = null;
+      exitPan();
+    };
+  }, [store, zoomToSelection]);
 
   // Canvas drag, shared by two sources: a catalog block being inserted
-  // (dragSpec) and an existing block being moved (movingId). While dragging, the
-  // iframe ignores pointer events so the host keeps receiving them; the target
-  // is computed from the reported block + slot geometry mapped into screen space.
+  // (dragSpec) and an existing block being moved (movingId). The iframe is
+  // click-through while dragging (owned by the render) so the host receives the
+  // pointer events; the target is computed from the reported block + slot
+  // geometry mapped into screen space.
   useEffect(() => {
     const iframe = iframeRef.current;
     if (!iframe) return;
@@ -196,7 +444,6 @@ export function CanvasFrame({
       dragSpec?.name ??
       (movingId ? findBlock(store.getState().tree, movingId)?.name : undefined);
     if (!draggingName) return;
-    iframe.style.pointerEvents = "none";
 
     const endDrag = (): void => {
       if (dragSpec) store.getState().endBlockDrag();
@@ -335,7 +582,6 @@ export function CanvasFrame({
       window.removeEventListener("pointerup", onUp);
       window.removeEventListener("pointercancel", onCancel);
       window.removeEventListener("keydown", onKey);
-      iframe.style.pointerEvents = "";
       setDropY(null);
       setDropSlot(null);
     };
@@ -348,6 +594,27 @@ export function CanvasFrame({
       store.getState().insertBlock(createNodeFromEntry(registry, entry), 0);
     }
   }, [registry, capabilities, store]);
+
+  // Host-side wheel: pan/zoom when the cursor is over the margin around the
+  // frame. Over the iframe the gesture is forwarded via the bridge (onWheel
+  // above). Native + non-passive so we can preventDefault the page scroll.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent): void => {
+      e.preventDefault();
+      const box = el.getBoundingClientRect();
+      handleWheel(
+        e.deltaX,
+        e.deltaY,
+        e.ctrlKey || e.metaKey,
+        e.clientX - box.left,
+        e.clientY - box.top,
+      );
+    };
+    el.addEventListener("wheel", onWheel, { passive: false });
+    return () => el.removeEventListener("wheel", onWheel);
+  }, [handleWheel]);
 
   // Overlays live in a clip layer pinned over the canvas viewport, so their
   // boxes are expressed relative to that layer's top-left (the container's
@@ -390,24 +657,32 @@ export function CanvasFrame({
     <div
       ref={containerRef}
       data-testid="plumix-canvas-frame"
-      // A neutral surface (not the shell's near-black) shows around the framed
-      // page — the device width is narrower than the column and a short page
-      // ends above the fold. `var(--muted)` reads as canvas, not a void.
+      // A Figma-style pannable stage: the device frame floats in this surface
+      // and is panned/zoomed via a transform (no scrollbars). `overflow:hidden`
+      // clips the off-stage frame; `touch-action:none` lets us own wheel/touch
+      // gestures. `var(--muted)` reads as canvas, not a void.
       style={{
         position: "relative",
         flex: 1,
-        overflow: "auto",
+        overflow: "hidden",
+        touchAction: "none",
         background: "var(--muted)",
+        cursor: panReady ? "grab" : "default",
       }}
     >
-      {/* `transform: scale()` shrinks the iframe visually but not its layout
-          box, so a wrapper sized to the SCALED dimensions keeps the scroll area
-          flush with the page — otherwise the surface shows below/right of the
-          zoomed-out frame as dead space. */}
+      {/* The stage: positioned at the container origin and moved as a whole by
+          `translate(pan) scale(zoom)`. The iframe sits at natural size; the
+          transform does the panning + zooming, and the overlays track it by
+          re-reading the iframe's live on-screen rect. */}
       <div
         style={{
-          width: frameWidth * zoom,
-          height: (contentHeight ?? CANVAS_HEIGHT) * zoom,
+          position: "absolute",
+          top: 0,
+          left: 0,
+          width: frameWidth,
+          height: contentHeight ?? CANVAS_HEIGHT,
+          transform: `translate(${String(panX)}px, ${String(panY)}px) scale(${String(zoom)})`,
+          transformOrigin: "top left",
         }}
       >
         <iframe
@@ -420,10 +695,26 @@ export function CanvasFrame({
             width: frameWidth,
             height: contentHeight ?? CANVAS_HEIGHT,
             border: 0,
-            transform: `scale(${String(zoom)})`,
-            transformOrigin: "top left",
+            // Click-through while a block drag or a space-pan is active so the
+            // host receives the pointer events. Single declarative owner — no
+            // imperative toggling that could desync across the two gestures.
+            pointerEvents:
+              dragSpec || movingId || panReady ? "none" : undefined,
           }}
         />
+        {/* Inside the stage so it sits on the frame (and pans/zooms with it),
+            rather than floating over the container now that the frame is
+            centered/pannable. */}
+        {!readOnly && isEmpty && (
+          <button
+            type="button"
+            data-testid="plumix-empty-add"
+            onClick={addFirstBlock}
+            className="border-muted-foreground/40 text-muted-foreground hover:bg-accent absolute inset-x-8 top-8 rounded-md border border-dashed p-6 text-sm"
+          >
+            <Trans id="editor.canvas.addBlock" message="Add a block" />
+          </button>
+        )}
       </div>
       {/* Clip layer pinned over the visible canvas column. Its overflow:hidden
           keeps the absolutely-positioned overlays + toolbar from spilling onto
@@ -482,18 +773,6 @@ export function CanvasFrame({
             />
           )}
         </div>
-      )}
-      {/* Stays visible during a drag so an empty canvas still shows a drop
-          target (no block geometry exists to draw an indicator against). */}
-      {!readOnly && isEmpty && (
-        <button
-          type="button"
-          data-testid="plumix-empty-add"
-          onClick={addFirstBlock}
-          className="border-muted-foreground/40 text-muted-foreground hover:bg-accent absolute inset-x-8 top-8 rounded-md border border-dashed p-6 text-sm"
-        >
-          <Trans id="editor.canvas.addBlock" message="Add a block" />
-        </button>
       )}
     </div>
   );

--- a/packages/admin-editor/src/canvas-view.test.ts
+++ b/packages/admin-editor/src/canvas-view.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  clampPan,
+  clampPanToFrame,
+  clampZoom,
+  fitView,
+  frameSelection,
+  MAX_ZOOM,
+  MIN_ZOOM,
+  zoomToCursor,
+} from "./canvas-view.js";
+
+describe("clampZoom", () => {
+  test("clamps to the allowed range", () => {
+    expect(clampZoom(99)).toBe(MAX_ZOOM);
+    expect(clampZoom(0)).toBe(MIN_ZOOM);
+    expect(clampZoom(1)).toBe(1);
+  });
+});
+
+describe("clampPan", () => {
+  test("keeps a frame narrower than the viewport on-screen", () => {
+    // 300px frame in a 1000px viewport: pan can range from a sliver visible on
+    // the right (64 - 300) to a sliver on the left (1000 - 64).
+    expect(clampPan(-9999, 300, 1000)).toBe(64 - 300);
+    expect(clampPan(9999, 300, 1000)).toBe(1000 - 64);
+    expect(clampPan(350, 300, 1000)).toBe(350);
+  });
+
+  test("keeps a frame wider than the viewport reachable from both edges", () => {
+    // 2000px frame in an 800px viewport.
+    expect(clampPan(-9999, 2000, 800)).toBe(64 - 2000);
+    expect(clampPan(9999, 2000, 800)).toBe(800 - 64);
+  });
+});
+
+describe("clampPanToFrame", () => {
+  test("clamps both axes against the scaled frame and viewport", () => {
+    // 300x200 frame in a 1000x800 viewport, pushed hard past both edges.
+    const p = clampPanToFrame(9999, -9999, 300, 200, 1000, 800);
+    expect(p.panX).toBe(1000 - 64);
+    expect(p.panY).toBe(64 - 200);
+  });
+});
+
+describe("fitView", () => {
+  test("centers a narrow frame and never upscales past 100%", () => {
+    // 375px frame, 600px tall content, 1000x800 viewport.
+    const v = fitView(375, 600, 1000, 800);
+    expect(v.zoom).toBe(1); // min(1, 1000/375) capped at 1
+    expect(v.panX).toBe(Math.round((1000 - 375) / 2)); // centered horizontally
+    expect(v.panY).toBe(Math.round((800 - 600) / 2)); // centered (content fits)
+  });
+
+  test("fits a wide frame to width and gives a top margin when it's tall", () => {
+    // 1280px frame, 4000px tall, 700px viewport: fit zoom < 1, content taller
+    // than viewport → top margin rather than vertical centering.
+    const v = fitView(1280, 4000, 700, 800);
+    expect(v.zoom).toBeCloseTo(700 / 1280, 5);
+    expect(v.panX).toBe(0); // scaledW === viewport width → no horizontal slack
+    expect(v.panY).toBe(32); // FIT_MARGIN_Y top margin
+  });
+});
+
+describe("zoomToCursor", () => {
+  test("keeps the world point under the cursor fixed", () => {
+    // At zoom 1, pan 0, the cursor at (200,100) is over world (200,100).
+    const v = zoomToCursor({ zoom: 1, panX: 0, panY: 0 }, 2, 200, 100);
+    expect(v.zoom).toBe(2);
+    // After zooming, that same world point must still sit under the cursor:
+    // screen = pan + world*zoom === cursor.
+    expect(v.panX + 200 * v.zoom).toBe(200);
+    expect(v.panY + 100 * v.zoom).toBe(100);
+  });
+
+  test("clamps the target zoom", () => {
+    expect(zoomToCursor({ zoom: 1, panX: 0, panY: 0 }, 99, 0, 0).zoom).toBe(
+      MAX_ZOOM,
+    );
+  });
+});
+
+describe("frameSelection", () => {
+  test("centers the block and fits it within the viewport padding", () => {
+    // A 200x100 block at (300,400) in a 1000x800 viewport.
+    const v = frameSelection(
+      { x: 300, y: 400, width: 200, height: 100 },
+      1000,
+      800,
+    );
+    // Largest zoom fitting the block with 85% padding, capped at MAX_ZOOM.
+    expect(v.zoom).toBe(MAX_ZOOM);
+    // Block center (400,450) lands at the viewport center (500,400).
+    expect(v.panX + 400 * v.zoom).toBe(500);
+    expect(v.panY + 450 * v.zoom).toBe(400);
+  });
+});

--- a/packages/admin-editor/src/canvas-view.ts
+++ b/packages/admin-editor/src/canvas-view.ts
@@ -1,0 +1,110 @@
+// Pure view math for the free canvas (no React, no store) — the device frame
+// floats in a Figma-style pannable/zoomable stage. Kept here so both the store
+// (toolbar zoom-to-center) and the canvas component (wheel, fit, zoom-to-
+// selection) share one tested implementation, and so the geometry is unit-
+// testable without a layout engine.
+
+export const MIN_ZOOM = 0.25;
+export const MAX_ZOOM = 2;
+// Keep at least this much of the frame inside the viewport so it can't be
+// panned into the void, and fit with this much top breathing room.
+const MIN_VISIBLE = 64;
+const FIT_MARGIN_Y = 32;
+// Zoom-to-selection leaves this fraction of the viewport as padding around the
+// framed block.
+const SELECTION_FIT = 0.85;
+
+/** The canvas viewport transform: the frame's top-left offset + scale. */
+export interface View {
+  readonly zoom: number;
+  readonly panX: number;
+  readonly panY: number;
+}
+
+export const clampZoom = (z: number): number =>
+  Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, z));
+
+/** Clamp a pan offset so `MIN_VISIBLE` px of the (scaled) frame stay inside the
+ *  viewport — the frame can always be grabbed back. */
+export function clampPan(
+  pan: number,
+  scaled: number,
+  viewport: number,
+): number {
+  return Math.min(viewport - MIN_VISIBLE, Math.max(MIN_VISIBLE - scaled, pan));
+}
+
+/** Clamp a candidate pan on both axes against the scaled frame size and the
+ *  viewport box — every pan/zoom gesture lands here so the frame stays
+ *  grabbable. */
+export function clampPanToFrame(
+  panX: number,
+  panY: number,
+  scaledW: number,
+  scaledH: number,
+  vw: number,
+  vh: number,
+): { readonly panX: number; readonly panY: number } {
+  return {
+    panX: clampPan(panX, scaledW, vw),
+    panY: clampPan(panY, scaledH, vh),
+  };
+}
+
+/** Center the frame in the viewport at a never-upscaled fit-to-width zoom (top
+ *  margin when it's taller than the viewport). What a device switch and "fit"
+ *  both land on, so the frame is always on-screen, never pinned top-left. */
+export function fitView(
+  frameWidth: number,
+  contentHeight: number,
+  vw: number,
+  vh: number,
+): View {
+  const zoom = clampZoom(Math.min(1, vw / frameWidth));
+  const scaledH = contentHeight * zoom;
+  return {
+    zoom,
+    panX: Math.round((vw - frameWidth * zoom) / 2),
+    panY: Math.round(scaledH < vh ? (vh - scaledH) / 2 : FIT_MARGIN_Y),
+  };
+}
+
+/** Zoom to `nextZoom` keeping the world point under `(cx, cy)` (viewport space)
+ *  fixed — used for both wheel zoom-to-cursor and toolbar zoom-to-center. */
+export function zoomToCursor(
+  view: View,
+  nextZoom: number,
+  cx: number,
+  cy: number,
+): View {
+  const zoom = clampZoom(nextZoom);
+  const wx = (cx - view.panX) / view.zoom;
+  const wy = (cy - view.panY) / view.zoom;
+  return { zoom, panX: cx - wx * zoom, panY: cy - wy * zoom };
+}
+
+/** Frame a block: the largest zoom that fits its rect (with padding) inside the
+ *  viewport, panned so the block is centered. `rect` is in the frame's unscaled
+ *  coordinate space. */
+export function frameSelection(
+  rect: {
+    readonly x: number;
+    readonly y: number;
+    readonly width: number;
+    readonly height: number;
+  },
+  vw: number,
+  vh: number,
+): View {
+  const zoom = clampZoom(
+    Math.min(
+      (vw * SELECTION_FIT) / rect.width,
+      (vh * SELECTION_FIT) / rect.height,
+    ),
+  );
+  return {
+    zoom,
+    panX: vw / 2 - (rect.x + rect.width / 2) * zoom,
+    panY: vh / 2 - (rect.y + rect.height / 2) * zoom,
+  };
+}

--- a/packages/admin-editor/src/connect-canvas.test.ts
+++ b/packages/admin-editor/src/connect-canvas.test.ts
@@ -56,6 +56,62 @@ describe("connectCanvas", () => {
     conn.dispose();
   });
 
+  test("a canvas:wheel message is delivered to onWheel", () => {
+    const store = createEditorStore();
+    const { win } = fakeFrame();
+    const onWheel = vi.fn();
+    const conn = connectCanvas({
+      store,
+      frameWindow: win,
+      origin: ORIGIN,
+      onWheel,
+    });
+
+    fromCanvas({
+      type: "canvas:wheel",
+      deltaX: 1,
+      deltaY: -8,
+      zoomIntent: true,
+      clientX: 50,
+      clientY: 60,
+    });
+
+    expect(onWheel).toHaveBeenCalledWith({
+      deltaX: 1,
+      deltaY: -8,
+      zoomIntent: true,
+      clientX: 50,
+      clientY: 60,
+    });
+    conn.dispose();
+  });
+
+  test("a canvas:key message is delivered to onKey", () => {
+    const store = createEditorStore();
+    const { win } = fakeFrame();
+    const onKey = vi.fn();
+    const conn = connectCanvas({
+      store,
+      frameWindow: win,
+      origin: ORIGIN,
+      onKey,
+    });
+
+    fromCanvas({
+      type: "canvas:key",
+      down: true,
+      code: "Space",
+      shiftKey: false,
+    });
+
+    expect(onKey).toHaveBeenCalledWith({
+      down: true,
+      code: "Space",
+      shiftKey: false,
+    });
+    conn.dispose();
+  });
+
   test("an additive canvas:select extends the selection set", () => {
     const store = createEditorStore();
     const { win } = fakeFrame();

--- a/packages/admin-editor/src/connect-canvas.ts
+++ b/packages/admin-editor/src/connect-canvas.ts
@@ -34,6 +34,21 @@ interface ConnectCanvasOptions {
     rects: readonly BlockRect[],
     slots: readonly SlotRect[],
   ) => void;
+  /** A wheel/trackpad gesture over the canvas, forwarded from the iframe so the
+   *  host can pan/zoom the free canvas. clientX/Y are iframe-local. */
+  readonly onWheel?: (wheel: {
+    readonly deltaX: number;
+    readonly deltaY: number;
+    readonly zoomIntent: boolean;
+    readonly clientX: number;
+    readonly clientY: number;
+  }) => void;
+  /** A canvas-view key, forwarded so pan/zoom shortcuts work over the iframe. */
+  readonly onKey?: (key: {
+    readonly down: boolean;
+    readonly code: string;
+    readonly shiftKey: boolean;
+  }) => void;
 }
 
 // The iframe runtime usually boots after the parent mounts, so a single hello
@@ -49,6 +64,8 @@ export function connectCanvas({
   frameWindow,
   origin,
   onGeometry,
+  onWheel,
+  onKey,
 }: ConnectCanvasOptions): CanvasConnection {
   const post = (message: object): void => {
     frameWindow.postMessage(encode(EDITOR_BRIDGE_CHANNEL, message), origin);
@@ -87,6 +104,22 @@ export function connectCanvas({
         break;
       case "canvas:geometry":
         onGeometry?.(canvas.rects, canvas.slots ?? []);
+        break;
+      case "canvas:wheel":
+        onWheel?.({
+          deltaX: canvas.deltaX,
+          deltaY: canvas.deltaY,
+          zoomIntent: canvas.zoomIntent,
+          clientX: canvas.clientX,
+          clientY: canvas.clientY,
+        });
+        break;
+      case "canvas:key":
+        onKey?.({
+          down: canvas.down,
+          code: canvas.code,
+          shiftKey: canvas.shiftKey,
+        });
         break;
     }
   };

--- a/packages/admin-editor/src/connect-runtime.test.ts
+++ b/packages/admin-editor/src/connect-runtime.test.ts
@@ -95,6 +95,46 @@ describe("connectRuntime (canvas/iframe side)", () => {
     conn.dispose();
   });
 
+  test("reportWheel posts canvas:wheel to the host", () => {
+    const { win, posted } = fakeParent();
+    const conn = connectRuntime({
+      parentWindow: win,
+      origin: ORIGIN,
+      onTree: () => undefined,
+    });
+
+    conn.reportWheel(4, -12, true, 100, 200);
+
+    expect(messages(posted)).toContainEqual({
+      type: "canvas:wheel",
+      deltaX: 4,
+      deltaY: -12,
+      zoomIntent: true,
+      clientX: 100,
+      clientY: 200,
+    });
+    conn.dispose();
+  });
+
+  test("reportKey posts canvas:key to the host", () => {
+    const { win, posted } = fakeParent();
+    const conn = connectRuntime({
+      parentWindow: win,
+      origin: ORIGIN,
+      onTree: () => undefined,
+    });
+
+    conn.reportKey(true, "Space", false);
+
+    expect(messages(posted)).toContainEqual({
+      type: "canvas:key",
+      down: true,
+      code: "Space",
+      shiftKey: false,
+    });
+    conn.dispose();
+  });
+
   test("ignores host messages from a foreign origin", () => {
     const seen: (readonly BlockNode[])[] = [];
     const { win } = fakeParent();

--- a/packages/admin-editor/src/connect-runtime.ts
+++ b/packages/admin-editor/src/connect-runtime.ts
@@ -21,6 +21,18 @@ export interface RuntimeConnection {
     rects: readonly BlockRect[],
     slots?: readonly SlotRect[],
   ) => void;
+  /** Forward a wheel/trackpad gesture to the host so it can pan/zoom the free
+   *  canvas. clientX/Y are iframe-local pointer coords. */
+  readonly reportWheel: (
+    deltaX: number,
+    deltaY: number,
+    zoomIntent: boolean,
+    clientX: number,
+    clientY: number,
+  ) => void;
+  /** Forward a canvas-view key (space / shift+digit) so the host's pan +
+   *  zoom shortcuts work while the iframe holds focus. */
+  readonly reportKey: (down: boolean, code: string, shiftKey: boolean) => void;
   readonly dispose: () => void;
 }
 
@@ -96,6 +108,22 @@ export function connectRuntime({
       post({ type: "canvas:hover", id } satisfies CanvasMessage),
     reportGeometry: (rects, slots) =>
       post({ type: "canvas:geometry", rects, slots } satisfies CanvasMessage),
+    reportWheel: (deltaX, deltaY, zoomIntent, clientX, clientY) =>
+      post({
+        type: "canvas:wheel",
+        deltaX,
+        deltaY,
+        zoomIntent,
+        clientX,
+        clientY,
+      } satisfies CanvasMessage),
+    reportKey: (down, code, shiftKey) =>
+      post({
+        type: "canvas:key",
+        down,
+        code,
+        shiftKey,
+      } satisfies CanvasMessage),
     dispose: () => window.removeEventListener("message", onMessage),
   };
 }

--- a/packages/admin-editor/src/editor-canvas.tsx
+++ b/packages/admin-editor/src/editor-canvas.tsx
@@ -120,6 +120,51 @@ export function EditorCanvas({
     return () => observer.disconnect();
   }, [reportGeometry]);
 
+  // Forward wheel/trackpad gestures to the host so it can pan/zoom the free
+  // canvas — events over the iframe never bubble to the parent stage. Native
+  // + non-passive so we can preventDefault and stop the iframe scrolling itself
+  // under the host's transform.
+  useEffect(() => {
+    const onWheel = (e: WheelEvent): void => {
+      e.preventDefault();
+      connectionRef.current?.reportWheel(
+        e.deltaX,
+        e.deltaY,
+        e.ctrlKey || e.metaKey,
+        e.clientX,
+        e.clientY,
+      );
+    };
+    window.addEventListener("wheel", onWheel, { passive: false });
+    return () => window.removeEventListener("wheel", onWheel);
+  }, []);
+
+  // Forward the canvas-view keys (space to pan, shift+digit to zoom) so those
+  // shortcuts work while focus is inside the iframe. Only these keys — typing
+  // in the canvas is otherwise untouched. Space is prevented so it doesn't
+  // scroll the iframe document.
+  useEffect(() => {
+    const isViewKey = (e: KeyboardEvent): boolean =>
+      e.code === "Space" ||
+      (e.shiftKey &&
+        (e.code === "Digit0" || e.code === "Digit1" || e.code === "Digit2"));
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (!isViewKey(e)) return;
+      if (e.code === "Space") e.preventDefault();
+      connectionRef.current?.reportKey(true, e.code, e.shiftKey);
+    };
+    const onKeyUp = (e: KeyboardEvent): void => {
+      if (e.code !== "Space") return;
+      connectionRef.current?.reportKey(false, e.code, e.shiftKey);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("keyup", onKeyUp);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("keyup", onKeyUp);
+    };
+  }, []);
+
   const blockIdAt = (event: MouseEvent<HTMLDivElement>): string | null => {
     const block = (event.target as HTMLElement).closest("[data-plumix-id]");
     return block?.getAttribute("data-plumix-id") ?? null;

--- a/packages/admin-editor/src/editor-toolbar.tsx
+++ b/packages/admin-editor/src/editor-toolbar.tsx
@@ -92,13 +92,16 @@ function DeviceZoomControls(): ReactElement {
   const device = useEditorStore((s) => s.device);
   const zoom = useEditorStore((s) => s.zoom);
   const setDevice = useEditorStore((s) => s.setDevice);
-  const setZoom = useEditorStore((s) => s.setZoom);
+  const zoomToCenter = useEditorStore((s) => s.zoomToCenter);
   const enableZoomFit = useEditorStore((s) => s.enableZoomFit);
 
+  // Zoom toward the viewport center (the wheel handles zoom-to-cursor).
   const zoomOut = (): void =>
-    setZoom([...ZOOM_STEPS].reverse().find((s) => s < zoom - 0.01) ?? zoom);
+    zoomToCenter(
+      [...ZOOM_STEPS].reverse().find((s) => s < zoom - 0.01) ?? zoom,
+    );
   const zoomIn = (): void =>
-    setZoom(ZOOM_STEPS.find((s) => s > zoom + 0.01) ?? zoom);
+    zoomToCenter(ZOOM_STEPS.find((s) => s > zoom + 0.01) ?? zoom);
 
   return (
     <div

--- a/packages/admin-editor/src/store.test.ts
+++ b/packages/admin-editor/src/store.test.ts
@@ -67,11 +67,25 @@ describe("editor store", () => {
   test("zoom is clamped to the allowed range", () => {
     const store = createEditorStore();
 
-    store.getState().setZoom(99);
+    store.getState().zoomToCenter(99);
     expect(store.getState().zoom).toBe(MAX_ZOOM);
 
-    store.getState().setZoom(0);
+    store.getState().zoomToCenter(0);
     expect(store.getState().zoom).toBe(MIN_ZOOM);
+  });
+
+  test("zoomToCenter keeps the viewport center's point fixed", () => {
+    const store = createEditorStore();
+    store.getState().setViewport(1000, 800);
+    store.getState().setPan(0, 0);
+
+    store.getState().zoomToCenter(2);
+
+    expect(store.getState().zoom).toBe(2);
+    // center (500,400) was world (500,400) at zoom 1; at zoom 2 it must still
+    // land at the viewport center: pan = center - world*zoom.
+    expect(store.getState().panX).toBe(500 - 500 * 2);
+    expect(store.getState().panY).toBe(400 - 400 * 2);
   });
 
   test("deviceWidth: desktop is fixed; tablet/mobile track the breakpoints", () => {
@@ -81,21 +95,22 @@ describe("editor store", () => {
     expect(deviceWidth("mobile", breakpoints)).toBe(500);
   });
 
-  test("manual zoom turns off fit; device switch + applyFitZoom keep/restore it", () => {
+  test("manual zoom turns off fit; device switch + applyFitView keep/restore it", () => {
     const store = createEditorStore();
     expect(store.getState().zoomFit).toBe(true);
 
-    store.getState().setZoom(1.5);
+    store.getState().zoomToCenter(1.5);
     expect(store.getState().zoomFit).toBe(false);
 
-    // The canvas applies a computed fit without leaving fit mode...
+    // The canvas applies a computed fit + center without leaving fit mode...
     store.getState().enableZoomFit();
-    store.getState().applyFitZoom(0.8);
+    store.getState().applyFitView({ zoom: 0.8, panX: 10, panY: 20 });
     expect(store.getState().zoom).toBe(0.8);
+    expect(store.getState().panX).toBe(10);
     expect(store.getState().zoomFit).toBe(true);
 
     // ...and a manual zoom leaves it, while switching device restores it.
-    store.getState().setZoom(2);
+    store.getState().zoomToCenter(2);
     expect(store.getState().zoomFit).toBe(false);
     store.getState().setDevice("mobile");
     expect(store.getState().device).toBe("mobile");

--- a/packages/admin-editor/src/store.ts
+++ b/packages/admin-editor/src/store.ts
@@ -21,6 +21,7 @@ import {
   removeBlocks,
   selectionRoots,
 } from "./block-tree-ops.js";
+import { clampZoom, zoomToCursor } from "./canvas-view.js";
 import { initHistory, recordHistory, redo, undo } from "./history.js";
 
 /** The responsive bucket a style edit targets (per active device). */
@@ -55,11 +56,9 @@ export function deviceWidth(
   return DESKTOP_CANVAS_WIDTH;
 }
 
-export const MIN_ZOOM = 0.25;
-export const MAX_ZOOM = 2;
-
-const clampZoom = (zoom: number): number =>
-  Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoom));
+// Re-exported for the package's public surface (index.ts) and consumers; the
+// zoom range + view math live in canvas-view.
+export { MAX_ZOOM, MIN_ZOOM } from "./canvas-view.js";
 
 /** The active tab in the right inspector rail. */
 export type RightPanel = "block" | "styles" | "page";
@@ -73,6 +72,14 @@ export interface EditorState {
   readonly hoverId: string | null;
   readonly device: EditorDevice;
   readonly zoom: number;
+  /** Free-canvas pan offset (px, host/container space) of the device frame's
+   *  top-left. The canvas is a Figma-style pannable stage, not a scroll area. */
+  readonly panX: number;
+  readonly panY: number;
+  /** The canvas viewport size, mirrored from the host so view actions
+   *  (zoom-to-center) can do their math without the DOM. */
+  readonly viewportW: number;
+  readonly viewportH: number;
   /** Theme breakpoints driving the device canvas widths. */
   readonly breakpoints: ThemeBreakpoints;
   /** When true, zoom auto-fits the canvas to the viewport width; a manual zoom
@@ -142,12 +149,30 @@ export interface EditorActions {
   setJsonOpen: (open: boolean) => void;
   /** Set (or clear, with an empty string) a block's Layers-tree instance name. */
   setBlockLabel: (id: string, label: string) => void;
-  /** Manual zoom — pins the level and turns off fit-to-width. */
-  setZoom: (zoom: number) => void;
-  /** Apply a computed fit-to-width zoom without leaving fit mode (canvas-driven). */
-  applyFitZoom: (zoom: number) => void;
-  /** Re-enable fit-to-width (the toolbar's "Fit" action). */
+  /** Re-enable fit-to-width (the toolbar's "Fit" action). Also recenters. */
   enableZoomFit: () => void;
+  /** Pan the free canvas to an absolute offset (canvas-driven; clamped by the
+   *  caller to keep the frame on-screen). A manual pan leaves fit mode. */
+  setPan: (panX: number, panY: number) => void;
+  /** Set zoom + pan atomically (zoom-to-cursor keeps a focal point fixed).
+   *  Leaves fit mode — it's a manual gesture. */
+  setView: (view: {
+    readonly zoom: number;
+    readonly panX: number;
+    readonly panY: number;
+  }) => void;
+  /** Mirror the host canvas viewport size so view actions can do their math. */
+  setViewport: (width: number, height: number) => void;
+  /** Zoom keeping the viewport center's point fixed (the toolbar +/- buttons,
+   *  vs. the wheel's zoom-to-cursor). Leaves fit mode. */
+  zoomToCenter: (zoom: number) => void;
+  /** Center + fit the frame in the viewport (canvas-driven, stays in fit mode).
+   *  This is how a device switch re-lands the frame on-screen. */
+  applyFitView: (view: {
+    readonly zoom: number;
+    readonly panX: number;
+    readonly panY: number;
+  }) => void;
   startBlockDrag: (entry: InsertableBlockEntry) => void;
   endBlockDrag: () => void;
   /** Begin / end dragging an existing block to a new canvas position. */
@@ -233,6 +258,10 @@ export function createEditorStore(
     hoverId: null,
     device: initial?.device ?? "desktop",
     zoom: initial?.zoom ?? 1,
+    panX: 0,
+    panY: 0,
+    viewportW: 0,
+    viewportH: 0,
     breakpoints: initial?.breakpoints ?? DEFAULT_BREAKPOINTS,
     zoomFit: true,
     dragSpec: null,
@@ -395,9 +424,32 @@ export function createEditorStore(
     setDevice: (device) => set({ device, zoomFit: true }),
     setRightPanel: (rightPanel) => set({ rightPanel }),
     setJsonOpen: (jsonOpen) => set({ jsonOpen }),
-    setZoom: (zoom) => set({ zoom: clampZoom(zoom), zoomFit: false }),
-    applyFitZoom: (zoom) => set({ zoom: clampZoom(zoom) }),
     enableZoomFit: () => set({ zoomFit: true }),
+    setPan: (panX, panY) => set({ panX, panY, zoomFit: false }),
+    setView: ({ zoom, panX, panY }) =>
+      set({ zoom: clampZoom(zoom), panX, panY, zoomFit: false }),
+    applyFitView: ({ zoom, panX, panY }) =>
+      set({ zoom: clampZoom(zoom), panX, panY }),
+    setViewport: (width, height) =>
+      set((s) =>
+        s.viewportW === width && s.viewportH === height
+          ? {}
+          : { viewportW: width, viewportH: height },
+      ),
+    zoomToCenter: (zoom) =>
+      set((s) => {
+        const next = clampZoom(zoom);
+        if (next === s.zoom) return {};
+        if (s.viewportW === 0) return { zoom: next, zoomFit: false };
+        // Zoom keeping the viewport center fixed (vs. the wheel's cursor).
+        const view = zoomToCursor(
+          { zoom: s.zoom, panX: s.panX, panY: s.panY },
+          next,
+          s.viewportW / 2,
+          s.viewportH / 2,
+        );
+        return { ...view, zoomFit: false };
+      }),
     startBlockDrag: (dragSpec) => set({ dragSpec }),
     endBlockDrag: () => set({ dragSpec: null }),
     startMove: (movingId) => set({ movingId }),

--- a/packages/blocks/src/renderer/editor-protocol.ts
+++ b/packages/blocks/src/renderer/editor-protocol.ts
@@ -56,6 +56,32 @@ export type CanvasMessage =
       readonly rects: readonly BlockRect[];
       /** Container slot regions, for resolving a drag to a nested drop target. */
       readonly slots?: readonly SlotRect[];
+    }
+  | {
+      // A wheel/trackpad gesture over the canvas, forwarded so the host can
+      // pan/zoom the free canvas (events over the iframe never reach the parent
+      // stage). `zoomIntent` is ctrl/⌘ held — which is also how trackpad pinch
+      // arrives — so the host zooms toward the cursor instead of panning.
+      // `clientX/Y` are the iframe-local pointer coords; the host maps them to
+      // its own space via the live iframe rect + zoom.
+      readonly type: "canvas:wheel";
+      readonly deltaX: number;
+      readonly deltaY: number;
+      readonly zoomIntent: boolean;
+      readonly clientX: number;
+      readonly clientY: number;
+    }
+  | {
+      // A canvas-view keyboard event (space to pan, shift+digit to zoom),
+      // forwarded so the shortcuts work while the iframe holds focus. Only the
+      // view keys are forwarded — typing in the canvas is unaffected.
+      // NB: no `kind` field — the bridge's handshake frames are discriminated
+      // by a string `kind`, so a `kind` here would be mistaken for one.
+      readonly type: "canvas:key";
+      readonly down: boolean;
+      /** Layout-independent physical key, e.g. "Space", "Digit1". */
+      readonly code: string;
+      readonly shiftKey: boolean;
     };
 
 export type EditorBridgeMessage = HostMessage | CanvasMessage;


### PR DESCRIPTION
The editor canvas was a top-left-pinned scroll area — narrow devices sat in a corner, and switching device could land the frame off-screen. This makes it a Figma-style **pannable, zoomable stage**: the device frame floats in a transform (no scrollbars) and is always centered and on-screen.

## What's in it

- **Stage** — the frame renders under `translate(pan) scale(zoom)`; selection/hover overlays keep tracking it by reading the iframe's live rect and re-measuring on pan/zoom (no overlay rewrite needed).
- **Always visible** — fit-and-center on load and on every device switch, with pan clamped so the frame can't be lost off-stage.
- **Gestures** — trackpad/wheel pan, `⌘`/`Ctrl`+scroll (and pinch) zoom-to-cursor, **Space-drag** pan, toolbar `+/−` zoom-to-center. Shortcuts: **Shift+1** fit, **Shift+0** 100%, **Shift+2** zoom-to-selection. Wheel + the view keys are forwarded iframe→host over the existing bridge so they work *over* the canvas, not just the margins.
- **Polish** — view math extracted to a pure, unit-tested `canvas-view` module shared by the store and component; the empty-state "Add a block" affordance now sits on the frame.

## Screenshots

(Default centered; mobile switch stays centered at exact 32/32px margins; 50% floating frame — shared earlier in the thread.)

## Testing — the editor's two-layer split

- **Unit** for the pure math + store + bridge wiring. The bridge tests caught a real bug: a `canvas:key` message field named `kind` collided with the bridge's handshake discriminator, so keys silently never dispatched — renamed to `down`.
- **e2e (playground)** for the layout-dependent behavior: device-switch-stays-centered (measures real margins), wheel-pan, zoom-to-selection.

Full repo green (101 tasks: typecheck/lint/format/test) + 24 editor e2e.

## Review notes addressed

- **senpai** found a real desync — a block-drag ending while Space is held re-enabled the iframe's pointer events. Fixed by making the iframe's click-through a single declarative owner (`dragSpec || movingId || panReady`) instead of two imperative effects fighting over it.
- **simplifier** — extracted the repeated two-axis pan clamp into `clampPanToFrame`.

## Out of scope (deliberate)

The imperative-transform perf optimization (apply the transform via ref during the gesture, commit on settle) — pan goes through React state per wheel event today, which felt fine; worth doing only if a big page ever feels rubbery.

Refs #1193