### PR TITLE
feat: use shadcn ScrollArea for the inserter popover

### DIFF
--- a/packages/admin-editor/e2e/editor-visual.spec.ts
+++ b/packages/admin-editor/e2e/editor-visual.spec.ts
@@ -227,6 +227,14 @@ test.describe("editor playground", () => {
     const popover = page.getByTestId("plumix-inserter-popover");
     await expect(popover).toBeVisible();
 
+    // The list is bounded by the ScrollArea viewport (max-h-96 ≈ 384px) rather
+    // than spilling out of the popover — guards the viewport-targeted cap, which
+    // silently fails if the scroll-area data-slot ever drifts.
+    const viewport = popover.locator('[data-slot="scroll-area-viewport"]');
+    const box = await viewport.boundingBox();
+    if (!box) throw new Error("expected scroll-area viewport box");
+    expect(box.height).toBeLessThanOrEqual(400);
+
     // Picking a block nests it into that column and closes the popover. The
     // fresh heading is empty (no box), so assert attachment, not visibility.
     await popover.getByTestId("block-catalog-item-core/heading").click();

--- a/packages/admin-editor/src/canvas-frame.tsx
+++ b/packages/admin-editor/src/canvas-frame.tsx
@@ -15,6 +15,7 @@ import {
   PopoverAnchor,
   PopoverContent,
 } from "@plumix/admin-ui/popover";
+import { ScrollArea } from "@plumix/admin-ui/scroll-area";
 
 import type { View } from "./canvas-view.js";
 import type { FrameOffset, OverlayBox } from "./overlay.js";
@@ -957,16 +958,21 @@ export function CanvasFrame({
           <PopoverContent
             data-testid="plumix-inserter-popover"
             align="start"
-            className="max-h-96 w-72 overflow-auto p-0"
+            className="w-72 p-0"
           >
-            <BlockCatalog
-              registry={registry}
-              capabilities={capabilities}
-              allowed={pendingAllowed}
-              parentName={pendingParentName}
-              target={pendingTarget}
-              onInsert={() => setPendingAdd(null)}
-            />
+            {/* Radix's viewport (height:100%) won't clamp to a max-height on
+                the Root, so cap the viewport directly — it then scrolls while
+                the popover still shrinks to fit short lists. */}
+            <ScrollArea className="[&>[data-slot=scroll-area-viewport]]:max-h-96">
+              <BlockCatalog
+                registry={registry}
+                capabilities={capabilities}
+                allowed={pendingAllowed}
+                parentName={pendingParentName}
+                target={pendingTarget}
+                onInsert={() => setPendingAdd(null)}
+              />
+            </ScrollArea>
           </PopoverContent>
         </Popover>
       )}

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -92,6 +92,10 @@
       "types": "./dist/radio-group.d.ts",
       "default": "./dist/radio-group.js"
     },
+    "./scroll-area": {
+      "types": "./dist/scroll-area.d.ts",
+      "default": "./dist/scroll-area.js"
+    },
     "./select": {
       "types": "./dist/select.d.ts",
       "default": "./dist/select.js"

--- a/packages/admin-ui/src/scroll-area.tsx
+++ b/packages/admin-ui/src/scroll-area.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import { ScrollArea as ScrollAreaPrimitive } from "radix-ui";
+
+import { cn } from "./utils.js";
+
+function ScrollArea({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      className={cn("relative", className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  );
+}
+
+function ScrollBar({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
+  return (
+    <ScrollAreaPrimitive.ScrollAreaScrollbar
+      data-slot="scroll-area-scrollbar"
+      orientation={orientation}
+      className={cn(
+        "flex touch-none p-px transition-colors select-none",
+        orientation === "vertical" &&
+          "h-full w-2.5 border-l border-l-transparent",
+        orientation === "horizontal" &&
+          "h-2.5 flex-col border-t border-t-transparent",
+        className,
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.ScrollAreaThumb
+        data-slot="scroll-area-thumb"
+        className="bg-border relative flex-1 rounded-full"
+      />
+    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+  );
+}
+
+export { ScrollArea, ScrollBar };


### PR DESCRIPTION
The slot-aware inserter popover (#1200) scrolled via a native `overflow-auto`. This swaps in shadcn's `ScrollArea` for a styled Radix scrollbar consistent with the rest of the admin UI.

`admin-ui/scroll-area.tsx` is the canonical shadcn component, vendored on the existing `radix-ui` umbrella (no new dependency), matching the repo's other vendored components; a `./scroll-area` subpath export is added.

The one non-obvious detail: the max-height is applied to the Radix **viewport**, not the `ScrollArea` root — the root's cap can't clamp the viewport's `height:100%`, so a root max-height lets the list spill out of the popover instead of scrolling. An e2e asserts the viewport stays bounded (≤ ~384px), so the viewport-targeted cap can't silently regress if the `data-slot` ever drifts.