### PR TITLE
feat(core): allow an (env) => resolver for oauth client credentials

### DIFF
--- a/packages/core/src/auth/config.ts
+++ b/packages/core/src/auth/config.ts
@@ -166,13 +166,25 @@ const oauthProviderClientSchema = v.object({
   tokenUrl: v.pipe(v.string(), v.url("tokenUrl must be a valid URL")),
   userInfoUrl: v.pipe(v.string(), v.url("userInfoUrl must be a valid URL")),
   scopes: v.array(v.string()),
-  client: v.object({
-    clientId: v.pipe(v.string(), v.nonEmpty("clientId must be non-empty")),
-    clientSecret: v.pipe(
-      v.string(),
-      v.nonEmpty("clientSecret must be non-empty"),
+  // Literal credentials, or an `(env) => OAuthClientConfig` resolver (the
+  // secret is read from the request env at token exchange). The resolver's
+  // return is validated at use, not here — env isn't available at config time.
+  client: v.union([
+    v.object({
+      clientId: v.pipe(v.string(), v.nonEmpty("clientId must be non-empty")),
+      clientSecret: v.pipe(
+        v.string(),
+        v.nonEmpty("clientSecret must be non-empty"),
+      ),
+    }),
+    v.pipe(
+      v.unknown(),
+      v.check(
+        (val) => typeof val === "function",
+        "client must be an { clientId, clientSecret } object or an (env) => … resolver",
+      ),
     ),
-  }),
+  ]),
   parseProfile: v.pipe(
     v.unknown(),
     v.check(

--- a/packages/core/src/auth/mailer/resolve.ts
+++ b/packages/core/src/auth/mailer/resolve.ts
@@ -1,36 +1,19 @@
 import type { PlumixEnv } from "../../runtime/bindings.js";
+import type { EnvInput } from "../../runtime/env-input.js";
 import type { Mailer } from "./types.js";
+import { resolveEnvInput } from "../../runtime/env-input.js";
 
 /**
- * The mailer config slot: either a literal {@link Mailer}, or a resolver that
- * derives one from the runtime `env` at request time. The resolver form is
- * required wherever the transport's secret only exists per-request — notably
- * Cloudflare Workers, where the API key arrives via the `env` binding (not
- * `process.env`) and the config module is evaluated before any request. The
- * literal form fits Node/Docker, where the key is known at config time. Mirrors
- * the `libsql()` connection-config union.
- *
- * `env` is the type-checked {@link PlumixEnv} — the cloudflare runtime augments
- * it with the wrangler-generated `Cloudflare.Env`, so `(env) => …` reads bindings
- * and secrets with full type-safety (no cast) once the user has run
- * `wrangler types`.
+ * The mailer config slot: a literal {@link Mailer}, or an `(env) => Mailer`
+ * resolver for a transport whose API key only exists in the per-request `env`
+ * (the Workers case). See {@link EnvInput} for the shared union + the typed
+ * `env`; resolution is memoized per resolver.
  */
-export type MailerInput = Mailer | ((env: PlumixEnv) => Mailer);
-
-// Memoize by resolver identity so a transport that owns a connection (SMTP, a
-// pooled client) is built once per isolate, not per request — `env` is
-// isolate-stable, the same lazy-once contract as `libsql()`'s client.
-const resolved = new WeakMap<(env: PlumixEnv) => Mailer, Mailer>();
+export type MailerInput = EnvInput<Mailer>;
 
 export function resolveMailer(
   input: MailerInput | undefined,
   env: PlumixEnv,
 ): Mailer | undefined {
-  if (typeof input !== "function") return input;
-  let mailer = resolved.get(input);
-  if (!mailer) {
-    mailer = input(env);
-    resolved.set(input, mailer);
-  }
-  return mailer;
+  return input === undefined ? undefined : resolveEnvInput(input, env);
 }

--- a/packages/core/src/auth/oauth/consumer.ts
+++ b/packages/core/src/auth/oauth/consumer.ts
@@ -1,5 +1,7 @@
 import type { Db } from "../../context/app.js";
+import type { PlumixEnv } from "../../runtime/bindings.js";
 import type { OAuthProfile, OAuthProviderClient } from "./types.js";
+import { resolveEnvInput } from "../../runtime/env-input.js";
 import { OAuthError } from "./errors.js";
 import { computeS256Challenge, generateCodeVerifier } from "./pkce.js";
 import { issueOAuthState } from "./state.js";
@@ -9,6 +11,8 @@ interface BuildAuthorizeUrlInput {
   readonly providerKey: string;
   readonly provider: OAuthProviderClient;
   readonly redirectUri: string;
+  /** Request env, for resolving a `client` that's an `(env) => …` resolver. */
+  readonly env: PlumixEnv;
 }
 
 interface BuiltAuthorizeUrl {
@@ -25,6 +29,7 @@ export async function buildAuthorizeUrl(
   input: BuildAuthorizeUrlInput,
 ): Promise<BuiltAuthorizeUrl> {
   const { provider } = input;
+  const client = resolveEnvInput(provider.client, input.env);
   const codeVerifier = generateCodeVerifier();
   const codeChallenge = await computeS256Challenge(codeVerifier);
 
@@ -34,7 +39,7 @@ export async function buildAuthorizeUrl(
   });
 
   const url = new URL(provider.authorizeUrl);
-  url.searchParams.set("client_id", provider.client.clientId);
+  url.searchParams.set("client_id", client.clientId);
   url.searchParams.set("redirect_uri", input.redirectUri);
   url.searchParams.set("response_type", "code");
   url.searchParams.set("scope", provider.scopes.join(" "));
@@ -51,6 +56,8 @@ interface ExchangeAndFetchInput {
   readonly code: string;
   readonly redirectUri: string;
   readonly codeVerifier: string;
+  /** Request env, for resolving a `client` that's an `(env) => …` resolver. */
+  readonly env: PlumixEnv;
 }
 
 interface TokenResponse {
@@ -103,6 +110,7 @@ async function exchangeCode(
   input: ExchangeAndFetchInput,
 ): Promise<TokenResponse> {
   const { provider } = input;
+  const client = resolveEnvInput(provider.client, input.env);
   // RFC 6749 §2.3.1 / Copenhagen Book: client credentials go in the
   // Authorization header (HTTP Basic). client_id stays in the body for
   // providers (like Google) whose docs require it on the form too —
@@ -111,12 +119,10 @@ async function exchangeCode(
     grant_type: "authorization_code",
     code: input.code,
     redirect_uri: input.redirectUri,
-    client_id: provider.client.clientId,
+    client_id: client.clientId,
     code_verifier: input.codeVerifier,
   });
-  const basic = btoa(
-    `${provider.client.clientId}:${provider.client.clientSecret}`,
-  );
+  const basic = btoa(`${client.clientId}:${client.clientSecret}`);
 
   let response: Response;
   try {

--- a/packages/core/src/auth/oauth/providers/github.ts
+++ b/packages/core/src/auth/oauth/providers/github.ts
@@ -1,8 +1,4 @@
-import type {
-  OAuthClientConfig,
-  OAuthProviderClient,
-  OAuthProviderFactory,
-} from "../types.js";
+import type { OAuthProviderClient, OAuthProviderFactory } from "../types.js";
 
 interface GitHubProfile {
   readonly id: number;
@@ -18,9 +14,7 @@ interface GitHubEmail {
   readonly verified: boolean;
 }
 
-export const github: OAuthProviderFactory = (
-  client: OAuthClientConfig,
-): OAuthProviderClient => ({
+export const github: OAuthProviderFactory = (client): OAuthProviderClient => ({
   label: "GitHub",
   authorizeUrl: "https://github.com/login/oauth/authorize",
   tokenUrl: "https://github.com/login/oauth/access_token",

--- a/packages/core/src/auth/oauth/providers/google.ts
+++ b/packages/core/src/auth/oauth/providers/google.ts
@@ -1,8 +1,4 @@
-import type {
-  OAuthClientConfig,
-  OAuthProviderClient,
-  OAuthProviderFactory,
-} from "../types.js";
+import type { OAuthProviderClient, OAuthProviderFactory } from "../types.js";
 
 interface GoogleProfile {
   readonly sub: string;
@@ -12,9 +8,7 @@ interface GoogleProfile {
   readonly picture: string | null;
 }
 
-export const google: OAuthProviderFactory = (
-  client: OAuthClientConfig,
-): OAuthProviderClient => ({
+export const google: OAuthProviderFactory = (client): OAuthProviderClient => ({
   label: "Google",
   authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",
   tokenUrl: "https://oauth2.googleapis.com/token",

--- a/packages/core/src/auth/oauth/routes.test.ts
+++ b/packages/core/src/auth/oauth/routes.test.ts
@@ -137,6 +137,28 @@ describe("oauth start route", () => {
     expect(rows.some((r) => r.type === "oauth_state")).toBe(true);
   });
 
+  test("resolves an (env) => client config from the request env at authorize", async () => {
+    const h = await createDispatcherHarness({
+      oauth: {
+        github: github((env) => ({
+          clientId: (env as { GH_ID?: string }).GH_ID ?? "",
+          clientSecret: (env as { GH_SECRET?: string }).GH_SECRET ?? "",
+        })),
+      },
+      env: { GH_ID: "gh-from-env", GH_SECRET: "secret-from-env" },
+    });
+    await h.seedUser("admin");
+
+    const response = await h.dispatch(
+      new Request("https://cms.example/_plumix/auth/oauth/github/start"),
+    );
+    const location = response.headers.get("location");
+    if (!location) throw new Error("missing location header");
+
+    // The clientId in the redirect came from the resolver, fed the request env.
+    expect(new URL(location).searchParams.get("client_id")).toBe("gh-from-env");
+  });
+
   test("redirects to login with error when provider isn't configured", async () => {
     const h = await createDispatcherHarness();
     await h.seedUser("admin");

--- a/packages/core/src/auth/oauth/routes.ts
+++ b/packages/core/src/auth/oauth/routes.ts
@@ -50,6 +50,7 @@ export async function handleOAuthStart(
       providerKey,
       provider,
       redirectUri,
+      env: ctx.env,
     });
     return redirectTo(url);
   } catch (error) {
@@ -95,6 +96,7 @@ export async function handleOAuthCallback(
       code,
       redirectUri,
       codeVerifier: stored.codeVerifier,
+      env: ctx.env,
     });
 
     const { user, created } = await resolveOAuthUser(ctx.db, {

--- a/packages/core/src/auth/oauth/types.ts
+++ b/packages/core/src/auth/oauth/types.ts
@@ -1,7 +1,18 @@
+import type { EnvInput } from "../../runtime/env-input.js";
+
 export interface OAuthClientConfig {
   readonly clientId: string;
   readonly clientSecret: string;
 }
+
+/**
+ * Either literal credentials, or an `(env) => OAuthClientConfig` resolver — the
+ * client secret is used at token exchange (request time), so on Workers it must
+ * come from the per-request `env`, not config-time. See {@link EnvInput}.
+ * Module-local: callers reach it through the `github`/`google` factory signature
+ * (`OAuthProviderFactory`), never by name.
+ */
+type OAuthClientInput = EnvInput<OAuthClientConfig>;
 
 export interface OAuthProfile {
   /** Provider-side stable user id. */
@@ -37,7 +48,7 @@ export interface OAuthProviderClient {
   readonly tokenUrl: string;
   readonly userInfoUrl: string;
   readonly scopes: readonly string[];
-  readonly client: OAuthClientConfig;
+  readonly client: OAuthClientInput;
 
   /**
    * Translate the provider's userinfo JSON into a partial OAuthProfile.
@@ -72,7 +83,7 @@ export interface OAuthProviderClient {
  * users can write their own factories the same way.
  */
 export type OAuthProviderFactory = (
-  client: OAuthClientConfig,
+  client: OAuthClientInput,
 ) => OAuthProviderClient;
 
 // Provider keys (the map keys in `auth.oauth.providers`) flow through the

--- a/packages/core/src/runtime/env-input.test.ts
+++ b/packages/core/src/runtime/env-input.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { resolveEnvInput } from "./env-input.js";
+
+describe("resolveEnvInput", () => {
+  test("returns a literal value unchanged", () => {
+    const value = { clientId: "a", clientSecret: "b" };
+    expect(resolveEnvInput(value, {})).toBe(value);
+  });
+
+  test("resolves a resolver with env once, then reuses the result", () => {
+    const value = { clientId: "a", clientSecret: "b" };
+    const resolver = vi.fn((_env: unknown) => value);
+    const env = { GH_SECRET: "s" };
+
+    const first = resolveEnvInput(resolver, env);
+    const second = resolveEnvInput(resolver, env);
+
+    expect(first).toBe(value);
+    expect(second).toBe(value);
+    expect(resolver).toHaveBeenCalledTimes(1);
+    expect(resolver).toHaveBeenCalledWith(env);
+  });
+});

--- a/packages/core/src/runtime/env-input.ts
+++ b/packages/core/src/runtime/env-input.ts
@@ -1,0 +1,30 @@
+import type { PlumixEnv } from "./bindings.js";
+
+/**
+ * A config value that's either a literal `T`, or a resolver deriving it from the
+ * runtime `env` at request time. The resolver form is required wherever the
+ * value carries a secret that only exists per-request — notably Cloudflare
+ * Workers, where secrets arrive via the `env` binding (not `process.env`) and
+ * the config module is evaluated before any request. `env` is the augmentable
+ * {@link PlumixEnv} (the cloudflare runtime extends it with `Cloudflare.Env`),
+ * so a resolver reads bindings/secrets type-checked. Used by the secret-bearing
+ * config slots — `mailer`, OAuth `clientSecret`, R2 S3 creds — all mirroring the
+ * `libsql()` connection-config union.
+ *
+ * `T` must be a non-callable value: the literal-vs-resolver discriminator is
+ * `typeof input === "function"`, which every current slot satisfies (each `T`
+ * is an object).
+ */
+export type EnvInput<T> = T | ((env: PlumixEnv) => T);
+
+// Memoize by resolver identity so a value that owns a connection (an SMTP
+// transport, a pooled client) is built once per isolate, not per request —
+// `env` is isolate-stable, the lazy-once contract `libsql()`'s client uses.
+const cache = new WeakMap<(env: PlumixEnv) => unknown, unknown>();
+
+export function resolveEnvInput<T>(input: EnvInput<T>, env: PlumixEnv): T {
+  if (typeof input !== "function") return input;
+  const resolver = input as (env: PlumixEnv) => T;
+  if (!cache.has(resolver)) cache.set(resolver, resolver(env));
+  return cache.get(resolver) as T;
+}


### PR DESCRIPTION
Slice 2 of #1022 (OAuth `clientSecret`; mailer was slice 1, merged in #1206).

## Problem
The OAuth client secret is used at **token exchange (request time)**, so on Workers it can only come from the per-request `env`. `github`/`google` factories taking a literal `{ clientId, clientSecret }` had no way to read it.

## Fix
The `github`/`google` factories — and `OAuthProviderClient.client` — now accept `OAuthClientConfig | ((env: PlumixEnv) => OAuthClientConfig)`:

```ts
oauth: { providers: { github: github((env) => ({ clientId: env.GH_ID, clientSecret: env.GH_SECRET })) } }
```

`consumer.ts` resolves the client from the request `env` at both the authorize-URL build and the token exchange (same resolver → built once via the shared memo); `routes.ts` threads `ctx.env` in. The valibot `client` schema becomes an **object-or-function union** (the resolver's *return* is validated at use, since `env` is request-time, not config-time). `env` is the typed `PlumixEnv`, so a CF user's `env.GH_SECRET` is checked against their generated `Cloudflare.Env`.

## Convergence (the slice-1 reviewers asked for this)
New `runtime/env-input.ts`: `EnvInput<T> = T | ((env: PlumixEnv) => T)` + `resolveEnvInput<T>` (memoized by resolver identity, one WeakMap, lazy-once per isolate like libsql). The **mailer** slot now delegates to it, dropping its own WeakMap — **no behavior change** (mailer tests still pass). R2 S3 creds (slice 3) will reuse the same shape.

## Verified
Integration test via the dispatcher harness: `github((env) => …)` produces an authorize redirect whose `client_id` came from the request `env`. Full suite green (2302 core tests + 92 oauth/config/mailer/env-input, typecheck/lint).

## Known low follow-ups (non-blocking, from review)
- A malformed *literal* client now surfaces the union message rather than the precise `"clientSecret must be non-empty"` field error (valibot union aggregation).
- `libsql` still uses `(env: unknown)` — converge it onto `EnvInput`/`PlumixEnv` for consistency.

Reviewed by senpai + simplifier.