### PR TITLE
feat: slot-aware add-block inserter with visible drop constraints

### DIFF
--- a/packages/admin-editor/e2e/editor-visual.spec.ts
+++ b/packages/admin-editor/e2e/editor-visual.spec.ts
@@ -207,6 +207,37 @@ test.describe("editor playground", () => {
     ).toBeAttached();
   });
 
+  test("the in-canvas appender opens a slot-scoped inserter that nests a pick", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const canvas = page.frameLocator(CANVAS_FRAME);
+
+    // Empty the seeded columns' left slot so its in-canvas appender appears.
+    await canvas.locator('[data-plumix-id="col-left"]').click();
+    await page.getByTestId("selection-toolbar-delete").click();
+    const appender = canvas.locator(
+      '[data-plumix-add][data-plumix-add-slot="left"]',
+    );
+    await expect(appender).toBeVisible();
+
+    // Clicking it opens the inserter popover (host-side, anchored to the slot)
+    // rather than silently inserting a default.
+    await appender.click();
+    const popover = page.getByTestId("plumix-inserter-popover");
+    await expect(popover).toBeVisible();
+
+    // Picking a block nests it into that column and closes the popover. The
+    // fresh heading is empty (no box), so assert attachment, not visibility.
+    await popover.getByTestId("block-catalog-item-core/heading").click();
+    await expect(popover).toBeHidden();
+    await expect(
+      canvas.locator(
+        '[data-plumix-column="left"] [data-plumix-block="core/heading"]',
+      ),
+    ).toBeAttached();
+  });
+
   test("dragging the toolbar handle reorders a top-level block", async ({
     page,
   }) => {

--- a/packages/admin-editor/locales/ar.po
+++ b/packages/admin-editor/locales/ar.po
@@ -269,6 +269,11 @@ msgid "editor.toolbar.device.tablet"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/canvas-frame.tsx
+msgid "editor.canvas.cantPlaceHere"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.header.title"
 msgstr ""

--- a/packages/admin-editor/locales/de.po
+++ b/packages/admin-editor/locales/de.po
@@ -269,6 +269,11 @@ msgid "editor.toolbar.device.tablet"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/canvas-frame.tsx
+msgid "editor.canvas.cantPlaceHere"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.header.title"
 msgstr ""

--- a/packages/admin-editor/locales/en.po
+++ b/packages/admin-editor/locales/en.po
@@ -269,6 +269,11 @@ msgid "editor.toolbar.device.tablet"
 msgstr "Tablet"
 
 #. js-lingui-explicit-id
+#: src/canvas-frame.tsx
+msgid "editor.canvas.cantPlaceHere"
+msgstr "This block can't be placed here."
+
+#. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.header.title"
 msgstr "Title"

--- a/packages/admin-editor/locales/uk.po
+++ b/packages/admin-editor/locales/uk.po
@@ -269,6 +269,11 @@ msgid "editor.toolbar.device.tablet"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/canvas-frame.tsx
+msgid "editor.canvas.cantPlaceHere"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.header.title"
 msgstr ""

--- a/packages/admin-editor/locales/zh-CN.po
+++ b/packages/admin-editor/locales/zh-CN.po
@@ -269,6 +269,11 @@ msgid "editor.toolbar.device.tablet"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/canvas-frame.tsx
+msgid "editor.canvas.cantPlaceHere"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.header.title"
 msgstr ""

--- a/packages/admin-editor/src/block-catalog-tab.test.tsx
+++ b/packages/admin-editor/src/block-catalog-tab.test.tsx
@@ -71,6 +71,23 @@ describe("BlockCatalog", () => {
     expect(getByTestId("block-catalog-item-core/image")).toBeDefined();
   });
 
+  test("restricts the listed blocks to the allowed set", () => {
+    const { getByTestId, queryByTestId } = render(
+      <I18nProvider i18n={i18n}>
+        <EditorProvider initialTree={[]}>
+          <BlockCatalog
+            registry={registry}
+            capabilities={NO_CAPS}
+            allowed={["core/heading"]}
+          />
+        </EditorProvider>
+      </I18nProvider>,
+    );
+    expect(getByTestId("block-catalog-item-core/heading")).toBeDefined();
+    expect(queryByTestId("block-catalog-item-core/image")).toBeNull();
+    expect(queryByTestId("block-catalog-item-core/quote")).toBeNull();
+  });
+
   test("search narrows the catalog", () => {
     const { getByTestId, queryByTestId } = renderCatalog();
     fireEvent.change(getByTestId("block-catalog-search"), {

--- a/packages/admin-editor/src/block-catalog-tab.tsx
+++ b/packages/admin-editor/src/block-catalog-tab.tsx
@@ -28,6 +28,12 @@ interface BlockCatalogProps {
   readonly patterns?: readonly InserterPattern[];
   /** Called after any click-insert, so a host popover can close itself. */
   readonly onInsert?: () => void;
+  /** Restrict the listed blocks to a slot's `allowedBlocks`; omit for all. */
+  readonly allowed?: readonly string[];
+  /** Insert picks into this slot instead of appending at the top level. */
+  readonly target?: { readonly parentId: string; readonly slotKey: string };
+  /** The target slot's parent block name, for enforcing `requiresParent`. */
+  readonly parentName?: string;
 }
 
 /**
@@ -41,17 +47,22 @@ export function BlockCatalog({
   capabilities,
   patterns,
   onInsert,
+  allowed,
+  target,
+  parentName,
 }: BlockCatalogProps): ReactElement {
   const { i18n } = useLingui();
   const [query, setQuery] = useState("");
   const insertBlock = useEditorStore((s) => s.insertBlock);
+  const insertBlockInto = useEditorStore((s) => s.insertBlockInto);
   const insertBlocks = useEditorStore((s) => s.insertBlocks);
   const startBlockDrag = useEditorStore((s) => s.startBlockDrag);
   const treeLength = useEditorStore((s) => s.tree.length);
 
   const groups = useMemo(
-    () => groupInsertables(registry, { capabilities, query }),
-    [registry, capabilities, query],
+    () =>
+      groupInsertables(registry, { capabilities, query, allowed, parentName }),
+    [registry, capabilities, query, allowed, parentName],
   );
   const matchedPatterns = useMemo(
     () => filterPatterns(patterns ?? [], query),
@@ -59,7 +70,15 @@ export function BlockCatalog({
   );
 
   const insertEntry = (node: BlockNode): void => {
-    insertBlock(node, treeLength);
+    if (target) {
+      insertBlockInto(
+        node,
+        { ...target, index: Number.MAX_SAFE_INTEGER },
+        allowed,
+      );
+    } else {
+      insertBlock(node, treeLength);
+    }
     onInsert?.();
   };
   const insertPattern = (nodes: readonly BlockNode[]): void => {

--- a/packages/admin-editor/src/block-catalog.test.ts
+++ b/packages/admin-editor/src/block-catalog.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import type { BlockNode, BlockPattern, BlockSpec } from "@plumix/blocks";
-import { createBlockRegistry } from "@plumix/blocks";
+import { columnsBlock, createBlockRegistry } from "@plumix/blocks";
 
 import {
   createNodeFromEntry,
@@ -109,6 +109,57 @@ describe("groupInsertables", () => {
       }).flatMap((g) => g.entries.map((e) => e.slug)),
     ).toEqual(["core/secret"]);
   });
+
+  test("restricts to allowed block names when an allow-list is given", () => {
+    const registry = createBlockRegistry([
+      spec({ name: "core/heading", category: "text", title: "Heading" }),
+      spec({ name: "core/quote", category: "text", title: "Quote" }),
+      spec({ name: "core/spacer", category: "layout", title: "Spacer" }),
+    ]);
+
+    const slugs = groupInsertables(registry, {
+      capabilities: NO_CAPS,
+      allowed: ["core/heading", "core/spacer"],
+    }).flatMap((g) => g.entries.map((e) => e.name));
+
+    expect(slugs).toEqual(["core/heading", "core/spacer"]);
+  });
+
+  test("hides requiresParent blocks unless the target parent matches", () => {
+    const registry = createBlockRegistry([
+      spec({ name: "core/heading", category: "text", title: "Heading" }),
+      spec({
+        name: "core/button",
+        category: "interactive",
+        title: "Button",
+        requiresParent: ["core/buttons"],
+      }),
+    ]);
+    const names = (parentName?: string): readonly string[] =>
+      groupInsertables(registry, { capabilities: NO_CAPS, parentName }).flatMap(
+        (g) => g.entries.map((e) => e.name),
+      );
+
+    // Root inserter (no parent) hides the parent-bound button.
+    expect(names()).toEqual(["core/heading"]);
+    // Offered only when scoped to a matching parent.
+    expect(names("core/buttons")).toContain("core/button");
+    expect(names("core/group")).not.toContain("core/button");
+  });
+
+  test("an undefined allow-list permits every eligible block", () => {
+    const registry = createBlockRegistry([
+      spec({ name: "core/heading", category: "text", title: "Heading" }),
+      spec({ name: "core/quote", category: "text", title: "Quote" }),
+    ]);
+
+    const slugs = groupInsertables(registry, {
+      capabilities: NO_CAPS,
+      allowed: undefined,
+    }).flatMap((g) => g.entries.map((e) => e.name));
+
+    expect(slugs).toEqual(["core/heading", "core/quote"]);
+  });
 });
 
 describe("filterPatterns", () => {
@@ -167,6 +218,78 @@ describe("createNodeFromEntry", () => {
     expect(a.id).not.toBe("seed");
     expect(a.id.length).toBeGreaterThan(0);
     expect(a.id).not.toBe(b.id);
+  });
+
+  test("seeds a slot's defaultChildren so a fresh container isn't bare", () => {
+    const seeded = createBlockRegistry([
+      spec({
+        name: "core/columns",
+        category: "layout",
+        inputs: [
+          {
+            name: "left",
+            type: "slot",
+            defaultChildren: [{ id: "d1", name: "core/rich-text" }],
+          },
+          { name: "right", type: "slot" },
+        ],
+      }),
+    ]);
+
+    const node = createNodeFromEntry(seeded, {
+      name: "core/columns",
+      slug: "core/columns",
+      title: "Columns",
+    });
+
+    const left = node.attrs?.left as readonly BlockNode[];
+    expect(left.map((n) => n.name)).toEqual(["core/rich-text"]);
+    // Freshly minted id, not the spec's template id.
+    expect(left[0]?.id).not.toBe("d1");
+    // A slot with no default stays absent (the empty-slot appender covers it).
+    expect(node.attrs?.right).toBeUndefined();
+  });
+
+  test("the core/columns block seeds a paragraph into each column", () => {
+    const reg = createBlockRegistry([columnsBlock]);
+    const node = createNodeFromEntry(reg, {
+      name: "core/columns",
+      slug: "core/columns",
+      title: "Columns",
+    });
+    expect(
+      (node.attrs?.left as readonly BlockNode[]).map((n) => n.name),
+    ).toEqual(["core/rich-text"]);
+    expect(
+      (node.attrs?.right as readonly BlockNode[]).map((n) => n.name),
+    ).toEqual(["core/rich-text"]);
+  });
+
+  test("an explicit slot value wins over the slot's defaultChildren", () => {
+    const seeded = createBlockRegistry([
+      spec({
+        name: "core/columns",
+        category: "layout",
+        inputs: [
+          {
+            name: "left",
+            type: "slot",
+            defaultChildren: [{ id: "d1", name: "core/rich-text" }],
+          },
+        ],
+      }),
+    ]);
+
+    const node = createNodeFromEntry(seeded, {
+      name: "core/columns",
+      slug: "core/columns",
+      title: "Columns",
+      attrs: { left: [{ id: "x", name: "core/heading" }] },
+    });
+
+    expect(
+      (node.attrs?.left as readonly BlockNode[]).map((n) => n.name),
+    ).toEqual(["core/heading"]);
   });
 });
 

--- a/packages/admin-editor/src/block-catalog.ts
+++ b/packages/admin-editor/src/block-catalog.ts
@@ -45,6 +45,12 @@ interface GroupOptions {
   readonly capabilities: ReadonlySet<string>;
   /** Case-insensitive filter over name, title and keywords. */
   readonly query?: string;
+  /** Restrict to these block names (a slot's `allowedBlocks`); `undefined`
+   *  permits every eligible block. */
+  readonly allowed?: readonly string[];
+  /** The block the inserter targets, for enforcing each candidate's
+   *  `requiresParent`. `undefined` = the top level (parent-bound blocks hidden). */
+  readonly parentName?: string;
 }
 
 interface InsertableGroup {
@@ -60,13 +66,16 @@ interface InsertableGroup {
  */
 export function groupInsertables(
   registry: BlockRegistry,
-  { capabilities, query }: GroupOptions,
+  { capabilities, query, allowed, parentName }: GroupOptions,
 ): readonly InsertableGroup[] {
   const needle = query?.trim().toLowerCase() ?? "";
   const eligible = [...registry].filter(
     (spec) =>
       spec.inserter !== false &&
-      (!spec.capability || capabilities.has(spec.capability)),
+      (!spec.capability || capabilities.has(spec.capability)) &&
+      (!allowed || allowed.includes(spec.name)) &&
+      (!spec.requiresParent ||
+        (parentName !== undefined && spec.requiresParent.includes(parentName))),
   );
   // Map iteration is insertion-ordered, which is the registry order we want.
   const buckets = new Map<string, InsertableBlockEntry[]>();
@@ -104,11 +113,24 @@ export function createNodeFromEntry(
   registry: BlockRegistry,
   entry: InsertableBlockEntry,
 ): BlockNode {
+  const spec = registry.get(entry.name);
   const attrs: Record<string, unknown> = {
-    ...registry.get(entry.name)?.defaults,
+    ...spec?.defaults,
     ...entry.attrs,
   };
   if (entry.innerBlocks) attrs[CONTENT_SLOT] = entry.innerBlocks;
+  // Seed each declared slot's defaultChildren unless that slot was already
+  // provided (by defaults, the variation's attrs, or innerBlocks). Ids are
+  // minted fresh below, so the spec's template ids never leak into the tree.
+  for (const input of spec?.inputs ?? []) {
+    if (
+      input.type === "slot" &&
+      input.defaultChildren &&
+      attrs[input.name] === undefined
+    ) {
+      attrs[input.name] = input.defaultChildren;
+    }
+  }
   const seed: BlockNode = { id: "seed", name: entry.name, attrs };
   const [node = seed] = rewriteBlockNodeIds([seed]);
   return node;

--- a/packages/admin-editor/src/canvas-frame.test.tsx
+++ b/packages/admin-editor/src/canvas-frame.test.tsx
@@ -2,7 +2,13 @@ import type { ReactElement, ReactNode } from "react";
 import { Profiler, useEffect } from "react";
 import { i18n } from "@lingui/core";
 import { I18nProvider } from "@lingui/react";
-import { act, cleanup, render } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
 
 import type { BlockNode, BlockSpec } from "@plumix/blocks";
@@ -221,8 +227,8 @@ describe("CanvasFrame", () => {
     }
   });
 
-  test("an in-canvas add request inserts the first catalog block at the root", () => {
-    const { getByTestId } = render(
+  test("an in-canvas add request opens the inserter; a pick inserts at root", () => {
+    const { getByTestId, queryByTestId } = render(
       <Wrapper>
         <CanvasFrame
           previewUrl="about:blank"
@@ -235,11 +241,18 @@ describe("CanvasFrame", () => {
     );
 
     expect(getByTestId("tree-probe").textContent).toBe("");
-    // The empty-document appender lives in the canvas; clicking it forwards a
-    // requestAdd over the bridge, which the host resolves into a top-level
-    // insert.
+    // The empty-document appender forwards a root requestAdd, which opens the
+    // inserter popover rather than inserting anything yet.
     fromCanvas({ type: "canvas:requestAdd" });
+    expect(getByTestId("plumix-inserter-popover")).toBeDefined();
+    expect(getByTestId("tree-probe").textContent).toBe("");
+
+    // Picking a block inserts it at the top level and closes the popover.
+    act(() => {
+      fireEvent.click(getByTestId("block-catalog-item-core/heading"));
+    });
     expect(getByTestId("tree-probe").textContent).toBe("core/heading");
+    expect(queryByTestId("plumix-inserter-popover")).toBeNull();
   });
 });
 
@@ -268,6 +281,13 @@ describe("CanvasFrame nested drop", () => {
           allowedBlocks: ["core/button"],
         },
       ],
+    },
+    {
+      name: "core/button",
+      render: () => null,
+      category: "interactive",
+      title: "Button",
+      requiresParent: ["core/buttons"],
     },
   ]);
 
@@ -334,20 +354,81 @@ describe("CanvasFrame nested drop", () => {
     expect(content?.map((n) => n.name)).toEqual(["core/heading"]);
   });
 
-  test("an in-canvas add request inserts into an empty slot", () => {
+  test("an in-canvas slot add opens the inserter; a pick nests into that slot", () => {
     renderWith([{ id: "g1", name: "core/group", attrs: { content: [] } }]);
 
-    // The empty slot's in-canvas appender forwards a slot-scoped requestAdd.
+    // The empty slot's appender forwards a slot-scoped requestAdd → the inserter
+    // opens scoped to that slot, inserting nothing until a block is picked.
     fromCanvas({
       type: "canvas:requestAdd",
       parentId: "g1",
       slotKey: "content",
+    });
+    expect(screen.getByTestId("plumix-inserter-popover")).toBeDefined();
+    expect(storeApi?.getState().tree[0]?.attrs?.content).toEqual([]);
+
+    act(() => {
+      fireEvent.click(screen.getByTestId("block-catalog-item-core/heading"));
     });
 
     const content = storeApi?.getState().tree[0]?.attrs?.content as
       | readonly BlockNode[]
       | undefined;
     expect(content?.map((n) => n.name)).toEqual(["core/heading"]);
+  });
+
+  test("the slot inserter lists only the slot's allowed blocks", () => {
+    renderWith([{ id: "b1", name: "core/buttons", attrs: { items: [] } }]);
+
+    fromCanvas({
+      type: "canvas:requestAdd",
+      parentId: "b1",
+      slotKey: "items",
+    });
+
+    // items allows only core/button — the heading must not be offered.
+    expect(screen.getByTestId("block-catalog-item-core/button")).toBeDefined();
+    expect(screen.queryByTestId("block-catalog-item-core/heading")).toBeNull();
+  });
+
+  test("refuses a requiresParent block dropped into a non-matching parent", () => {
+    renderWith([{ id: "g1", name: "core/group", attrs: { content: [] } }]);
+
+    fromCanvas({
+      type: "canvas:geometry",
+      rects: [{ id: "g1", x: 0, y: 0, width: 500, height: 500 }],
+      slots: [
+        {
+          parentId: "g1",
+          slotKey: "content",
+          x: 0,
+          y: 0,
+          width: 500,
+          height: 500,
+        },
+      ],
+    });
+    act(() =>
+      storeApi?.getState().startBlockDrag({
+        name: "core/button",
+        slug: "core/button",
+        title: "Button",
+        category: "interactive",
+      }),
+    );
+    act(() => {
+      window.dispatchEvent(
+        new MouseEvent("pointermove", { clientX: 50, clientY: 50 }),
+      );
+      window.dispatchEvent(
+        new MouseEvent("pointerup", { clientX: 50, clientY: 50 }),
+      );
+    });
+
+    // core/button requiresParent core/buttons — the group must refuse it, with
+    // a visible notice and no insert.
+    expect(storeApi?.getState().tree[0]?.attrs?.content).toEqual([]);
+    expect(screen.getByTestId("plumix-add-rejection")).toBeDefined();
   });
 
   test("a slot rejects a block its allowedBlocks does not permit", () => {

--- a/packages/admin-editor/src/canvas-frame.tsx
+++ b/packages/admin-editor/src/canvas-frame.tsx
@@ -10,14 +10,16 @@ import { useLingui } from "@lingui/react";
 
 import type { BlockRegistry } from "@plumix/blocks";
 import type { BlockRect, SlotRect } from "@plumix/blocks/renderer";
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from "@plumix/admin-ui/popover";
 
 import type { View } from "./canvas-view.js";
 import type { FrameOffset, OverlayBox } from "./overlay.js";
-import {
-  createNodeFromEntry,
-  groupInsertables,
-  slotAllowedBlocks,
-} from "./block-catalog.js";
+import { BlockCatalog } from "./block-catalog-tab.js";
+import { createNodeFromEntry, slotAllowedBlocks } from "./block-catalog.js";
 import { findBlock } from "./block-tree-ops.js";
 import {
   clampPanToFrame,
@@ -141,6 +143,17 @@ export function CanvasFrame({
   >(null);
   const [dropY, setDropY] = useState<number | null>(null);
   const [dropSlot, setDropSlot] = useState<SlotDrop | null>(null);
+  // The in-canvas "Add a block" affordance opens a slot-scoped inserter popover
+  // instead of inserting a default. Null when closed; an empty target (no
+  // parentId/slotKey) is the root document.
+  const [pendingAdd, setPendingAdd] = useState<{
+    readonly parentId?: string;
+    readonly slotKey?: string;
+  } | null>(null);
+  // A transient "can't place here" notice (a refused `requiresParent` drop).
+  // The editor has no toast surface of its own, so it shows inline and clears
+  // itself after a moment.
+  const [rejection, setRejection] = useState<string | null>(null);
   // The iframe's own document height (same-origin), so the frame sizes to its
   // content — footer visible, no fixed gap below it.
   const [contentHeight, setContentHeight] = useState<number | null>(null);
@@ -272,39 +285,14 @@ export function CanvasFrame({
     [applyLive],
   );
 
-  // Insert the first insertable block at the top level (empty-document add).
-  const addFirstBlock = useCallback((): void => {
-    const [group] = groupInsertables(registry, { capabilities });
-    const entry = group?.entries[0];
-    if (entry) {
-      store.getState().insertBlock(createNodeFromEntry(registry, entry), 0);
-    }
-  }, [registry, capabilities, store]);
-
-  // Resolve an in-canvas "Add a block" click: root (no target) inserts at the
-  // top level; an empty slot inserts the first block its allowedBlocks permits.
+  // An in-canvas "Add a block" click opens the slot-scoped inserter popover
+  // rather than inserting a default — the author picks the block. Root has no
+  // parentId/slotKey; a slot carries both.
   const requestAdd = useCallback(
     (parentId?: string, slotKey?: string): void => {
-      if (!parentId || !slotKey) {
-        addFirstBlock();
-        return;
-      }
-      const parent = findBlock(store.getState().tree, parentId);
-      if (!parent) return;
-      const allowed = slotAllowedBlocks(registry, parent.name, slotKey);
-      const entry = groupInsertables(registry, { capabilities })
-        .flatMap((g) => g.entries)
-        .find((e) => !allowed || allowed.includes(e.name));
-      if (!entry) return;
-      store
-        .getState()
-        .insertBlockInto(
-          createNodeFromEntry(registry, entry),
-          { parentId, slotKey, index: Number.MAX_SAFE_INTEGER },
-          allowed,
-        );
+      setPendingAdd({ parentId, slotKey });
     },
-    [registry, capabilities, store, addFirstBlock],
+    [],
   );
 
   useEffect(() => {
@@ -580,12 +568,6 @@ export function CanvasFrame({
       if (dragSpec) store.getState().endBlockDrag();
       else store.getState().endMove();
     };
-    const allowedForSlot = (slot: SlotDrop): readonly string[] | undefined => {
-      const parent = findBlock(store.getState().tree, slot.parentId);
-      return parent
-        ? slotAllowedBlocks(registry, parent.name, slot.slotKey)
-        : undefined;
-    };
 
     const placementAt = (clientX: number, clientY: number) => {
       const rect = iframe.getBoundingClientRect();
@@ -650,8 +632,26 @@ export function CanvasFrame({
       );
     };
     const onUp = (e: PointerEvent): void => {
+      // A `requiresParent` block is refused unless the parent it would land
+      // under (a slot's parent, or none at the top level) is in its list.
+      const req = registry.get(draggingName)?.requiresParent;
+      const refuse = (): void => {
+        setRejection(
+          i18n._({
+            id: "editor.canvas.cantPlaceHere",
+            message: "This block can't be placed here.",
+          }),
+        );
+        endDrag();
+      };
+
       const slot = slotTargetAt(e.clientX, e.clientY);
       if (slot) {
+        const parent = findBlock(store.getState().tree, slot.parentId);
+        if (req && (!parent || !req.includes(parent.name))) {
+          refuse();
+          return;
+        }
         // Nested drops append (a sentinel index that insertNode/moveBlock clamp
         // to the slot length).
         const target = {
@@ -659,7 +659,9 @@ export function CanvasFrame({
           slotKey: slot.slotKey,
           index: Number.MAX_SAFE_INTEGER,
         };
-        const allowed = allowedForSlot(slot);
+        const allowed = parent
+          ? slotAllowedBlocks(registry, parent.name, slot.slotKey)
+          : undefined;
         if (dragSpec) {
           store
             .getState()
@@ -674,6 +676,11 @@ export function CanvasFrame({
       } else {
         const placement = placementAt(e.clientX, e.clientY);
         if (placement) {
+          // A `requiresParent` block can't live at the top level.
+          if (req) {
+            refuse();
+            return;
+          }
           if (dragSpec) {
             store
               .getState()
@@ -716,7 +723,14 @@ export function CanvasFrame({
       setDropY(null);
       setDropSlot(null);
     };
-  }, [dragSpec, movingId, store, registry]);
+  }, [dragSpec, movingId, store, registry, i18n]);
+
+  // Auto-dismiss the transient rejection notice.
+  useEffect(() => {
+    if (!rejection) return;
+    const t = setTimeout(() => setRejection(null), 2500);
+    return () => clearTimeout(t);
+  }, [rejection]);
 
   // Host-side wheel: pan/zoom when the cursor is over the margin around the
   // frame. Over the iframe the gesture is forwarded via the bridge (onWheel
@@ -775,6 +789,34 @@ export function CanvasFrame({
       />
     );
   };
+
+  // Inserter popover scope: a slot target carries both ids; the root document
+  // carries neither (no allow-list — every block is offered).
+  const pendingTarget =
+    pendingAdd?.parentId && pendingAdd.slotKey
+      ? { parentId: pendingAdd.parentId, slotKey: pendingAdd.slotKey }
+      : undefined;
+  const pendingParentName = pendingTarget
+    ? findBlock(store.getState().tree, pendingTarget.parentId)?.name
+    : undefined;
+  const pendingAllowed =
+    pendingTarget && pendingParentName
+      ? slotAllowedBlocks(registry, pendingParentName, pendingTarget.slotKey)
+      : undefined;
+  // Anchor the popover over the slot's on-screen box when we have its geometry;
+  // fall back to the canvas box (root add, or a slot not yet measured).
+  const pendingSlotRect =
+    pendingTarget && geometry.frame
+      ? geometry.slots.find(
+          (s) =>
+            s.parentId === pendingTarget.parentId &&
+            s.slotKey === pendingTarget.slotKey,
+        )
+      : undefined;
+  const pendingAnchor =
+    pendingSlotRect && geometry.frame
+      ? overlayBox(pendingSlotRect, geometry.frame, zoom)
+      : container;
 
   return (
     <div
@@ -889,6 +931,68 @@ export function CanvasFrame({
               }}
             />
           )}
+        </div>
+      )}
+
+      {/* Slot-scoped inserter: opened by the in-canvas "Add a block" affordance,
+          anchored over the slot, listing only that slot's permitted blocks. A
+          pick inserts into the slot (or at the root) and closes it. */}
+      {!readOnly && pendingAdd && (
+        <Popover
+          open
+          onOpenChange={(next) => {
+            if (!next) setPendingAdd(null);
+          }}
+        >
+          <PopoverAnchor
+            style={{
+              position: "fixed",
+              left: pendingAnchor?.left ?? 0,
+              top: pendingAnchor?.top ?? 0,
+              width: pendingAnchor?.width ?? 0,
+              height: pendingAnchor?.height ?? 0,
+              pointerEvents: "none",
+            }}
+          />
+          <PopoverContent
+            data-testid="plumix-inserter-popover"
+            align="start"
+            className="max-h-96 w-72 overflow-auto p-0"
+          >
+            <BlockCatalog
+              registry={registry}
+              capabilities={capabilities}
+              allowed={pendingAllowed}
+              parentName={pendingParentName}
+              target={pendingTarget}
+              onInsert={() => setPendingAdd(null)}
+            />
+          </PopoverContent>
+        </Popover>
+      )}
+
+      {/* Transient "can't place here" notice for a refused requiresParent drop;
+          the editor has no toast surface, so it shows inline. */}
+      {!readOnly && rejection && (
+        <div
+          role="status"
+          data-testid="plumix-add-rejection"
+          style={{
+            position: "absolute",
+            left: "50%",
+            bottom: 16,
+            transform: "translateX(-50%)",
+            zIndex: 30,
+            padding: "0.5rem 0.75rem",
+            borderRadius: 8,
+            fontSize: "0.8125rem",
+            color: "var(--destructive-foreground, #fff)",
+            background: "var(--destructive, #dc2626)",
+            boxShadow: "0 2px 8px rgba(0,0,0,0.2)",
+            pointerEvents: "none",
+          }}
+        >
+          {rejection}
         </div>
       )}
     </div>

--- a/packages/blocks/src/block-registry.ts
+++ b/packages/blocks/src/block-registry.ts
@@ -29,6 +29,13 @@ export interface BlockInput {
    * selectable via their own seam).
    */
   readonly rawSlot?: boolean;
+  /**
+   * Slot inputs only: the body seeded into this slot when the block is first
+   * inserted, so a fresh container isn't bare. Inserted as a deep-cloned,
+   * ID-rewritten tree; an explicit slot value (e.g. a variation's innerBlocks)
+   * wins. Mirrors Builder.io's `defaultChildren`.
+   */
+  readonly defaultChildren?: readonly BlockNode[];
 }
 
 export type BlockVariationScope = "inserter" | "block" | "transform";
@@ -146,6 +153,14 @@ export interface BlockSpec<
   readonly capability?: string;
   readonly transforms?: BlockTransforms;
   readonly variations?: readonly BlockVariation[];
+  /**
+   * The parent block names this block may be nested under. Set = the block can
+   * only be inserted into a matching parent's slot (never at the top level); the
+   * inserter hides it elsewhere and a drop into a non-matching parent is
+   * refused. The inverse of a slot's `allowedBlocks`. Mirrors Builder.io's
+   * `requiresParent`.
+   */
+  readonly requiresParent?: readonly string[];
 }
 
 export interface BlockRegistry {

--- a/packages/blocks/src/columns/index.tsx
+++ b/packages/blocks/src/columns/index.tsx
@@ -23,8 +23,18 @@ export const columnsBlock = defineBlock({
       label: "Gap",
       options: GAPS.map((v) => ({ label: v, value: v })),
     },
-    { name: "left", type: "slot", label: "Left column" },
-    { name: "right", type: "slot", label: "Right column" },
+    {
+      name: "left",
+      type: "slot",
+      label: "Left column",
+      defaultChildren: [{ id: "left-text", name: "core/rich-text" }],
+    },
+    {
+      name: "right",
+      type: "slot",
+      label: "Right column",
+      defaultChildren: [{ id: "right-text", name: "core/rich-text" }],
+    },
   ],
   defaults: { gap: "md" },
   render: ({ attrs }): ReactNode => {

--- a/packages/blocks/src/validate-content.test.ts
+++ b/packages/blocks/src/validate-content.test.ts
@@ -165,6 +165,85 @@ describe("validateEntryContent", () => {
     );
   });
 
+  describe("requiresParent", () => {
+    const reg = createBlockRegistry([
+      headingBlock,
+      {
+        name: "core/group",
+        render: () => null,
+        inputs: [{ name: "content", type: "slot" }],
+      },
+      {
+        name: "core/buttons",
+        render: () => null,
+        inputs: [{ name: "items", type: "slot" }],
+      },
+      {
+        name: "core/button",
+        render: () => null,
+        requiresParent: ["core/buttons"],
+      },
+    ]);
+
+    test("rejects a requiresParent block at the top level", () => {
+      const result = validateEntryContent(
+        { version: "plumix.v2", blocks: [{ id: "b1", name: "core/button" }] },
+        reg,
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          code: "requires_parent",
+          nodeName: "core/button",
+          path: "blocks[0]",
+        }),
+      );
+    });
+
+    test("rejects a requiresParent block under a non-matching parent", () => {
+      const result = validateEntryContent(
+        {
+          version: "plumix.v2",
+          blocks: [
+            {
+              id: "g1",
+              name: "core/group",
+              attrs: { content: [{ id: "b1", name: "core/button" }] },
+            },
+          ],
+        },
+        reg,
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({
+          code: "requires_parent",
+          nodeName: "core/button",
+          path: "blocks[0].content[0]",
+        }),
+      );
+    });
+
+    test("accepts a requiresParent block under a matching parent", () => {
+      const result = validateEntryContent(
+        {
+          version: "plumix.v2",
+          blocks: [
+            {
+              id: "p1",
+              name: "core/buttons",
+              attrs: { items: [{ id: "b1", name: "core/button" }] },
+            },
+          ],
+        },
+        reg,
+      );
+      expect(result.ok).toBe(true);
+    });
+  });
+
   test("accepts a valid table tree", () => {
     const result = validateEntryContent(
       {

--- a/packages/blocks/src/validate-content.ts
+++ b/packages/blocks/src/validate-content.ts
@@ -22,7 +22,7 @@ export function validateEntryContent(
   registry: SpecLookup,
 ): BlockContentValidationResult {
   const errors: BlockContentValidationIssue[] = [];
-  walk(content.blocks, "blocks", errors, registry);
+  walk(content.blocks, "blocks", null, errors, registry);
   if (errors.length === 0) return { ok: true };
   return { ok: false, errors };
 }
@@ -30,6 +30,7 @@ export function validateEntryContent(
 function walk(
   nodes: readonly BlockNode[],
   basePath: string,
+  parentName: string | null,
   out: BlockContentValidationIssue[],
   registry: SpecLookup,
 ): void {
@@ -44,6 +45,21 @@ function walk(
         nodeName: node.name,
       });
       return;
+    }
+    // The inverse of a slot's `allowedBlocks`: a parent-bound block may only sit
+    // under a listed parent (and never at the top level, where parentName null).
+    if (
+      spec.requiresParent &&
+      (parentName === null || !spec.requiresParent.includes(parentName))
+    ) {
+      out.push({
+        code: "requires_parent",
+        message: `Block "${node.name}" can only be nested under ${spec.requiresParent
+          .map((p) => `"${p}"`)
+          .join(", ")} at ${path}.`,
+        path,
+        nodeName: node.name,
+      });
     }
     for (const [key, value] of Object.entries(node.attrs ?? {})) {
       if (!isBlockNodeArray(value)) continue;
@@ -64,7 +80,7 @@ function walk(
           });
         });
       }
-      walk(value, `${path}.${key}`, out, registry);
+      walk(value, `${path}.${key}`, node.name, out, registry);
     }
   });
 }

--- a/packages/blocks/src/validation-errors.ts
+++ b/packages/blocks/src/validation-errors.ts
@@ -7,7 +7,8 @@ import type { BlockContentValidationResult } from "./validate-content.js";
  */
 export type BlockContentValidationCode =
   | "unknown_block_type"
-  | "disallowed_child";
+  | "disallowed_child"
+  | "requires_parent";
 
 export interface BlockContentValidationIssue {
   readonly code: BlockContentValidationCode;


### PR DESCRIPTION
Closes #1199. Builds on #1198 (the in-canvas "Add a block" appender).

Clicking the in-canvas appender now opens an inserter popover — the existing left-rail `BlockCatalog` rendered in a `Popover`, anchored to the slot — instead of silently inserting the first permitted block. The author picks. The popover is scoped to where it was opened: it lists only the blocks the slot's `allowedBlocks` permits, and hides `requiresParent` blocks unless the target parent matches. A pick inserts into that slot (or the root) and closes the popover.

This adds two block-definition primitives, mirroring Builder.io's model:
- **`requiresParent`** (BlockSpec) — the inverse of a slot's `allowedBlocks`: a block that may only nest under listed parents, never at the top level. Enforced in the inserter (hidden where invalid), in drag-drop (refused with a transient inline notice — the editor has no toast surface of its own), **and at the write-time content validator**, so the guarantee holds for every persistence path (patterns, JSON, direct RPC), not just the canvas UI.
- **`defaultChildren`** (BlockInput, slot only) — the body seeded into a slot on first insert, so a fresh container isn't bare. `core/columns` seeds a paragraph into each column.

The tree ops stay registry-agnostic — all constraint resolution happens in the caller, consistent with the existing `allowedBlocks` convention.

Review focus: the `onUp` drag-drop enforcement (slot + top-level paths) and the symmetric server-side `requires_parent` check in `validate-content.ts`. Covered by unit tests at each layer (inserter filtering, scoped insert, `defaultChildren` seeding, `requiresParent` refusal client + server) plus a playground e2e that opens the popover and nests a pick end to end.

The popover's anchoring for a root add (no measured slot) falls back to the canvas box; carrying the appender's own geometry over the bridge for a precise root anchor is a noted follow-up.