### PR TITLE
refactor(plumix): drift-check admin shims for removals, not additions

### DIFF
--- a/packages/plumix/src/admin/radix.ts
+++ b/packages/plumix/src/admin/radix.ts
@@ -2,9 +2,10 @@
 // `window.plumix.runtime.radix` so plugin chunks share it instead of
 // bundling their own copy. The plugin-bundle Vite step aliases bare
 // `radix-ui` imports here (see SHARED_ADMIN_RUNTIME_SPECIFIERS in
-// @plumix/core). Re-export every public upstream member — shim-drift.test.ts
-// fails CI if this falls behind upstream. Each export is annotated with its
-// upstream type so declaration emit references `radix-ui` rather than the
+// @plumix/core). A curated surface, not a full mirror — shim-drift.test.ts
+// fails CI only if a binding re-exported here disappears upstream (#1177); add
+// new upstream bindings when a plugin needs them. Each export is annotated with
+// its upstream type so declaration emit references `radix-ui` rather than the
 // non-portable per-primitive sub-package paths (TS2883).
 import type * as RadixNs from "radix-ui";
 

--- a/packages/plumix/src/admin/shim-drift.test.ts
+++ b/packages/plumix/src/admin/shim-drift.test.ts
@@ -14,10 +14,18 @@ import * as SonnerNs from "sonner";
 import * as TailwindMergeNs from "tailwind-merge";
 import { beforeAll, describe, expect, test } from "vitest";
 
