### PR TITLE
feat: render an in-canvas add-block affordance for empty slots

### DIFF
--- a/packages/admin-editor/e2e/editor-visual.spec.ts
+++ b/packages/admin-editor/e2e/editor-visual.spec.ts
@@ -179,9 +179,11 @@ test.describe("editor playground", () => {
     const handle = await page
       .getByTestId("selection-toolbar-drag")
       .boundingBox();
-    const target = await canvas
-      .locator('[data-plumix-id="group-heading"]')
-      .boundingBox();
+    // Await the drop target's paint before measuring — boundingBox() returns
+    // null for a not-yet-visible element, which raced under slow CI.
+    const groupHeading = canvas.locator('[data-plumix-id="group-heading"]');
+    await expect(groupHeading).toBeVisible();
+    const target = await groupHeading.boundingBox();
     if (!handle || !target) throw new Error("expected handle + target boxes");
 
     // Drag the handle (host-side) into the group's slot and release.

--- a/packages/admin-editor/src/block-tree-ops.test.ts
+++ b/packages/admin-editor/src/block-tree-ops.test.ts
@@ -357,10 +357,31 @@ describe("moveBlock into a named slot", () => {
     expect(slot(moved, "left").map((n) => n.id)).toEqual(["a", "l"]);
   });
 
-  test("is a no-op for a slot the parent does not have", () => {
+  test("moving into an unset slot creates it (an empty slot is droppable)", () => {
+    const sparse: readonly BlockNode[] = [
+      { id: "a", name: "core/heading" },
+      {
+        id: "cols",
+        name: "core/columns",
+        attrs: { left: [{ id: "l", name: "x" }] },
+      },
+    ];
+    const moved = moveBlock(sparse, "a", {
+      parentId: "cols",
+      slotKey: "right",
+      index: 0,
+    });
+    expect(slot(moved, "right").map((n) => n.id)).toEqual(["a"]);
+  });
+
+  test("is a no-op when the target value is a non-slot scalar", () => {
+    const scalar: readonly BlockNode[] = [
+      { id: "a", name: "core/heading" },
+      { id: "cols", name: "core/columns", attrs: { gap: "md" } },
+    ];
     expect(
-      moveBlock(tree, "a", { parentId: "cols", slotKey: "missing", index: 0 }),
-    ).toBe(tree);
+      moveBlock(scalar, "a", { parentId: "cols", slotKey: "gap", index: 0 }),
+    ).toBe(scalar);
   });
 });
 
@@ -429,14 +450,35 @@ describe("insertBlockAt", () => {
     ).toBe(tree);
   });
 
-  test("is a no-op when the target slot is absent", () => {
+  test("creates an unset slot's array on first insert", () => {
+    // A freshly inserted container has no array for its declared slots yet.
+    // Inserting into one must create it rather than no-op, so the in-canvas
+    // "Add a block" affordance can fill an empty slot. The caller resolves the
+    // slot key from the registry, so it always names a real slot.
+    const empty: readonly BlockNode[] = [{ id: "cols", name: "core/columns" }];
+    const next = insertBlockAt(
+      empty,
+      { id: "n", name: "core/heading" },
+      { parentId: "cols", slotKey: "left", index: 0 },
+    );
+    expect(
+      (findBlock(next, "cols")?.attrs?.left as readonly BlockNode[]).map(
+        (node) => node.id,
+      ),
+    ).toEqual(["n"]);
+  });
+
+  test("is a no-op when the target value is a non-slot scalar", () => {
+    const scalar: readonly BlockNode[] = [
+      { id: "cols", name: "core/columns", attrs: { gap: "md" } },
+    ];
     expect(
       insertBlockAt(
-        tree,
+        scalar,
         { id: "n", name: "x" },
-        { parentId: "cols", slotKey: "missing", index: 0 },
+        { parentId: "cols", slotKey: "gap", index: 0 },
       ),
-    ).toBe(tree);
+    ).toBe(scalar);
   });
 });
 

--- a/packages/admin-editor/src/block-tree-ops.ts
+++ b/packages/admin-editor/src/block-tree-ops.ts
@@ -185,7 +185,10 @@ export function moveBlock(
 }
 
 // Whether `target` names a real slot on a real parent. The top level always
