### PR TITLE
feat(core): allow an (env) => mailer resolver for request-time secrets

### DIFF
--- a/packages/core/src/auth/mailer/index.ts
+++ b/packages/core/src/auth/mailer/index.ts
@@ -1,2 +1,3 @@
 export { consoleMailer } from "./console.js";
+export type { MailerInput } from "./resolve.js";
 export type { EmailMessage, Mailer } from "./types.js";

--- a/packages/core/src/auth/mailer/resolve.test.ts
+++ b/packages/core/src/auth/mailer/resolve.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { Mailer } from "./types.js";
+import { resolveMailer } from "./resolve.js";
+
+const stubMailer = (): Mailer => ({ send: () => Promise.resolve() });
+
+describe("resolveMailer", () => {
+  test("returns a literal mailer unchanged", () => {
+    const mailer = stubMailer();
+    expect(resolveMailer(mailer, {})).toBe(mailer);
+  });
+
+  test("resolves a resolver with env once, then reuses the result", () => {
+    const mailer = stubMailer();
+    const resolver = vi.fn((_env: unknown) => mailer);
+    const env = { RESEND_API_KEY: "secret" };
+
+    const first = resolveMailer(resolver, env);
+    const second = resolveMailer(resolver, env);
+
+    expect(first).toBe(mailer);
+    expect(second).toBe(mailer);
+    // env is isolate-stable, so build the transport once and reuse it.
+    expect(resolver).toHaveBeenCalledTimes(1);
+    expect(resolver).toHaveBeenCalledWith(env);
+  });
+
+  test("returns undefined when no mailer is configured", () => {
+    expect(resolveMailer(undefined, {})).toBeUndefined();
+  });
+});

--- a/packages/core/src/auth/mailer/resolve.ts
+++ b/packages/core/src/auth/mailer/resolve.ts
@@ -1,0 +1,36 @@
+import type { PlumixEnv } from "../../runtime/bindings.js";
+import type { Mailer } from "./types.js";
+
+/**
+ * The mailer config slot: either a literal {@link Mailer}, or a resolver that
+ * derives one from the runtime `env` at request time. The resolver form is
+ * required wherever the transport's secret only exists per-request — notably
+ * Cloudflare Workers, where the API key arrives via the `env` binding (not
+ * `process.env`) and the config module is evaluated before any request. The
+ * literal form fits Node/Docker, where the key is known at config time. Mirrors
+ * the `libsql()` connection-config union.
+ *
+ * `env` is the type-checked {@link PlumixEnv} — the cloudflare runtime augments
+ * it with the wrangler-generated `Cloudflare.Env`, so `(env) => …` reads bindings
+ * and secrets with full type-safety (no cast) once the user has run
+ * `wrangler types`.
+ */
+export type MailerInput = Mailer | ((env: PlumixEnv) => Mailer);
+
+// Memoize by resolver identity so a transport that owns a connection (SMTP, a
+// pooled client) is built once per isolate, not per request — `env` is
+// isolate-stable, the same lazy-once contract as `libsql()`'s client.
+const resolved = new WeakMap<(env: PlumixEnv) => Mailer, Mailer>();
+
+export function resolveMailer(
+  input: MailerInput | undefined,
+  env: PlumixEnv,
+): Mailer | undefined {
+  if (typeof input !== "function") return input;
+  let mailer = resolved.get(input);
+  if (!mailer) {
+    mailer = input(env);
+    resolved.set(input, mailer);
+  }
+  return mailer;
+}

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -2,7 +2,7 @@ import type { HtmlAllowlistOverride } from "@plumix/blocks";
 import type { RemotePattern } from "@plumix/blocks/renderer";
 
 import type { PlumixAuthConfig } from "./auth/config.js";
-import type { Mailer } from "./auth/mailer/types.js";
+import type { MailerInput } from "./auth/mailer/resolve.js";
 import type { I18nInput, ResolvedI18n } from "./i18n/locale-registry.js";
 import type { PluginDescriptor } from "./plugin/define.js";
 import type { RuntimeAdapter } from "./runtime/adapter.js";
