### PR TITLE
feat: keep the editor canvas from navigating away on link clicks

### DIFF
--- a/packages/admin-editor/src/editor-canvas.test.tsx
+++ b/packages/admin-editor/src/editor-canvas.test.tsx
@@ -228,4 +228,83 @@ describe("EditorCanvas", () => {
     expect(hover).toEqual({ type: "canvas:hover", id: "h1" });
     spy.mockRestore();
   });
+
+  test("a link click in the canvas is prevented from navigating", () => {
+    const { container } = render(
+      <EditorCanvas registry={registry} origin={ORIGIN} />,
+    );
+    const link = document.createElement("a");
+    link.href = "/elsewhere";
+    container.appendChild(link);
+
+    const event = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+    });
+    act(() => {
+      link.dispatchEvent(event);
+    });
+
+    // The capture-phase guard kills navigation, leaving selection to bubble.
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  test("a middle-click on a link is prevented (no new-tab navigation)", () => {
+    const { container } = render(
+      <EditorCanvas registry={registry} origin={ORIGIN} />,
+    );
+    const link = document.createElement("a");
+    link.href = "/elsewhere";
+    container.appendChild(link);
+
+    const event = new MouseEvent("auxclick", {
+      bubbles: true,
+      cancelable: true,
+      button: 1,
+    });
+    act(() => {
+      link.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  test("a form submit in the canvas is prevented", () => {
+    const { container } = render(
+      <EditorCanvas registry={registry} origin={ORIGIN} />,
+    );
+    const form = document.createElement("form");
+    container.appendChild(form);
+
+    const event = new Event("submit", { bubbles: true, cancelable: true });
+    act(() => {
+      form.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  test("theme chrome around the content root is made inert, content stays live", () => {
+    const { getByTestId } = render(
+      <div>
+        <header data-testid="chrome-header">
+          <a href="/x">Home</a>
+        </header>
+        <div data-plumix-content-root>
+          <EditorCanvas registry={registry} origin={ORIGIN} />
+        </div>
+        <footer data-testid="chrome-footer" />
+      </div>,
+    );
+
+    expect(getByTestId("chrome-header").hasAttribute("inert")).toBe(true);
+    expect(
+      getByTestId("chrome-header").hasAttribute("data-plumix-chrome"),
+    ).toBe(true);
+    expect(getByTestId("chrome-footer").hasAttribute("inert")).toBe(true);
+    // The editable content root is left interactive.
+    expect(getByTestId("plumix-editor-canvas").hasAttribute("inert")).toBe(
+      false,
+    );
+  });
 });

--- a/packages/admin-editor/src/editor-canvas.tsx
+++ b/packages/admin-editor/src/editor-canvas.tsx
@@ -170,6 +170,70 @@ export function EditorCanvas({
     };
   }, []);
 
+  // Layer 1 — navigation guard. The canvas renders the entry's real themed
+  // route, so its links and forms are live and would carry the iframe off the
+  // entry. Neutralize at capture phase (ahead of theme JS). We preventDefault
+  // but deliberately do NOT stopPropagation: the click still bubbles to
+  // handleClick so an in-content link block stays selectable — it just doesn't
+  // navigate. Covers chrome links too (belt-and-suspenders with layer 2).
+  useEffect(() => {
+    const onClickCapture = (event: Event): void => {
+      if ((event.target as HTMLElement | null)?.closest("a[href]")) {
+        event.preventDefault();
+      }
+    };
+    const onSubmitCapture = (event: Event): void => event.preventDefault();
+    // `auxclick` covers middle-click, which doesn't fire `click` — without it a
+    // middle-click would open the themed route in a new tab.
+    document.addEventListener("click", onClickCapture, true);
+    document.addEventListener("auxclick", onClickCapture, true);
+    document.addEventListener("submit", onSubmitCapture, true);
+    return () => {
+      document.removeEventListener("click", onClickCapture, true);
+      document.removeEventListener("auxclick", onClickCapture, true);
+      document.removeEventListener("submit", onSubmitCapture, true);
+    };
+  }, []);
+
+  // Layer 2 — isolate the editable content. The entry's blocks render inside the
+  // content root (this container); the theme chrome (header/footer/nav) is
+  // everything else on the page. Mark those off-path regions `inert` so they
+  // render faithfully but take no clicks, hover, focus or theme-JS events —
+  // mirroring Gutenberg's `disabled` block editing mode. Walks root→body,
+  // disabling each ancestor's other children so only the content branch stays
+  // live. Anchors on the SSR `[data-plumix-content-root]` (production, where the
+  // theme wraps it in chrome), falling back to this container (the standalone
+  // playground, which has no content-root marker).
+  useEffect(() => {
+    const root =
+      document.querySelector<HTMLElement>("[data-plumix-content-root]") ??
+      containerRef.current;
+    if (!root) return;
+    // Track whether we added `inert` so cleanup never strips chrome the theme
+    // had already marked inert itself.
+    const touched: { el: HTMLElement; addedInert: boolean }[] = [];
+    let node: HTMLElement = root;
+    while (node !== document.body) {
+      const parent = node.parentElement;
+      if (!parent) break;
+      for (const sibling of Array.from(parent.children)) {
+        if (sibling !== node && sibling instanceof HTMLElement) {
+          const addedInert = !sibling.hasAttribute("inert");
+          if (addedInert) sibling.setAttribute("inert", "");
+          sibling.setAttribute("data-plumix-chrome", "");
+          touched.push({ el: sibling, addedInert });
+        }
+      }
+      node = parent;
+    }
+    return () => {
+      for (const { el, addedInert } of touched) {
+        if (addedInert) el.removeAttribute("inert");
+        el.removeAttribute("data-plumix-chrome");
+      }
+    };
+  }, []);
+
   const blockIdAt = (event: MouseEvent<HTMLDivElement>): string | null => {
     const block = (event.target as HTMLElement).closest("[data-plumix-id]");
     return block?.getAttribute("data-plumix-id") ?? null;


### PR DESCRIPTION
## Problem
The editor canvas loads the entry's **real themed route** in an iframe (full-page WYSIWYG — theme header, nav, footer, plus the editable blocks). Every `<a>` and `<form>` in there was live and unguarded, so clicking a header/footer link — or even an in-content link — navigated the iframe off the entry being edited. The canvas stopped being a stable editing surface.

## Approach
Researched how Gutenberg, Builder.io, Puck and Craft.js solve this (Gutenberg's post editor sidesteps it by rendering *no* chrome; its site editor renders the full template and bulk-locks chrome via the `disabled` block-editing mode; Builder/Puck intercept host-side). Since we deliberately render the full themed route, the right fit is two layers in the in-iframe runtime:

**Layer 1 — navigation guard.** Capture-phase `click`/`auxclick`/`submit` listeners that `preventDefault()` link navigation (incl. middle-click) and form submits. Deliberately no `stopPropagation()`, so the click still bubbles to selection — an in-content link block stays selectable, it just doesn't navigate.

**Layer 2 — isolate the editable content.** Anchored on the SSR `[data-plumix-content-root]` (the element the editor mounts into in production; falls back to the canvas container in the playground), walk root→body and mark every off-path sibling `inert` — mirroring Gutenberg's `disabled` editing mode. Theme chrome renders **faithfully** (that's the WYSIWYG point — no blur) but takes no clicks, hover, focus or theme-JS, which is also how it communicates "this isn't what you're editing." Cleanup only removes `inert` it added, never a value the theme set itself.

Both run only inside `EditorCanvas` (edit mode only); selection/geometry are unaffected because chrome is untagged (`data-plumix-id` is content-only). Covered by unit tests for link-prevent, middle-click-prevent, submit-prevent, and chrome-inert-with-live-content.

## Deliberately out of scope (follow-ups)
- JS-driven navigation (`location`/`pushState`) — content blocks don't self-navigate and chrome JS is `inert`-neutralized, so this is a low-risk hardening, not a fix.
- A `MutationObserver` for late-loading chrome.
- A **focus-mode to edit the template chrome itself** (Gutenberg's entity-swap model) — the natural next feature once editing chrome is wanted.