### PR TITLE
feat: allow an (env) => resolver for r2 s3 presign credentials

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,8 @@ export type { PlumixApp } from "./runtime/app.js";
 export type * from "./runtime/bindings.js";
 export { createPlumixDispatcher } from "./runtime/dispatcher.js";
 export type { PlumixDispatcher } from "./runtime/dispatcher.js";
+export type { EnvInput } from "./runtime/env-input.js";
+export { resolveEnvInput } from "./runtime/env-input.js";
 export {
   forbidden,
   jsonResponse,

--- a/packages/runtimes/cloudflare/src/r2.test.ts
+++ b/packages/runtimes/cloudflare/src/r2.test.ts
@@ -253,4 +253,30 @@ describe("r2 presignPut", () => {
     // among the headers the browser is told to send back.
     expect(result.headers).not.toHaveProperty("host");
   });
+
+  test("resolves an (env) => s3 credentials block from the connect env", async () => {
+    const fake = fakeR2Binding();
+    const store = r2({
+      binding: "MEDIA",
+      s3: (env) => ({
+        bucket: "plumix-media",
+        accountId: "abc123",
+        accessKeyId: (env as { S3_KEY?: string }).S3_KEY ?? "",
+        secretAccessKey: (env as { S3_SECRET?: string }).S3_SECRET ?? "",
+      }),
+    }).connect({
+      MEDIA: fake.binding,
+      S3_KEY: "AKIA-FROM-ENV",
+      S3_SECRET: "secret-from-env",
+    });
+    if (!store.presignPut) throw new Error("r2 should expose presignPut");
+
+    const result = await store.presignPut("uploads/cat.jpg", {
+      contentType: "image/jpeg",
+      expiresIn: 600,
+    });
+
+    // The signing credential came from the resolver, fed the request env.
+    expect(result.url).toContain("AKIA-FROM-ENV");
+  });
 });

--- a/packages/runtimes/cloudflare/src/r2.ts
+++ b/packages/runtimes/cloudflare/src/r2.ts
@@ -1,15 +1,18 @@
 import type {
   ConnectedObjectStorage,
+  EnvInput,
   GetResult,
   ListOptions,
   ListResult,
   ObjectBody,
   ObjectStorage,
+  PlumixEnv,
   PresignedPutResult,
   PresignPutOptions,
   PutOptions,
   UrlOptions,
 } from "plumix";
+import { resolveEnvInput } from "plumix";
 
 import { R2Error } from "./errors.js";
 import { presignPutUrl } from "./sigv4.js";
@@ -41,8 +44,12 @@ export interface R2Config {
    * `presignPut` throws "not configured" and consumers must accept that
    * uploads cannot bypass the worker. R2 native bindings cannot mint
    * presigned URLs — that's an S3-API-only capability.
+   *
+   * Either literal credentials, or an `(env) => R2S3Credentials` resolver — the
+   * keys sign requests at presign (request) time, so on Workers they come from
+   * the per-request `env`, resolved + memoized like the other secret slots.
    */
-  readonly s3?: R2S3Credentials;
+  readonly s3?: EnvInput<R2S3Credentials>;
 }
 
 export interface R2ObjectStorage extends ObjectStorage {
@@ -209,7 +216,10 @@ export function r2(config: R2Config): R2ObjectStorage {
       // R2 native bindings can't mint presigned URLs, so the optional
       // slot stays `undefined` if the consumer didn't opt in.
       if (config.s3) {
-        const s3 = config.s3;
+        // `connect`'s env is loosely typed (`unknown`); a resolver authored
+        // against `EnvInput` expects the typed `PlumixEnv`. The runtime value
+        // is that env — bridge it here, at the one loose boundary.
+        const s3 = resolveEnvInput(config.s3, env as PlumixEnv);
         connected.presignPut = async (
           key: string,
           opts: PresignPutOptions,


### PR DESCRIPTION
**Fixes #1022** (slice 3 of 3 — the last; mailer #1206 and OAuth #1207 already merged).

## Problem
R2 presigned-PUT signing keys are used at **presign (request) time**, so on Workers they can only come from the per-request `env`. An `s3` block with literal `accessKeyId`/`secretAccessKey` at config time couldn't carry them.

## Fix
`r2({ s3 })` now accepts the whole block as `EnvInput<R2S3Credentials>` — a literal or an `(env) => R2S3Credentials` resolver:

```ts
r2({ binding: "MEDIA", s3: (env) => ({ bucket, accountId, accessKeyId: env.S3_KEY, secretAccessKey: env.S3_SECRET }) })
```

Resolved (and memoized) via the shared `resolveEnvInput` inside the storage adapter's `connect(env)`, at the point `presignPut` is attached — so the SigV4 signer gets the env-derived keys. `connect` runs per request but the resolver fires **once per isolate** (WeakMap by resolver identity), the same lazy-once contract as the mailer/OAuth slots.

`EnvInput` + `resolveEnvInput` are now exported from `@plumix/core` so the cloudflare runtime can reuse them. Per review, `resolveEnvInput` stays strict (`env: PlumixEnv`); the one loose boundary — `connect(env: unknown)` — is bridged with a single cast there rather than weakening the shared primitive.

## Verified
Test: `r2({ s3: (env) => … })` produces a SigV4 presigned URL whose `X-Amz-Credential` carries the env-resolved access key. Full suites green (core 2302, runtime-cloudflare 161), knip/typecheck/lint clean. Reviewed by senpai + simplifier (applied simplifier's narrow-the-cast call; one senpai comment finding was unverifiable so skipped).

## #1022 complete
All three secret-bearing slots (mailer, OAuth `clientSecret`, R2 S3) now take the `(env) =>` resolver, converged on one `EnvInput`/`resolveEnvInput` helper. Remaining out-of-scope follow-ups (noted, not blocking): converge `libsql` onto `EnvInput`; the OAuth malformed-literal valibot-union diagnostic.