### PR TITLE
perf(plumix): cache loadConfig across cold-start hooks

### DIFF
--- a/packages/plumix/src/cli/load-config.test.ts
+++ b/packages/plumix/src/cli/load-config.test.ts
@@ -1,0 +1,76 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { loadConfig } from "./load-config.js";
+
+// A valid PlumixConfig (passes isPlumixConfig) that bumps a global counter
+// every time the module is evaluated. With jiti's `moduleCache: false`, each
+// real load re-executes the module body — so the counter tells us exactly how
+// many times the config was evaluated vs. served from cache.
+const FIXTURE = `
+(globalThis as unknown as Record<string, number>).__plumixEvalCount =
+  ((globalThis as unknown as Record<string, number>).__plumixEvalCount ?? 0) + 1;
+export default {
+  runtime: { name: "test", buildFetchHandler: () => () => new Response() },
+  database: { kind: "d1" },
+  auth: { passkey: {} },
+};
+`;
+
+const evalStore = globalThis as unknown as { __plumixEvalCount?: number };
+
+function evalCount(): number {
+  return evalStore.__plumixEvalCount ?? 0;
+}
+
+// A fresh temp dir per call gives each test a unique config path, so the
+// module-level cache in load-config.ts never collides across tests (it is keyed
+// by absolute path and intentionally has no reset hook).
+function writeFixtureDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "plumix-loadconfig-"));
+  writeFileSync(join(dir, "plumix.config.ts"), FIXTURE);
+  return dir;
+}
+
+afterEach(() => {
+  evalStore.__plumixEvalCount = 0;
+});
+
+describe("loadConfig", () => {
+  test("evaluates the config once, then serves cold-start callers from cache", async () => {
+    const dir = writeFixtureDir();
+
+    const first = await loadConfig(dir);
+    const second = await loadConfig(dir);
+
+    // The fan-out across CLI + Vite hooks (#1102) collapses to one evaluation.
+    expect(evalCount()).toBe(1);
+    expect(second.config).toBe(first.config);
+  });
+
+  test("`fresh` re-evaluates and refreshes the cache for the watcher", async () => {
+    const dir = writeFixtureDir();
+
+    await loadConfig(dir); // cold start → eval 1
+    const refreshed = await loadConfig(dir, undefined, { fresh: true }); // eval 2
+    const afterRefresh = await loadConfig(dir); // cache hit, no eval
+
+    expect(evalCount()).toBe(2);
+    // The forced-fresh result is what later cold reads now see.
+    expect(afterRefresh.config).toBe(refreshed.config);
+  });
+
+  test("caches per resolved config path", async () => {
+    const a = writeFixtureDir();
+    const b = writeFixtureDir();
+
+    await loadConfig(a);
+    await loadConfig(b);
+    await loadConfig(a);
+
+    // Distinct paths each evaluate once; the repeat of `a` is cached.
+    expect(evalCount()).toBe(2);
+  });
+});

--- a/packages/plumix/src/cli/load-config.ts
+++ b/packages/plumix/src/cli/load-config.ts
@@ -17,12 +17,41 @@ export interface LoadedConfig {
   readonly configPath: string;
 }
 