-// Drift detection: when an upstream package adds a new public export,
-// our shim should re-export it. This test fails CI when a shim falls
-// behind upstream — at which point either add the missing export to
-// the shim or extend `KNOWN_GAPS` below with a justification.
+// Drift detection. Each admin shim hand-re-exports a curated slice of an
+// upstream package off `globalThis.plumix.runtime` (admin ships precompiled;
+// plugin chunks reach deps via that global). The shims are an *intentional*
+// surface, not a mirror — so this guards the failure that actually breaks
+// plugins: a binding a shim re-exports having DISAPPEARED upstream (a dangling
+// `ns.X` that resolves to `undefined`), e.g. an upstream rename/removal.
+//
+// It deliberately does NOT fail when upstream *adds* an export the shim hasn't
+// adopted. That additive churn forced a manual `KNOWN_GAPS` edit (with a
+// written rationale) on every routine dependency bump and didn't scale with
+// upstream release cadence (see #1177). New upstream APIs are exposed pull-
+// based: add the binding to the shim when a plugin actually needs it.
 
 beforeAll(() => {
   (globalThis as { plumix?: unknown }).plumix = {
@@ -42,266 +50,53 @@ beforeAll(() => {
 
 interface ShimSpec {
   readonly name: string;
-  readonly upstream: Readonly<Record<string, unknown>>;
   readonly load: () => Promise<Readonly<Record<string, unknown>>>;
-  readonly knownGaps?: ReadonlySet<string>;
 }
 
-// Names we deliberately don't re-export. Reasons:
-//   - `module.exports` / `default` — namespace artefacts, not real exports
-//   - `unstable_*` — explicit opt-out so plugin authors don't depend on
-//     APIs that may break between minor versions
 const SHIMS: readonly ShimSpec[] = [
-  {
-    name: "react",
-    upstream: ReactNs,
-    load: () => import("./react.js"),
-  },
-  {
-    name: "react/jsx-runtime",
-    upstream: ReactJsxRuntimeNs,
-    load: () => import("./react-jsx-runtime.js"),
-  },
-  {
-    name: "react-dom",
-    upstream: ReactDomNs,
-    load: () => import("./react-dom.js"),
-  },
-  {
-    name: "react-dom/client",
-    upstream: ReactDomClientNs,
-    load: () => import("./react-dom-client.js"),
-    // `version` leaks at runtime but isn't in @types/react-dom — skip
-    // until the types include it.
-    knownGaps: new Set(["version"]),
-  },
-  {
-    name: "@tanstack/react-query",
-    upstream: ReactQueryNs,
-    load: () => import("./react-query.js"),
-    knownGaps: new Set([
-      // Internal singletons — plugin code reaches them via hooks
-      // (useIsFetching etc.) instead.
-      "focusManager",
-      "notifyManager",
-      "onlineManager",
-      // Public hook, but its inferred return type references
-      // `QueryErrorResetBoundaryValue` from react-query's internal
-      // `_tsup-dts-rollup.js` — re-exporting trips TS2883 in our
-      // `.d.ts` emit. Plugins that need error-boundary reset can read
-      // it via the `QueryErrorResetBoundary` component (re-exported)
-      // through context.
-      "useQueryErrorResetBoundary",
-      // Internal helpers + symbols — not part of the documented surface.
-      "dataTagErrorSymbol",
-      "dataTagSymbol",
-      "defaultScheduler",
-      "defaultShouldDehydrateMutation",
-      "defaultShouldDehydrateQuery",
-      "environmentManager",
-      "isServer",
-      "noop",
-      "partialMatchKey",
-      "shouldThrowError",
-      "timeoutManager",
-      "unsetMarker",
-      // Experimental — explicit opt-out so plugin authors don't depend
-      // on APIs the upstream may break between minors.
-      "experimental_streamedQuery",
-    ]),
-  },
-  {
-    name: "@tanstack/react-router",
-    upstream: ReactRouterNs,
-    load: () => import("./react-router.js"),
-    // Plugin pages mount inside admin's router via the catch-all
-    // route — they don't construct routers, history, or file routes
-    // themselves. Skip the advanced/internal helpers; revisit when a
-    // plugin actually needs one (the failing test reminds us).
-    knownGaps: new Set([
-      "Asset",
-      "Await",
-      "Asyncify",
-      "Block",
-      "CatchBoundary",
-      "CatchNotFound",
-      "ClientOnly",
-      "DEFAULT_PROTOCOL_ALLOWLIST",
-      "DefaultGlobalNotFound",
-      "DefaultNotFoundComponent",
-      "ErrorComponent",
-      "FileRoute",
-      "FileRouteLoader",
-      "HeadContent",
-      "LazyRoute",
-      "Match",
-      "MatchRoute",
-      "Matches",
-      "NotFoundError",
-      "NotFoundRoute",
-      "PathParamError",
-      "RootRoute",
-      "Route",
-      "RouteApi",
-      "Router",
-      "RouterContextProvider",
-      "ScriptOnce",
-      "Scripts",
-      "SearchParamError",
-      "Transitioner",
-      "asyncBuildLocation",
-      "cleanPath",
-      "composeRewrites",
-      "createBrowserHistory",
-      "createControlledPromise",
-      "createFileRoute",
-      "createHashHistory",
-      "createHistory",
-      "createLazyFileRoute",
-      "createLazyRoute",
-      "createLink",
-      "createMemoryHistory",
-      "createRootRoute",
-      "createRootRouteWithContext",
-      "createRoute",
-      "createRouteMask",
-      "createRouter",
-      "createRouterConfig",
-      "createSerializationAdapter",
-      "decode",
-      "deepEqual",
-      "defaultDeserializeError",
-      "defaultParseSearch",
-      "defaultSerializeError",
-      "defaultStringifySearch",
-      "defaultTransformer",
-      "defer",
-      "encode",
-      "escapeJSON",
-      "exactPathTest",
-      "fileRouteRoutes",
-      "functionalUpdate",
-      "getInitialRouterMetadata",
-      "getLocationChangeInfo",
-      "getMatchedRoutes",
-      "getRouteApi",
-      "isMatch",
-      "isModuleNotFoundError",
-      "isPlainArray",
-      "isPlainObject",
-      "isResolvedRedirect",
-      "joinPaths",
-      "lazyFn",
-      "lazyRouteComponent",
-      "linkOptions",
-      "matchByPath",
-      "matchPathname",
-      "parsePathname",
-      "parseSearchWith",
-      "pick",
-      "preloadWarning",
-      "processRouteTree",
-      // react-router's internal re-export of React's `use` hook — plugins
-      // get `use` from the React shim, so the router copy is redundant.
-      "reactUse",
-      "removeBasepath",
-      "removeTrailingSlash",
-      "replaceEqualDeep",
-      "resolvePath",
-      "retainSearchParams",
-      "rootRouteId",
-      "rootRouteWithContext",
-      "shallow",
-      "stringifySearchWith",
-      "stripSearchParams",
-      "trimPath",
-      "trimPathLeft",
-      "trimPathRight",
-      "useAwaited",
-      "useElementScrollRestoration",
-      "useHydrated",
-      "useLayoutEffect",
-      "useMatchRoute",
-      "useTags",
-      "warning",
-    ]),
-  },
-  {
-    name: "@orpc/client",
-    upstream: OrpcClientNs,
-    load: () => import("./orpc-client.js"),
-  },
-  {
-    name: "@orpc/client/fetch",
-    upstream: OrpcClientFetchNs,
-    load: () => import("./orpc-client-fetch.js"),
-  },
+  { name: "react", load: () => import("./react.js") },
+  { name: "react/jsx-runtime", load: () => import("./react-jsx-runtime.js") },
+  { name: "react-dom", load: () => import("./react-dom.js") },
+  { name: "react-dom/client", load: () => import("./react-dom-client.js") },
+  { name: "@tanstack/react-query", load: () => import("./react-query.js") },
+  { name: "@tanstack/react-router", load: () => import("./react-router.js") },
+  { name: "@orpc/client", load: () => import("./orpc-client.js") },
+  { name: "@orpc/client/fetch", load: () => import("./orpc-client-fetch.js") },
   {
     name: "@orpc/tanstack-query",
-    upstream: OrpcTanstackQueryNs,
     load: () => import("./orpc-tanstack-query.js"),
-    knownGaps: new Set([
-      // Stream handling — adds future-flag risk; opt-in by name when
-      // a plugin actually wants it.
-      "experimental_serializableStreamedQuery",
-    ]),
   },
-  {
-    name: "@lingui/core",
-    upstream: LinguiCoreNs,
-    load: () => import("./lingui-core.js"),
-  },
-  {
-    name: "@lingui/react",
-    upstream: LinguiReactNs,
-    load: () => import("./lingui-react.js"),
-  },
-  {
-    name: "radix-ui",
-    upstream: RadixNs,
-    load: () => import("./radix.js"),
-  },
-  {
-    name: "sonner",
-    upstream: SonnerNs,
-    load: () => import("./sonner.js"),
-  },
-  {
-    name: "tailwind-merge",
-    upstream: TailwindMergeNs,
-    load: () => import("./tailwind-merge.js"),
-  },
+  { name: "@lingui/core", load: () => import("./lingui-core.js") },
+  { name: "@lingui/react", load: () => import("./lingui-react.js") },
+  { name: "radix-ui", load: () => import("./radix.js") },
+  { name: "sonner", load: () => import("./sonner.js") },
+  { name: "tailwind-merge", load: () => import("./tailwind-merge.js") },
 ];
 
+// `default` / `module.exports` / `__esModule` are namespace artefacts whose
+// value can legitimately be `undefined` — never treat them as a broken binding.
 const ALWAYS_SKIPPED_KEYS = new Set([
   "default",
   "module.exports",
   "__esModule",
 ]);
 
-function publicKeysOf(
-  ns: Readonly<Record<string, unknown>>,
-): readonly string[] {
-  return Object.keys(ns)
-    .filter((k) => !ALWAYS_SKIPPED_KEYS.has(k))
-    .filter((k) => !k.startsWith("_"))
-    .filter((k) => !k.startsWith("unstable_"))
-    .sort();
-}
-
 describe("shim drift vs upstream packages", () => {
   test.each(SHIMS)(
-    "$name shim re-exports every public upstream value",
-    async ({ name, upstream, load, knownGaps }) => {
+    "$name shim re-exports only bindings upstream still provides",
+    async ({ name, load }) => {
       const shim = await load();
-      const expected = publicKeysOf(upstream).filter((k) => !knownGaps?.has(k));
-      const actual = publicKeysOf(shim);
-      const missing = expected.filter((k) => !actual.includes(k));
+      // A re-export wired to `ns.X` resolves to a real value when upstream
+      // still provides `X`, and to `undefined` once upstream renames or removes
+      // it. Surface those — they're the silent breakage for plugins.
+      const broken = Object.keys(shim).filter(
+        (k) => !ALWAYS_SKIPPED_KEYS.has(k) && shim[k] === undefined,
+      );
       expect(
-        missing,
-        `Shim "${name}" is missing upstream exports: ${missing.join(", ")}. ` +
-          `Add them to packages/plumix/src/admin/<shim>.ts, or extend ` +
-          `KNOWN_GAPS in shim-drift.test.ts with a justification.`,
+        broken,
+        `Shim "${name}" re-exports bindings that no longer exist upstream: ` +
+          `${broken.join(", ")}. Upstream renamed or removed them — update ` +
+          `packages/plumix/src/admin/<shim>.ts.`,
       ).toEqual([]);
     },
   );

--- a/packages/plumix/src/admin/sonner.ts
+++ b/packages/plumix/src/admin/sonner.ts
@@ -2,8 +2,9 @@
 // `window.plumix.runtime.sonner` so plugin chunks share it instead of
 // bundling their own copy. The plugin-bundle Vite step aliases bare
 // `sonner` imports here (see SHARED_ADMIN_RUNTIME_SPECIFIERS in
-// @plumix/core). Re-export every public upstream member — shim-drift.test.ts
-// fails CI if this falls behind upstream.
+// @plumix/core). A curated surface, not a full mirror — shim-drift.test.ts
+// fails CI only if a binding re-exported here disappears upstream (#1177); add
+// new upstream bindings when a plugin needs them.
 import type * as SonnerNs from "sonner";
 
 import { getRuntime } from "./runtime.js";

--- a/packages/plumix/src/admin/tailwind-merge.ts
+++ b/packages/plumix/src/admin/tailwind-merge.ts
@@ -2,8 +2,9 @@
 // `window.plumix.runtime.tailwindMerge` so plugin chunks share it instead of
 // bundling their own copy. The plugin-bundle Vite step aliases bare
 // `tailwind-merge` imports here (see SHARED_ADMIN_RUNTIME_SPECIFIERS in
-// @plumix/core). Re-export every public upstream member — shim-drift.test.ts
-// fails CI if this falls behind upstream.
+// @plumix/core). A curated surface, not a full mirror — shim-drift.test.ts
+// fails CI only if a binding re-exported here disappears upstream (#1177); add
+// new upstream bindings when a plugin needs them.
 import type * as TailwindMergeNs from "tailwind-merge";
 
 import { getRuntime } from "./runtime.js";


### PR DESCRIPTION
Fixes #1177.

## Problem
The admin exposes bundled runtime libs to plugin chunks via `globalThis.plumix.runtime`, each fronted by a hand-written shim that re-exports the upstream surface one binding at a time (you can't `export *` from a runtime value). `shim-drift` failed whenever upstream **added** a public export the shim hadn't adopted, forcing a manual `KNOWN_GAPS` edit with a written rationale on every routine dependency bump. The react-router gap set alone was ~90 entries; #1176's `reactUse` bump is the canonical instance. Cost scaled with (shimmed packages) × (upstream release cadence).

Reproduced first: dropping one gap on the old test reproduced the failure exactly (`missing upstream exports: reactUse`).

## Fix (issue direction 3 — reframe the contract)
The shims are an **intentional, curated surface**, not a mirror. The test now fails only when a binding a shim re-exports has **disappeared** upstream — detected by loading each shim against the real runtime namespaces and asserting no re-export resolves to `undefined`. That's the regression that silently breaks plugins (an upstream rename/removal); additive churn no longer taxes every bump, and new upstream APIs are exposed pull-based when a plugin needs them.

- All `KNOWN_GAPS` deleted (−~110 lines); `ShimSpec` reduced to `{name, load}`.
- **Shim source files unchanged** → zero runtime/behavior change; this is a test-contract change.
- Refreshed the now-stale "fails CI if this falls behind upstream" comments in the radix/sonner/tailwind-merge shims.

Verified the new guard still catches real breakage: a deliberately-bogus `export const Bogus = ns.Bogus` is reported as "re-exports bindings that no longer exist upstream: Bogus". Reviewed by senpai + simplifier (both findings applied: inlined the single-use helper; fixed the stale shim comments).

## Trade-off
We give up the auto-prompt to expose every new upstream export — deliberate, and aligned with the existing model (the gaps already curated a subset). A plugin wanting a newly-added upstream binding requests a one-line shim addition.