-// exists; a nested target needs the parent present with that slot as an array.
+// exists; a nested target needs the parent present and the slot either already
+// populated or unset — an unset declared slot is simply empty, and insertNode
+// creates its array. A non-array value (a scalar attr) is never a slot. Callers
+// resolve `slotKey` from the registry/geometry, so it always names a real slot.
 function slotTargetExists(
   tree: readonly BlockNode[],
   target: MoveTarget,
@@ -194,7 +197,9 @@ function slotTargetExists(
   const parent = findBlock(tree, target.parentId);
   if (!parent) return false;
   const key = target.slotKey ?? slotKey(parent);
-  return key !== null && isBlockNodeArray(parent.attrs?.[key]);
+  if (key === null) return false;
+  const value = parent.attrs?.[key];
+  return value === undefined || isBlockNodeArray(value);
 }
 
 /**
@@ -370,8 +375,9 @@ function insertNode(
       const key = target.slotKey ?? slotKey(current);
       if (key === null) return current;
       const slot = current.attrs?.[key];
-      if (!isBlockNodeArray(slot)) return current;
-      const children = slot;
+      // A scalar attr is never a slot; an unset slot starts empty.
+      if (slot !== undefined && !isBlockNodeArray(slot)) return current;
+      const children = isBlockNodeArray(slot) ? slot : [];
       const at = clampIndex(target.index, children.length);
       return {
         ...current,

--- a/packages/admin-editor/src/canvas-frame.test.tsx
+++ b/packages/admin-editor/src/canvas-frame.test.tsx
@@ -338,7 +338,11 @@ describe("CanvasFrame nested drop", () => {
     renderWith([{ id: "g1", name: "core/group", attrs: { content: [] } }]);
 
     // The empty slot's in-canvas appender forwards a slot-scoped requestAdd.
-    fromCanvas({ type: "canvas:requestAdd", parentId: "g1", slotKey: "content" });
+    fromCanvas({
+      type: "canvas:requestAdd",
+      parentId: "g1",
+      slotKey: "content",
+    });
 
     const content = storeApi?.getState().tree[0]?.attrs?.content as
       | readonly BlockNode[]

--- a/packages/admin-editor/src/canvas-frame.test.tsx
+++ b/packages/admin-editor/src/canvas-frame.test.tsx
@@ -2,7 +2,7 @@ import type { ReactElement, ReactNode } from "react";
 import { Profiler, useEffect } from "react";
 import { i18n } from "@lingui/core";
 import { I18nProvider } from "@lingui/react";
-import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { act, cleanup, render } from "@testing-library/react";
 import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
 
 import type { BlockNode, BlockSpec } from "@plumix/blocks";
@@ -221,8 +221,8 @@ describe("CanvasFrame", () => {
     }
   });
 
-  test("empty-state affordance inserts the first catalog block", () => {
-    const { getByTestId, queryByTestId } = render(
+  test("an in-canvas add request inserts the first catalog block at the root", () => {
+    const { getByTestId } = render(
       <Wrapper>
         <CanvasFrame
           previewUrl="about:blank"
@@ -235,10 +235,11 @@ describe("CanvasFrame", () => {
     );
 
     expect(getByTestId("tree-probe").textContent).toBe("");
-    fireEvent.click(getByTestId("plumix-empty-add"));
+    // The empty-document appender lives in the canvas; clicking it forwards a
+    // requestAdd over the bridge, which the host resolves into a top-level
+    // insert.
+    fromCanvas({ type: "canvas:requestAdd" });
     expect(getByTestId("tree-probe").textContent).toBe("core/heading");
-    // Affordance disappears once the canvas is no longer empty.
-    expect(queryByTestId("plumix-empty-add")).toBeNull();
   });
 });
 
@@ -326,6 +327,18 @@ describe("CanvasFrame nested drop", () => {
     renderWith([{ id: "g1", name: "core/group", attrs: { content: [] } }]);
 
     dragInto("g1", "content");
+
+    const content = storeApi?.getState().tree[0]?.attrs?.content as
+      | readonly BlockNode[]
+      | undefined;
+    expect(content?.map((n) => n.name)).toEqual(["core/heading"]);
+  });
+
+  test("an in-canvas add request inserts into an empty slot", () => {
+    renderWith([{ id: "g1", name: "core/group", attrs: { content: [] } }]);
+
+    // The empty slot's in-canvas appender forwards a slot-scoped requestAdd.
+    fromCanvas({ type: "canvas:requestAdd", parentId: "g1", slotKey: "content" });
 
     const content = storeApi?.getState().tree[0]?.attrs?.content as
       | readonly BlockNode[]

--- a/packages/admin-editor/src/canvas-frame.tsx
+++ b/packages/admin-editor/src/canvas-frame.tsx
@@ -6,7 +6,6 @@ import {
   useRef,
   useState,
 } from "react";
-import { Trans } from "@lingui/react";
 
 import type { BlockRegistry } from "@plumix/blocks";
 import type { BlockRect, SlotRect } from "@plumix/blocks/renderer";
@@ -101,7 +100,6 @@ export function CanvasFrame({
   const hoverId = useEditorStore((s) => s.hoverId);
   const dragSpec = useEditorStore((s) => s.dragSpec);
   const movingId = useEditorStore((s) => s.movingId);
-  const isEmpty = useEditorStore((s) => s.tree.length === 0);
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [geometry, setGeometry] = useState<Geometry>({
@@ -266,6 +264,41 @@ export function CanvasFrame({
     [applyLive],
   );
 
+  // Insert the first insertable block at the top level (empty-document add).
+  const addFirstBlock = useCallback((): void => {
+    const [group] = groupInsertables(registry, { capabilities });
+    const entry = group?.entries[0];
+    if (entry) {
+      store.getState().insertBlock(createNodeFromEntry(registry, entry), 0);
+    }
+  }, [registry, capabilities, store]);
+
+  // Resolve an in-canvas "Add a block" click: root (no target) inserts at the
+  // top level; an empty slot inserts the first block its allowedBlocks permits.
+  const requestAdd = useCallback(
+    (parentId?: string, slotKey?: string): void => {
+      if (!parentId || !slotKey) {
+        addFirstBlock();
+        return;
+      }
+      const parent = findBlock(store.getState().tree, parentId);
+      if (!parent) return;
+      const allowed = slotAllowedBlocks(registry, parent.name, slotKey);
+      const entry = groupInsertables(registry, { capabilities })
+        .flatMap((g) => g.entries)
+        .find((e) => !allowed || allowed.includes(e.name));
+      if (!entry) return;
+      store
+        .getState()
+        .insertBlockInto(
+          createNodeFromEntry(registry, entry),
+          { parentId, slotKey, index: Number.MAX_SAFE_INTEGER },
+          allowed,
+        );
+    },
+    [registry, capabilities, store, addFirstBlock],
+  );
+
   useEffect(() => {
     const frameWindow = iframeRef.current?.contentWindow;
     if (!frameWindow) return;
@@ -300,6 +333,7 @@ export function CanvasFrame({
       },
       onKey: ({ down, code, shiftKey }) =>
         keyHandlerRef.current?.(down, code, shiftKey),
+      onRequestAdd: ({ parentId, slotKey }) => requestAdd(parentId, slotKey),
     });
     // Expose the loader-data push to the inspector's refresh control.
     if (loaderPushRef) loaderPushRef.current = connection.pushLoaderData;
@@ -307,7 +341,15 @@ export function CanvasFrame({
       if (loaderPushRef) loaderPushRef.current = null;
       connection.dispose();
     };
-  }, [store, origin, measureHost, measureContent, loaderPushRef, handleWheel]);
+  }, [
+    store,
+    origin,
+    measureHost,
+    measureContent,
+    loaderPushRef,
+    handleWheel,
+    requestAdd,
+  ]);
 
   // Keep frame/container fresh when the canvas moves without a block report:
   // column scroll, window resize, and rail collapse (which resizes the inset).
@@ -666,14 +708,6 @@ export function CanvasFrame({
     };
   }, [dragSpec, movingId, store, registry]);
 
-  const addFirstBlock = useCallback((): void => {
-    const [group] = groupInsertables(registry, { capabilities });
-    const entry = group?.entries[0];
-    if (entry) {
-      store.getState().insertBlock(createNodeFromEntry(registry, entry), 0);
-    }
-  }, [registry, capabilities, store]);
-
   // Host-side wheel: pan/zoom when the cursor is over the margin around the
   // frame. Over the iframe the gesture is forwarded via the bridge (onWheel
   // above). Native + non-passive so we can preventDefault the page scroll.
@@ -785,19 +819,6 @@ export function CanvasFrame({
               dragSpec || movingId || panReady ? "none" : undefined,
           }}
         />
-        {/* Inside the stage so it sits on the frame (and pans/zooms with it),
-            rather than floating over the container now that the frame is
-            centered/pannable. */}
-        {!readOnly && isEmpty && (
-          <button
-            type="button"
-            data-testid="plumix-empty-add"
-            onClick={addFirstBlock}
-            className="border-muted-foreground/40 text-muted-foreground hover:bg-accent absolute inset-x-8 top-8 rounded-md border border-dashed p-6 text-sm"
-          >
-            <Trans id="editor.canvas.addBlock" message="Add a block" />
-          </button>
-        )}
       </div>
       {/* Clip layer pinned over the visible canvas column. Its overflow:hidden
           keeps the absolutely-positioned overlays + toolbar from spilling onto

--- a/packages/admin-editor/src/canvas-frame.tsx
+++ b/packages/admin-editor/src/canvas-frame.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { useLingui } from "@lingui/react";
 
 import type { BlockRegistry } from "@plumix/blocks";
 import type { BlockRect, SlotRect } from "@plumix/blocks/renderer";
@@ -86,6 +87,13 @@ export function CanvasFrame({
   capabilities,
   readOnly = false,
 }: CanvasFrameProps): ReactElement {
+  const { i18n } = useLingui();
+  // The canvas has no i18n runtime, so resolve its chrome (the in-canvas "Add a
+  // block" affordance, root + empty slots) here and push it over the bridge.
+  const addBlockLabel = i18n._({
+    id: "editor.canvas.addBlock",
+    message: "Add a block",
+  });
   const store = useEditorStoreApi();
   const loaderPushRef = useLoaderPushRef();
   const device = useEditorStore((s) => s.device);
@@ -334,6 +342,7 @@ export function CanvasFrame({
       onKey: ({ down, code, shiftKey }) =>
         keyHandlerRef.current?.(down, code, shiftKey),
       onRequestAdd: ({ parentId, slotKey }) => requestAdd(parentId, slotKey),
+      config: { addBlockLabel },
     });
     // Expose the loader-data push to the inspector's refresh control.
     if (loaderPushRef) loaderPushRef.current = connection.pushLoaderData;
@@ -349,6 +358,7 @@ export function CanvasFrame({
     loaderPushRef,
     handleWheel,
     requestAdd,
+    addBlockLabel,
   ]);
 
   // Keep frame/container fresh when the canvas moves without a block report:

--- a/packages/admin-editor/src/connect-canvas.test.ts
+++ b/packages/admin-editor/src/connect-canvas.test.ts
@@ -112,6 +112,26 @@ describe("connectCanvas", () => {
     conn.dispose();
   });
 
+  test("a canvas:requestAdd message is delivered to onRequestAdd", () => {
+    const store = createEditorStore();
+    const { win } = fakeFrame();
+    const onRequestAdd = vi.fn();
+    const conn = connectCanvas({
+      store,
+      frameWindow: win,
+      origin: ORIGIN,
+      onRequestAdd,
+    });
+
+    fromCanvas({ type: "canvas:requestAdd", parentId: "g1", slotKey: "content" });
+
+    expect(onRequestAdd).toHaveBeenCalledWith({
+      parentId: "g1",
+      slotKey: "content",
+    });
+    conn.dispose();
+  });
+
   test("an additive canvas:select extends the selection set", () => {
     const store = createEditorStore();
     const { win } = fakeFrame();

--- a/packages/admin-editor/src/connect-canvas.test.ts
+++ b/packages/admin-editor/src/connect-canvas.test.ts
@@ -123,12 +123,48 @@ describe("connectCanvas", () => {
       onRequestAdd,
     });
 
-    fromCanvas({ type: "canvas:requestAdd", parentId: "g1", slotKey: "content" });
+    fromCanvas({
+      type: "canvas:requestAdd",
+      parentId: "g1",
+      slotKey: "content",
+    });
 
     expect(onRequestAdd).toHaveBeenCalledWith({
       parentId: "g1",
       slotKey: "content",
     });
+    conn.dispose();
+  });
+
+  test("pushes host:config to the canvas on ready when config is given", () => {
+    const store = createEditorStore();
+    const { win, posted } = fakeFrame();
+    const conn = connectCanvas({
+      store,
+      frameWindow: win,
+      origin: ORIGIN,
+      config: { addBlockLabel: "Ajouter un bloc" },
+    });
+
+    fromCanvas({ type: "canvas:ready" });
+
+    const configMsg = hostMessages(posted).find(
+      (m) => m.type === "host:config",
+    ) as { addBlockLabel?: string } | undefined;
+    expect(configMsg?.addBlockLabel).toBe("Ajouter un bloc");
+    conn.dispose();
+  });
+
+  test("sends no host:config when no config is given", () => {
+    const store = createEditorStore();
+    const { win, posted } = fakeFrame();
+    const conn = connectCanvas({ store, frameWindow: win, origin: ORIGIN });
+
+    fromCanvas({ type: "canvas:ready" });
+
+    expect(hostMessages(posted).some((m) => m.type === "host:config")).toBe(
+      false,
+    );
     conn.dispose();
   });
 

--- a/packages/admin-editor/src/connect-canvas.ts
+++ b/packages/admin-editor/src/connect-canvas.ts
@@ -54,6 +54,9 @@ interface ConnectCanvasOptions {
     readonly parentId?: string;
     readonly slotKey?: string;
   }) => void;
+  /** Host-resolved canvas chrome (localized labels) pushed once the canvas is
+   *  ready. The canvas has no i18n runtime, so the host owns these strings. */
+  readonly config?: { readonly addBlockLabel: string };
 }
 
 // The iframe runtime usually boots after the parent mounts, so a single hello