@@ -86,7 +86,7 @@ export interface PlumixConfigInput {
    * configure the transport once at the top level. `consoleMailer()`
    * is the dev default.
    */
-  readonly mailer?: Mailer;
+  readonly mailer?: MailerInput;
   /**
    * The site's theme. Optional: a site that registers none falls back to
    * the built-in {@link welcomeTheme}, which renders a self-contained
@@ -145,7 +145,7 @@ export interface PlumixConfig {
   readonly imageDelivery?: ImageDelivery;
   readonly kv?: KV;
   readonly cache?: CacheProvider;
-  readonly mailer?: Mailer;
+  readonly mailer?: MailerInput;
   readonly theme: ThemeDescriptor;
   readonly plugins: readonly AnyPluginDescriptor[];
   readonly i18n: ResolvedI18n;

--- a/packages/core/src/context/app.test.ts
+++ b/packages/core/src/context/app.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "vitest";
+
+import type { Mailer } from "../auth/mailer/types.js";
+import { createDispatcherHarness } from "../test/dispatcher.js";
+import { createAppContext } from "./app.js";
+
+const stubMailer = (): Mailer => ({ send: () => Promise.resolve() });
+
+describe("createAppContext mailer resolution", () => {
+  test("resolves a mailer resolver against the request env", async () => {
+    const harness = await createDispatcherHarness({ env: { SECRET: "s" } });
+    const mailer = stubMailer();
+    const seenEnv: unknown[] = [];
+
+    const ctx = createAppContext({
+      db: harness.db,
+      env: harness.env,
+      request: new Request("https://cms.example/"),
+      hooks: harness.app.hooks,
+      plugins: harness.app.plugins,
+      // The config slot now accepts an `(env) => Mailer` resolver; the context
+      // must hand consumers the resolved transport, with the request env.
+      mailer: (env) => {
+        seenEnv.push(env);
+        return mailer;
+      },
+    });
+
+    expect(ctx.mailer).toBe(mailer);
+    expect(seenEnv).toEqual([harness.env]);
+  });
+
+  test("passes a literal mailer through unchanged", async () => {
+    const harness = await createDispatcherHarness();
+    const mailer = stubMailer();
+
+    const ctx = createAppContext({
+      db: harness.db,
+      env: harness.env,
+      request: new Request("https://cms.example/"),
+      hooks: harness.app.hooks,
+      plugins: harness.app.plugins,
+      mailer,
+    });
+
+    expect(ctx.mailer).toBe(mailer);
+  });
+});

--- a/packages/core/src/context/app.ts
+++ b/packages/core/src/context/app.ts
@@ -9,6 +9,7 @@ import type { RemotePattern } from "@plumix/blocks/renderer";
 import { createBlockRegistry } from "@plumix/blocks";
 
 import type { RequestAuthenticator } from "../auth/authenticator.js";
+import type { MailerInput } from "../auth/mailer/resolve.js";
 import type { Mailer } from "../auth/mailer/types.js";
 import type { KnownCapability } from "../auth/rbac.js";
 import type * as coreSchema from "../db/schema/index.js";
@@ -26,6 +27,7 @@ import type {
   ImageDelivery,
 } from "../runtime/slots.js";
 import { defaultAuthenticator } from "../auth/authenticator.js";
+import { resolveMailer } from "../auth/mailer/resolve.js";
 import { createCapabilityResolver } from "../auth/rbac.js";
 import { resolveLocales } from "../i18n/locale-registry.js";
 import { resolveLocale } from "../i18n/resolve-locale.js";
@@ -281,7 +283,9 @@ export interface CreateAppContextArgs<TSchema extends Record<string, unknown>> {
   readonly cache?: ConnectedCache;
   readonly imageDelivery?: ImageDelivery;
   readonly imageRemotePatterns?: readonly RemotePattern[];
-  readonly mailer?: Mailer;
+  /** Literal transport, or an `(env) => Mailer` resolver (resolved per-request
+   *  from `env`, memoized) for secrets that only exist at request time. */
+  readonly mailer?: MailerInput;
   readonly i18n?: ResolvedI18n;
   readonly oauthProviders?: readonly OAuthProviderSummary[];
   readonly authenticator?: RequestAuthenticator;
@@ -385,7 +389,7 @@ export function createAppContext<TSchema extends Record<string, unknown>>(
     cache: args.cache,
     imageDelivery: args.imageDelivery,
     imageRemotePatterns: args.imageRemotePatterns,
-    mailer: args.mailer,
+    mailer: resolveMailer(args.mailer, args.env),
     i18n,
     locale,
     oauthProviders: args.oauthProviders ?? [],


### PR DESCRIPTION
Slice 1 of #1022 (mailer — the highest-value, structural gap).

## Problem
On Cloudflare Workers the config module is evaluated at module-init, **before any request**, and secrets arrive via the per-request `env` binding — not `process.env`. A mailer built at config time (Resend/SMTP/CF Email) had no way to read its API key, so magic-link email couldn't work on Workers.

## Fix
Apply the `libsql()` config-resolver pattern to the mailer slot:

```ts
mailer: (env) => resendMailer(env.RESEND_API_KEY)   // resolved per-request, memoized
// — or a literal Mailer, as before
```

`MailerInput = Mailer | ((env: PlumixEnv) => Mailer)`. `createAppContext` resolves the union per request from the request `env` and **memoizes by resolver identity** (a transport that owns a connection is built once per isolate — same lazy-once contract as libsql's client). Resolution is centralized in `createAppContext`, which already receives both the config mailer and `env`, so **no runtime-adapter changes** are needed and `AppContext.mailer` stays a resolved `Mailer` for every consumer. The `magicLink requires mailer` build-time check still holds.

## Typed `env` (no cast)
`env` is the augmentable `PlumixEnv`, not `unknown`. The cloudflare runtime already does `declare module "plumix" { interface PlumixEnv extends Cloudflare.Env {} }`, so once a user runs `wrangler types`, `(env) => env.RESEND_API_KEY` is **fully type-checked against their generated bindings/secrets** — no cast. (libsql + the upcoming OAuth/R2 slots use `unknown` today; converging them on `PlumixEnv` is a small consistency follow-up.)

## Verified end-to-end
Against a real `@cloudflare/vite-plugin` dev server: a `.dev.vars` secret reached an `(env) => Mailer` resolver, and across 3 requests the resolver ran **exactly once** (memoization holds in the real workerd isolate). The Workers local-secrets file is `.dev.vars` (not `.env.local`, which this plugin version doesn't read). Unit tests cover the helper (literal / memoized resolver / undefined) and the `createAppContext` integration (resolver receives the request env; literal passthrough).

## Remaining slices (follow-up PRs)
- OAuth `clientSecret` → `github`/`google` factories take an `(env) =>` resolver.
- R2 S3 presign credentials → `r2({ s3: (env) => … })`.

Reviewed by senpai + simplifier.