+export interface LoadConfigOptions {
+  /**
+   * Bypass the cache and re-evaluate the config module, then refresh the cached
+   * entry. The dev file-watcher passes this so an edit to `plumix.config.ts`
+   * hot-reloads; cold-start callers omit it and share one evaluation.
+   */
+  readonly fresh?: boolean;
+}
+
+// One cold start fans `loadConfig` out across the CLI dispatch, the runtime
+// adapter's pre-vite source emit, and the Vite plugin's `config()` +
+// `buildStart()` hooks (the latter once per build environment) — ~8 calls for a
+// build, each re-evaluating the config's whole JSX theme graph (`moduleCache:
+// false`), ~12ms+ apiece. They all resolve to the same file in one process, so
+// cache by absolute path. The watcher invalidates via `fresh` (see #1102), so
+// config hot-reload still works — this is a watch-aware cache, not a plain memo.
+const cache = new Map<string, LoadedConfig>();
+
 export async function loadConfig(
   cwd: string,
   explicit?: string,
+  options?: LoadConfigOptions,
 ): Promise<LoadedConfig> {
   const configPath = resolveConfigPath(cwd, explicit);
+  if (!options?.fresh) {
+    const cached = cache.get(configPath);
+    if (cached) return cached;
+  }
 
+  const loaded = await evaluateConfig(configPath);
+  cache.set(configPath, loaded);
+  return loaded;
+}
+
+async function evaluateConfig(configPath: string): Promise<LoadedConfig> {
   const jiti = createJiti(pathToFileURL(configPath).href, {
     interopDefault: true,
     moduleCache: false,

--- a/packages/plumix/src/vite/index.ts
+++ b/packages/plumix/src/vite/index.ts
@@ -30,6 +30,7 @@ import {
   pluginCatalogStagedPath,
 } from "@plumix/core";
 
+import type { LoadConfigOptions } from "../cli/load-config.js";
 import type { DiscoveredIsland } from "./island-transform.js";
 import { loadConfig } from "../cli/load-config.js";
 import {
@@ -175,11 +176,10 @@ export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
       if (userConfig.publicDir === undefined) {
         base.publicDir = ".plumix/public";
       }
-      // Loaded fresh (not memoized) on purpose: the dev watcher in
-      // `configureServer` re-runs `regenerate` -> `loadConfig` on every
-      // `plumix.config.ts` edit, so a path-keyed cache here would break
-      // config hot-reload. Deduping the cold-start fan-out needs
-      // watch-aware invalidation — tracked in #1102.
+      // Served from the cold-start config cache (#1102) — populated by the CLI
+      // dispatch / `emitPlumixSources` earlier in this same process. The dev
+      // watcher in `configureServer` forces a fresh eval on edits, so config
+      // hot-reload still works.
       const { config } = await loadConfig(scanRoot, options.configFile);
       return config.vite
         ? (mergeConfig(
@@ -264,7 +264,9 @@ export function plumix(options: PlumixVitePluginOptions = {}): Plugin {
     configureServer(server) {
       server.watcher.on("change", (path) => {
         if (!configPath || resolve(path) !== configPath) return;
-        void regenerate(root, options.configFile)
+        // Force-fresh: the whole point of the watcher is to pick up the edit,
+        // so bypass (and refresh) the cold-start config cache.
+        void regenerate(root, options.configFile, { fresh: true })
           .then(async (emitted) => {
             await stageUserPublic({ workspaceRoot: root, publicDir });
             await stageAdminAssets(
@@ -305,13 +307,16 @@ export async function emitPlumixSources(
 async function regenerate(
   cwd: string,
   explicitConfig: string | undefined,
+  // The dev watcher forces a fresh config eval on `plumix.config.ts` edits;
+  // cold-start callers share the cached one (#1102).
+  options?: LoadConfigOptions,
 ): Promise<{
   configPath: string;
   manifest: PlumixManifest;
   registry: PluginRegistry;
   plugins: readonly AnyPluginDescriptor[];
 }> {
-  const { config, configPath } = await loadConfig(cwd, explicitConfig);
+  const { config, configPath } = await loadConfig(cwd, explicitConfig, options);
 
   const schemaSource = generateSchemaSource(config).source;
   writeIfChanged(resolve(cwd, ".plumix/schema.ts"), schemaSource);


### PR DESCRIPTION
Fixes #1102.

## Reproduced
`loadConfig` fans out far more than the issue's "~3×" estimate — **8× per build** (CLI dispatch, the runtime adapter's pre-vite `emitPlumixSources`, and the Vite plugin's `config()` + `buildStart()` hooks, the latter once per build *environment*). Instrumented the blog example:

```
#1 117.8ms  (CLI, cold)
#2  13.0ms  #3 14.6  #4 12.6  #5 12.7  #6 12.1  #7 13.3  #8 13.5   (vite hooks)
≈ 210ms total, ~92ms of it redundant re-evals
```

`import` (the jiti eval of the config + its JSX theme graph, `moduleCache:false`) is ~99% of each call; `resolve`/`createJiti` are noise. The first call is cold; the rest are ~13ms each because Node's module cache is warm but jiti still re-executes the theme graph every time.

## Fix
A path-keyed `Map<configPath, LoadedConfig>` cache. All cold-start callers run in one process (`vite.createBuilder`/`createServer` are in-process), so they share one evaluation — **measured 8 evals → 1** on the blog build. A `fresh` option bypasses *and refreshes* the cache; **only the dev watcher passes it**, so editing `plumix.config.ts` still re-evaluates and hot-reloads. That's the watch-aware invalidation #1102 explicitly required, not a plain memo (which the issue notes would silently break config hot-reload).

`regenerate()` threads the `fresh` flag through; `LoadedConfig` is read-only so sharing one reference across the CLI and plugin is safe. New unit tests assert cache-hit (1 eval), `fresh` re-eval (2 evals), and per-path keying.

Reviewed by senpai + simplifier; applied their findings (refreshed the now-obsolete "loaded fresh on purpose" comment, reused `LoadConfigOptions` in `regenerate`, tidied the test).

## Timing breakdown + follow-up
This removes the ~92ms of redundant config re-evals. The remaining cold-start cost is dominated by the **two sequential Vite/esbuild passes** (client ~1170 modules, worker ~2081 modules) — most of the ~3.3s blog build. Filing a separate issue with that breakdown and further optimization candidates.