@@ -72,6 +75,7 @@ export function connectCanvas({
   onWheel,
   onKey,
   onRequestAdd,
+  config,
 }: ConnectCanvasOptions): CanvasConnection {
   const post = (message: object): void => {
     frameWindow.postMessage(encode(EDITOR_BRIDGE_CHANNEL, message), origin);
@@ -83,6 +87,15 @@ export function connectCanvas({
       type: "host:tree",
       tree: store.getState().tree,
     } satisfies HostMessage);
+  };
+
+  const pushConfig = (): void => {
+    if (config) {
+      post({
+        type: "host:config",
+        addBlockLabel: config.addBlockLabel,
+      } satisfies HostMessage);
+    }
   };
 
   const onMessage = (event: MessageEvent): void => {
@@ -100,6 +113,7 @@ export function connectCanvas({
     const canvas = message as CanvasMessage;
     switch (canvas.type) {
       case "canvas:ready":
+        pushConfig();
         pushTree();
         break;
       case "canvas:select":

--- a/packages/admin-editor/src/connect-canvas.ts
+++ b/packages/admin-editor/src/connect-canvas.ts
@@ -49,6 +49,11 @@ interface ConnectCanvasOptions {
     readonly code: string;
     readonly shiftKey: boolean;
   }) => void;
+  /** An in-canvas "Add a block" affordance was clicked — root or empty slot. */
+  readonly onRequestAdd?: (target: {
+    readonly parentId?: string;
+    readonly slotKey?: string;
+  }) => void;
 }
 
 // The iframe runtime usually boots after the parent mounts, so a single hello
@@ -66,6 +71,7 @@ export function connectCanvas({
   onGeometry,
   onWheel,
   onKey,
+  onRequestAdd,
 }: ConnectCanvasOptions): CanvasConnection {
   const post = (message: object): void => {
     frameWindow.postMessage(encode(EDITOR_BRIDGE_CHANNEL, message), origin);
@@ -120,6 +126,9 @@ export function connectCanvas({
           code: canvas.code,
           shiftKey: canvas.shiftKey,
         });
+        break;
+      case "canvas:requestAdd":
+        onRequestAdd?.({ parentId: canvas.parentId, slotKey: canvas.slotKey });
         break;
     }
   };

--- a/packages/admin-editor/src/connect-runtime.test.ts
+++ b/packages/admin-editor/src/connect-runtime.test.ts
@@ -135,6 +135,22 @@ describe("connectRuntime (canvas/iframe side)", () => {
     conn.dispose();
   });
 
+  test("delivers a pushed host:config to onConfig", () => {
+    const seen: { addBlockLabel: string }[] = [];
+    const { win } = fakeParent();
+    const conn = connectRuntime({
+      parentWindow: win,
+      origin: ORIGIN,
+      onTree: () => undefined,
+      onConfig: (config) => seen.push(config),
+    });
+
+    fromHost({ type: "host:config", addBlockLabel: "Ajouter un bloc" });
+
+    expect(seen.at(-1)).toEqual({ addBlockLabel: "Ajouter un bloc" });
+    conn.dispose();
+  });
+
   test("reportRequestAdd posts canvas:requestAdd to the host", () => {
     const { win, posted } = fakeParent();
     const conn = connectRuntime({

--- a/packages/admin-editor/src/connect-runtime.test.ts
+++ b/packages/admin-editor/src/connect-runtime.test.ts
@@ -135,6 +135,27 @@ describe("connectRuntime (canvas/iframe side)", () => {
     conn.dispose();
   });
 
+  test("reportRequestAdd posts canvas:requestAdd to the host", () => {
+    const { win, posted } = fakeParent();
+    const conn = connectRuntime({
+      parentWindow: win,
+      origin: ORIGIN,
+      onTree: () => undefined,
+    });
+
+    conn.reportRequestAdd("g1", "content");
+    expect(messages(posted)).toContainEqual({
+      type: "canvas:requestAdd",
+      parentId: "g1",
+      slotKey: "content",
+    });
+
+    // Root (no args) omits the slot identity.
+    conn.reportRequestAdd();
+    expect(messages(posted)).toContainEqual({ type: "canvas:requestAdd" });
+    conn.dispose();
+  });
+
   test("ignores host messages from a foreign origin", () => {
     const seen: (readonly BlockNode[])[] = [];
     const { win } = fakeParent();

--- a/packages/admin-editor/src/connect-runtime.ts
+++ b/packages/admin-editor/src/connect-runtime.ts
@@ -48,6 +48,8 @@ interface ConnectRuntimeOptions {
   readonly onTree: (tree: readonly BlockNode[]) => void;
   /** Called with a scoped refresh's re-resolved loader data (node-keyed). */
   readonly onLoaderData?: (data: SerializedLoaderData) => void;
+  /** Called with the host's resolved canvas chrome (e.g. localized labels). */
+  readonly onConfig?: (config: { readonly addBlockLabel: string }) => void;
 }
 
 /**
@@ -61,6 +63,7 @@ export function connectRuntime({
   origin,
   onTree,
   onLoaderData,
+  onConfig,
 }: ConnectRuntimeOptions): RuntimeConnection {
   const post = (message: object): void => {
     parentWindow.postMessage(encode(EDITOR_BRIDGE_CHANNEL, message), origin);
@@ -93,6 +96,9 @@ export function connectRuntime({
         break;
       case "host:loader-data":
         onLoaderData?.(host.data);
+        break;
+      case "host:config":
+        onConfig?.({ addBlockLabel: host.addBlockLabel });
         break;
     }
   };

--- a/packages/admin-editor/src/connect-runtime.ts
+++ b/packages/admin-editor/src/connect-runtime.ts
@@ -33,6 +33,9 @@ export interface RuntimeConnection {
   /** Forward a canvas-view key (space / shift+digit) so the host's pan +
    *  zoom shortcuts work while the iframe holds focus. */
   readonly reportKey: (down: boolean, code: string, shiftKey: boolean) => void;
+  /** An in-canvas "Add a block" affordance was clicked — root (no args) or an
+   *  empty slot. The host resolves the insert. */
+  readonly reportRequestAdd: (parentId?: string, slotKey?: string) => void;
   readonly dispose: () => void;
 }
 
@@ -123,6 +126,12 @@ export function connectRuntime({
         down,
         code,
         shiftKey,
+      } satisfies CanvasMessage),
+    reportRequestAdd: (parentId, slotKey) =>
+      post({
+        type: "canvas:requestAdd",
+        ...(parentId !== undefined && { parentId }),
+        ...(slotKey !== undefined && { slotKey }),
       } satisfies CanvasMessage),
     dispose: () => window.removeEventListener("message", onMessage),
   };

--- a/packages/admin-editor/src/editor-canvas.test.tsx
+++ b/packages/admin-editor/src/editor-canvas.test.tsx
@@ -180,6 +180,33 @@ describe("EditorCanvas", () => {
     spy.mockRestore();
   });
 
+  test("applies the host's pushed config label to the add affordance", () => {
+    const { container } = render(
+      <EditorCanvas registry={registry} origin={ORIGIN} />,
+    );
+
+    // Before config arrives, the appender falls back to English.
+    expect(container.querySelector("[data-plumix-add]")?.textContent).toBe(
+      "Add a block",
+    );
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: encode(EDITOR_BRIDGE_CHANNEL, {
+            type: "host:config",
+            addBlockLabel: "Ajouter un bloc",
+          }),
+          origin: ORIGIN,
+        }),
+      );
+    });
+
+    expect(container.querySelector("[data-plumix-add]")?.textContent).toBe(
+      "Ajouter un bloc",
+    );
+  });
+
   test("hovering a block reports canvas:hover to the host", () => {
     const posted: unknown[] = [];
     const spy = vi

--- a/packages/admin-editor/src/editor-canvas.test.tsx
+++ b/packages/admin-editor/src/editor-canvas.test.tsx
@@ -159,6 +159,27 @@ describe("EditorCanvas", () => {
     expect(css).toContain("#ff0000");
   });
 
+  test("empty document renders the add affordance; clicking it reports requestAdd", () => {
+    const posted: unknown[] = [];
+    const spy = vi
+      .spyOn(window.parent, "postMessage")
+      .mockImplementation((data) => posted.push(data));
+
+    // No tree pushed → empty document → the in-canvas "Add a block" appender.
+    const { container } = render(
+      <EditorCanvas registry={registry} origin={ORIGIN} />,
+    );
+    const add = container.querySelector("[data-plumix-add]");
+    expect(add).not.toBeNull();
+    if (add) fireEvent.click(add);
+
+    const req = posted
+      .map((p) => (p as { message?: { type?: string } }).message)
+      .find((m) => m?.type === "canvas:requestAdd");
+    expect(req).toEqual({ type: "canvas:requestAdd" });
+    spy.mockRestore();
+  });
+
   test("hovering a block reports canvas:hover to the host", () => {
     const posted: unknown[] = [];
     const spy = vi

--- a/packages/admin-editor/src/editor-canvas.tsx
+++ b/packages/admin-editor/src/editor-canvas.tsx
@@ -59,6 +59,10 @@ export function EditorCanvas({
       document.querySelector("[data-plumix-loader-data]")?.textContent ?? "",
     ),
   );
+  // Canvas chrome the host resolves (it owns Lingui; the canvas has none).
+  // Undefined until config arrives, so editAppender's own default is the single
+  // English fallback for the pre-config window.
+  const [addBlockLabel, setAddBlockLabel] = useState<string>();
   const connectionRef = useRef<RuntimeConnection | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -69,6 +73,7 @@ export function EditorCanvas({
       onTree: setTree,
       onLoaderData: (data) =>
         setLoaderData((prior) => mergeLoaderData(prior, data)),
+      onConfig: (config) => setAddBlockLabel(config.addBlockLabel),
     });
     connectionRef.current = connection;
     return () => {
@@ -212,13 +217,16 @@ export function EditorCanvas({
         {tree.length === 0 ? (
           // Empty document: the same in-canvas appender an empty slot shows,
           // flowing in content rather than as a host overlay.
-          <div style={{ padding: "2rem" }}>{editAppender()}</div>
+          <div style={{ padding: "2rem" }}>
+            {editAppender(undefined, addBlockLabel)}
+          </div>
         ) : (
           renderBlockTree(tree, registry, {
             editing: true,
             loaderData,
             tokens,
             breakpoints,
+            addBlockLabel,
           })
         )}
       </div>

--- a/packages/admin-editor/src/editor-canvas.tsx
+++ b/packages/admin-editor/src/editor-canvas.tsx
@@ -15,7 +15,7 @@ import type {
   ThemeTokens,
 } from "@plumix/blocks";
 import type { BlockRect, SlotRect } from "@plumix/blocks/renderer";
-import { parseLoaderData, renderBlockTree } from "@plumix/blocks";
+import { editAppender, parseLoaderData, renderBlockTree } from "@plumix/blocks";
 import { PlumixProvider } from "@plumix/blocks/renderer";
 
 import type { RuntimeConnection } from "./connect-runtime.js";
@@ -171,6 +171,16 @@ export function EditorCanvas({
   };
 
   const handleClick = (event: MouseEvent<HTMLDivElement>): void => {
+    // An in-canvas "Add a block" affordance (root or empty slot) takes
+    // precedence over selection — it lives inside the parent block's box.
+    const add = (event.target as HTMLElement).closest("[data-plumix-add]");
+    if (add) {
+      connectionRef.current?.reportRequestAdd(
+        add.getAttribute("data-plumix-add-parent") ?? undefined,
+        add.getAttribute("data-plumix-add-slot") ?? undefined,
+      );
+      return;
+    }
     const id = blockIdAt(event);
     if (!id) return;
     // Shift / cmd / ctrl extend the selection rather than replacing it.
@@ -199,12 +209,18 @@ export function EditorCanvas({
             the SSR content-root boundary it was mounted into — just the
             per-block data-plumix-id seam for selection. tokens/breakpoints feed
             the per-block style emitter so token-or-custom edits paint live. */}
-        {renderBlockTree(tree, registry, {
-          editing: true,
-          loaderData,
-          tokens,
-          breakpoints,
-        })}
+        {tree.length === 0 ? (
+          // Empty document: the same in-canvas appender an empty slot shows,
+          // flowing in content rather than as a host overlay.
+          <div style={{ padding: "2rem" }}>{editAppender()}</div>
+        ) : (
+          renderBlockTree(tree, registry, {
+            editing: true,
+            loaderData,
+            tokens,
+            breakpoints,
+          })
+        )}
       </div>
     </PlumixProvider>
   );

--- a/packages/admin/e2e/bespoke-editor.spec.ts
+++ b/packages/admin/e2e/bespoke-editor.spec.ts
@@ -90,9 +90,7 @@ test.describe("bespoke editor route", () => {
     await expect(page.getByTestId("block-inspector-empty")).toBeVisible();
   });
 
-  test("mounts the left-rail block catalog and the empty-state affordance", async ({
-    page,
-  }) => {
+  test("mounts the left-rail block catalog", async ({ page }) => {
     await mockRpc(page, {
       "/auth/session": AUTHED_ADMIN,
       "/entry/get": editorEntry(),
@@ -101,14 +99,15 @@ test.describe("bespoke editor route", () => {
 
     await page.goto("entries/posts/1/edit");
 
-    // The catalog lists the core blocks the registry ships, searchable.
+    // The catalog lists the core blocks the registry ships, searchable. The
+    // empty-state "Add a block" affordance now renders inside the canvas iframe
+    // (the mock harness can't serve that route — see above), so it's covered by
+    // the admin-editor unit + playground layers, not here.
     await expect(page.getByTestId("plumix-editor-left")).toBeVisible();
     await expect(page.getByTestId("block-catalog-search")).toBeVisible();
     await expect(
       page.getByTestId("block-catalog-item-core/heading"),
     ).toBeVisible();
-    // A fresh (content-less) entry offers the "Add a block" affordance.
-    await expect(page.getByTestId("plumix-empty-add")).toBeVisible();
   });
 
   test("the Layers tab outlines the entry's nested block structure", async ({

--- a/packages/blocks/src/edit-appender.ts
+++ b/packages/blocks/src/edit-appender.ts
@@ -27,12 +27,17 @@ const STYLE: Record<string, string> = {
  * canvas click-delegation turns into an add-intent; it has no event handler so
  * the renderer stays pure (the same code string-renders for SSR, where this is
  * never emitted because it's edit-only). `target` identifies an empty slot;
- * omit it for the root document.
+ * omit it for the root document. `label` is the localized text — resolved by
+ * the host (which owns Lingui) and threaded in, since the canvas has no i18n
+ * runtime; it falls back to English when the host hasn't pushed config yet.
  */
-export function editAppender(target?: {
-  readonly parentId: string;
-  readonly slotKey: string;
-}): ReactElement {
+export function editAppender(
+  target?: {
+    readonly parentId: string;
+    readonly slotKey: string;
+  },
+  label = "Add a block",
+): ReactElement {
   return createElement(
     "button",
     {
@@ -44,6 +49,6 @@ export function editAppender(target?: {
       }),
       style: STYLE,
     },
-    "Add a block",
+    label,
   );
 }

--- a/packages/blocks/src/edit-appender.ts
+++ b/packages/blocks/src/edit-appender.ts
@@ -1,0 +1,49 @@
+import type { ReactElement } from "react";
+import { createElement } from "react";
+
+// Inline-styled because this renders inside the canvas iframe, which carries the
+// theme's CSS, not admin-ui's. Theme-agnostic muted gray so it reads as editor
+// chrome on any background. `currentColor` is avoided for the same reason.
+const STYLE: Record<string, string> = {
+  display: "flex",
+  width: "100%",
+  boxSizing: "border-box",
+  alignItems: "center",
+  justifyContent: "center",
+  minHeight: "3rem",
+  padding: "0.75rem 1rem",
+  border: "1px dashed rgba(127,127,127,0.45)",
+  borderRadius: "8px",
+  color: "rgba(127,127,127,0.95)",
+  background: "transparent",
+  font: "inherit",
+  fontSize: "0.875rem",
+  cursor: "pointer",
+};
+
+/**
+ * Edit-mode "Add a block" affordance, rendered in the canvas content flow — for
+ * an empty root document or an empty child slot. It carries data attributes the
+ * canvas click-delegation turns into an add-intent; it has no event handler so
+ * the renderer stays pure (the same code string-renders for SSR, where this is
+ * never emitted because it's edit-only). `target` identifies an empty slot;
+ * omit it for the root document.
+ */
+export function editAppender(target?: {
+  readonly parentId: string;
+  readonly slotKey: string;
+}): ReactElement {
+  return createElement(
+    "button",
+    {
+      type: "button",
+      "data-plumix-add": "",
+      ...(target && {
+        "data-plumix-add-parent": target.parentId,
+        "data-plumix-add-slot": target.slotKey,
+      }),
+      style: STYLE,
+    },
+    "Add a block",
+  );
+}

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -26,6 +26,7 @@ export {
   isBlockNodeArray,
   renderBlockTree,
 } from "./render-block-tree.js";
+export { editAppender } from "./edit-appender.js";
 export { rewriteBlockNodeIds } from "./rewrite-node-ids.js";
 export { countProse } from "./count-prose.js";
 export type { ProseCount } from "./count-prose.js";

--- a/packages/blocks/src/render-block-tree.edit.test.tsx
+++ b/packages/blocks/src/render-block-tree.edit.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 
 import type { BlockNode } from "./render-block-tree.js";
 import { createBlockRegistry } from "./block-registry.js";
+import { columnsBlock } from "./columns/index.js";
 import { groupBlock } from "./group/index.js";
 import { headingBlock } from "./heading/index.js";
 import { renderBlockTree } from "./render-block-tree.js";
@@ -12,7 +13,7 @@ import {
   tableCellBlock,
 } from "./table/index.js";
 
-const registry = createBlockRegistry([headingBlock, groupBlock]);
+const registry = createBlockRegistry([headingBlock, groupBlock, columnsBlock]);
 const tableRegistry = createBlockRegistry([
   tableBlock,
   tableBodyRowBlock,
@@ -94,7 +95,7 @@ describe("renderBlockTree edit-aware seam", () => {
     expect(html).toContain('data-plumix-id="h1"');
   });
 
-  test("editing gives an empty slot a droppable placeholder", () => {
+  test("editing gives an empty slot a droppable placeholder + add affordance", () => {
     const empty: readonly BlockNode[] = [
       { id: "g2", name: "core/group", attrs: { content: [] } },
     ];
@@ -104,11 +105,39 @@ describe("renderBlockTree edit-aware seam", () => {
 
     expect(html).toContain('data-plumix-slot-parent="g2"');
     expect(html).toContain("data-plumix-slot-empty");
+    // The empty slot shows the in-canvas "Add a block" affordance scoped to it.
+    expect(html).toContain("data-plumix-add");
+    expect(html).toContain('data-plumix-add-parent="g2"');
+    expect(html).toContain('data-plumix-add-slot="content"');
   });
 
-  test("the normal render carries no slot markers", () => {
+  test("editing reveals declared slots even when the attr was never set", () => {
+    // Columns ship with no `left`/`right` in their defaults, so a freshly
+    // inserted columns block has unset slots. Edit mode must still surface each
+    // declared slot as an empty drop target with its own "Add a block".
+    const cols: readonly BlockNode[] = [{ id: "c1", name: "core/columns" }];
+    const html = renderToStaticMarkup(
+      renderBlockTree(cols, registry, { editing: true }),
+    );
+
+    expect(html).toContain('data-plumix-slot-key="left"');
+    expect(html).toContain('data-plumix-slot-key="right"');
+    expect(html).toContain('data-plumix-add-slot="left"');
+    expect(html).toContain('data-plumix-add-slot="right"');
+  });
+
+  test("an unset slot stays absent outside edit mode (no SSR drift)", () => {
+    const cols: readonly BlockNode[] = [{ id: "c1", name: "core/columns" }];
+    const html = renderToStaticMarkup(renderBlockTree(cols, registry));
+
+    expect(html).not.toContain("data-plumix-slot");
+    expect(html).not.toContain("data-plumix-add");
+  });
+
+  test("the normal render carries no slot markers or add affordance", () => {
     const html = renderToStaticMarkup(renderBlockTree(nested, registry));
 
     expect(html).not.toContain("data-plumix-slot");
+    expect(html).not.toContain("data-plumix-add");
   });
 });

--- a/packages/blocks/src/render-block-tree.edit.test.tsx
+++ b/packages/blocks/src/render-block-tree.edit.test.tsx
@@ -134,6 +134,21 @@ describe("renderBlockTree edit-aware seam", () => {
     expect(html).not.toContain("data-plumix-add");
   });
 
+  test("threads the localized add-block label into the empty-slot affordance", () => {
+    const empty: readonly BlockNode[] = [
+      { id: "g2", name: "core/group", attrs: { content: [] } },
+    ];
+    const html = renderToStaticMarkup(
+      renderBlockTree(empty, registry, {
+        editing: true,
+        addBlockLabel: "Ajouter un bloc",
+      }),
+    );
+
+    expect(html).toContain("Ajouter un bloc");
+    expect(html).not.toContain("Add a block");
+  });
+
   test("the normal render carries no slot markers or add affordance", () => {
     const html = renderToStaticMarkup(renderBlockTree(nested, registry));
 

--- a/packages/blocks/src/render-block-tree.ts
+++ b/packages/blocks/src/render-block-tree.ts
@@ -14,6 +14,7 @@ import type {
   ThemeBreakpoints,
 } from "./styles/style-emitter.js";
 import type { ThemeTokens } from "./styles/types.js";
+import { editAppender } from "./edit-appender.js";
 import { emitBlockStyleCss } from "./styles/style-emitter.js";
 
 const PATTERN_REF_BLOCK = "core/pattern-ref";
@@ -167,40 +168,61 @@ function materializeSlots(
 ): Readonly<Record<string, unknown>> {
   const attrs = node.attrs ?? {};
   const inputs = env.registry.get(node.name)?.inputs;
-  let materialized: Record<string, unknown> | undefined;
+
+  // Slots to materialize: any attr that already holds a child array, plus —
+  // when editing — every declared slot input even if unset, so an empty slot
+  // still renders its placeholder + "Add a block" affordance. Outside edit
+  // mode an unset slot stays absent, keeping SSR output byte-identical.
+  const slotKeys = new Set<string>();
   for (const [key, value] of Object.entries(attrs)) {
-    if (isBlockNodeArray(value)) {
-      materialized ??= { ...attrs };
-      const children = value;
-      // A raw slot renders children directly — its drop-target wrapper would be
-      // invalid HTML in the parent (e.g. a `<div>` inside `<table>`/`<tr>`).
-      const rawSlot = inputs?.find((i) => i.name === key)?.rawSlot === true;
-      materialized[key] = function SlotComponent() {
-        const rendered = renderNodes(children, env, childContext);
-        if (!env.editing || rawSlot) return rendered;
-        // Tag the slot so the canvas can resolve a nested drop to it. The
-        // wrapper is display:contents — zero layout impact, the children flow
-        // as if it weren't there. Parent id + slot key are separate attrs (not
-        // one delimited string) so an id never needs charset-escaping. An empty
-        // slot gets a min-height placeholder so it stays a measurable target.
-        return createElement(
-          "div",
-          {
-            "data-plumix-slot-parent": node.id,
-            "data-plumix-slot-key": key,
-            style: { display: "contents" },
-          },
-          children.length > 0
-            ? rendered
-            : createElement("div", {
-                "data-plumix-slot-empty": "",
-                style: { minHeight: "2rem" },
-              }),
-        );
-      };
+    if (isBlockNodeArray(value)) slotKeys.add(key);
+  }
+  if (env.editing) {
+    for (const input of inputs ?? []) {
+      if (input.type === "slot" && input.rawSlot !== true)
+        slotKeys.add(input.name);
     }
   }
-  return materialized ?? attrs;
+  if (slotKeys.size === 0) return attrs;
+
+  const materialized: Record<string, unknown> = { ...attrs };
+  for (const key of slotKeys) {
+    const value = attrs[key];
+    const children = isBlockNodeArray(value) ? value : [];
+    // A raw slot renders children directly — its drop-target wrapper would be
+    // invalid HTML in the parent (e.g. a `<div>` inside `<table>`/`<tr>`).
+    const rawSlot = inputs?.find((i) => i.name === key)?.rawSlot === true;
+    materialized[key] = function SlotComponent() {
+      const rendered = renderNodes(children, env, childContext);
+      if (!env.editing || rawSlot) return rendered;
+      // Tag the slot so the canvas can resolve a nested drop to it. The
+      // wrapper is display:contents — zero layout impact, the children flow
+      // as if it weren't there. Parent id + slot key are separate attrs (not
+      // one delimited string) so an id never needs charset-escaping. An empty
+      // slot gets a min-height placeholder so it stays a measurable target.
+      return createElement(
+        "div",
+        {
+          "data-plumix-slot-parent": node.id,
+          "data-plumix-slot-key": key,
+          style: { display: "contents" },
+        },
+        children.length > 0
+          ? rendered
+          : createElement(
+              "div",
+              {
+                "data-plumix-slot-empty": "",
+                style: { minHeight: "2rem", padding: "0.5rem" },
+              },
+              // An empty slot shows the same in-canvas "Add a block"
+              // affordance as the root — clicking it inserts into this slot.
+              editAppender({ parentId: node.id, slotKey: key }),
+            ),
+      );
+    };
+  }
+  return materialized;
 }
 
 interface WalkerEnv {

--- a/packages/blocks/src/render-block-tree.ts
+++ b/packages/blocks/src/render-block-tree.ts
@@ -81,6 +81,10 @@ export interface RenderBlockTreeOptions {
   readonly entry?: Readonly<Record<string, unknown>> | null;
   /** Edit mode: tag each block wrapper with `data-plumix-id` for canvas selection. */
   readonly editing?: boolean;
+  /** Localized "Add a block" label for the edit-mode empty-slot affordance.
+   *  The host resolves it (it owns Lingui) and passes it in; the canvas has no
+   *  i18n runtime. Defaults to English inside `editAppender` when absent. */
+  readonly addBlockLabel?: string;
 }
 
 /** Editor/style seam attributes a block spreads onto its root element when it
@@ -217,7 +221,10 @@ function materializeSlots(
               },
               // An empty slot shows the same in-canvas "Add a block"
               // affordance as the root — clicking it inserts into this slot.
-              editAppender({ parentId: node.id, slotKey: key }),
+              editAppender(
+                { parentId: node.id, slotKey: key },
+                env.addBlockLabel,
+              ),
             ),
       );
     };
@@ -234,6 +241,7 @@ interface WalkerEnv {
   readonly loaderData: ResolvedBlockLoaders | undefined;
   readonly patterns: PatternRegistry | undefined;
   readonly editing: boolean;
+  readonly addBlockLabel: string | undefined;
 }
 
 function renderNodes(
@@ -382,6 +390,7 @@ export function renderBlockTree(
     loaderData: options?.loaderData,
     patterns: options?.patterns,
     editing: options?.editing ?? false,
+    addBlockLabel: options?.addBlockLabel,
   };
   const rootContext: BlockContext = {
     ...DEFAULT_BLOCK_CONTEXT,

--- a/packages/blocks/src/renderer/editor-protocol.ts
+++ b/packages/blocks/src/renderer/editor-protocol.ts
@@ -35,6 +35,13 @@ export interface SlotRect {
 export type HostMessage =
   | { readonly type: "host:tree"; readonly tree: readonly BlockNode[] }
   | {
+      // Static, locale-dependent canvas chrome the host resolves (it owns the
+      // i18n runtime; the canvas does not). Sent once the canvas is ready and
+      // again if the locale changes. Currently just the "Add a block" label.
+      readonly type: "host:config";
+      readonly addBlockLabel: string;
+    }
+  | {
       // A scoped refresh's re-resolved loader data, node-keyed (same shape
       // `serializeLoaderData` emits). The canvas merges it into its loader map.
       readonly type: "host:loader-data";

--- a/packages/blocks/src/renderer/editor-protocol.ts
+++ b/packages/blocks/src/renderer/editor-protocol.ts
@@ -82,6 +82,14 @@ export type CanvasMessage =
       /** Layout-independent physical key, e.g. "Space", "Digit1". */
       readonly code: string;
       readonly shiftKey: boolean;
+    }
+  | {
+      // An in-canvas "Add a block" affordance was clicked (empty root document,
+      // or an empty child slot identified by parentId+slotKey). The host owns
+      // the tree, so it resolves the actual insert.
+      readonly type: "canvas:requestAdd";
+      readonly parentId?: string;
+      readonly slotKey?: string;
     };
 
 export type EditorBridgeMessage = HostMessage | CanvasMessage;


### PR DESCRIPTION
The editor's "Add a block" control now renders inside the canvas content, in document flow, instead of only as a host-side overlay. An empty document shows it at the root, and — in edit mode — every empty child slot of a container shows its own, so blocks that accept children (columns, group, details, callout) read coherently when empty. Clicking it posts a new `canvas:requestAdd` bridge message and the host inserts the first allowed block into that slot (or at the root). The renderer stays pure for SSR: the button carries `data-plumix-add*` attributes but no handler, and click delegation lives in the canvas runtime, so public output is byte-identical (unset slots stay absent outside edit mode).

The non-obvious part is the tree-ops change. Previously `slotTargetExists`/`insertNode` no-op'd on a slot whose attr array did not exist yet, which is the case for a freshly inserted container — so an empty slot could never be filled (and drag-drop into an empty slot silently did nothing). They now treat an unset *declared* slot as empty and create its array on first insert, while still rejecting a non-array scalar attr. The tree ops stay registry-agnostic; the caller (which has the registry) resolves the slot key, so it always names a real slot — the same trust model as the existing `allowedBlocks` checks.

Because the affordance moved into the canvas iframe (which has no Lingui runtime), the "Add a block" label is localized by resolving it on the host and pushing it over the bridge as a new `host:config` message; the renderer and canvas take the label as a parameter and fall back to English until config arrives. This keeps the `editor.canvas.addBlock` msgid live and avoids an i18n regression.

True raw slots are excluded by design: `core/table` renders rows and cells straight into `<tbody>`/`<tr>`, where an in-flow wrapper or button would be invalid HTML. Adding rows/cells there is a structured operation, not a generic "add any block" target, so it is intentionally out of scope here.

Worth a careful look: the edit-mode-only branch in `materializeSlots` (the SSR-divergence boundary), the relaxed slot-target validation in `block-tree-ops.ts`, and the `host:config` round-trip. Covered by unit tests at every layer — renderer edit seam, label threading, the bridge round-trip (both directions, with/without config), host insert for root and slot, and the empty/unset-slot tree ops — plus the playground e2e (one flaky drop-target read hardened to await visibility first).

Follow-up tracked in #1199: turn the silent first-block insert into a slot-aware inserter popup that hides disallowed blocks, plus `requiresParent` + `defaultChildren`.