### PR TITLE
fix(core): surface field-precise oauth client config errors

### DIFF
--- a/packages/core/src/auth/config.test.ts
+++ b/packages/core/src/auth/config.test.ts
@@ -172,6 +172,50 @@ describe("auth() — oauth schema", () => {
     expect(error.issues[0]?.message).toMatch(/authorizeUrl/);
   });
 
+  test("rejects an empty clientSecret literal, naming the field", () => {
+    const error = rejected({
+      passkey: validPasskey,
+      oauth: {
+        providers: {
+          acme: {
+            ...stubProvider,
+            client: { clientId: "id", clientSecret: "" },
+          },
+        },
+      },
+    });
+    expect(error.issues[0]?.message).toMatch(/clientSecret/);
+  });
+
+  test("accepts an (env) => client resolver", () => {
+    const config = auth({
+      passkey: validPasskey,
+      oauth: {
+        providers: {
+          acme: {
+            ...stubProvider,
+            client: () => ({ clientId: "id", clientSecret: "s" }),
+          },
+        },
+      },
+    });
+    expect(config.oauth?.providers.acme).toBeDefined();
+  });
+
+  test("rejects a provider missing the client entirely", () => {
+    const error = rejected({
+      passkey: validPasskey,
+      oauth: {
+        providers: {
+          acme: { ...stubProvider, client: undefined },
+        },
+      } as unknown as PlumixAuthInput["oauth"],
+    });
+    expect(error.issues[0]?.message).toMatch(
+      /client must be an .* object or an .* resolver/,
+    );
+  });
+
   test("rejects a provider missing the parseProfile function", () => {
     const error = rejected({
       passkey: validPasskey,

--- a/packages/core/src/auth/config.ts
+++ b/packages/core/src/auth/config.ts
@@ -126,6 +126,15 @@ export class PlumixConfigError extends Error {
   }
 }
 
+const isPlainObject = (val: unknown): val is Record<string, unknown> =>
+  typeof val === "object" && val !== null;
+
+const isNonEmptyString = (val: unknown): boolean =>
+  typeof val === "string" && val.length > 0;
+
+const field = (val: unknown, key: string): unknown =>
+  isPlainObject(val) ? val[key] : undefined;
+
 const passkeySchema = v.object({
   rpName: v.pipe(v.string(), v.nonEmpty("rpName must be a non-empty string")),
   rpId: v.pipe(v.string(), v.nonEmpty("rpId must be a non-empty string")),
@@ -167,24 +176,29 @@ const oauthProviderClientSchema = v.object({
   userInfoUrl: v.pipe(v.string(), v.url("userInfoUrl must be a valid URL")),
   scopes: v.array(v.string()),
   // Literal credentials, or an `(env) => OAuthClientConfig` resolver (the
-  // secret is read from the request env at token exchange). The resolver's
-  // return is validated at use, not here — env isn't available at config time.
-  client: v.union([
-    v.object({
-      clientId: v.pipe(v.string(), v.nonEmpty("clientId must be non-empty")),
-      clientSecret: v.pipe(
-        v.string(),
-        v.nonEmpty("clientSecret must be non-empty"),
-      ),
-    }),
-    v.pipe(
-      v.unknown(),
-      v.check(
-        (val) => typeof val === "function",
-        "client must be an { clientId, clientSecret } object or an (env) => … resolver",
-      ),
+  // secret is read from the request env at token exchange). A resolver's
+  // return is validated at use, not here — env isn't available at config
+  // time — so the field checks below short-circuit for functions. A bare
+  // pipe (not `v.union`) keeps the literal path's field errors precise:
+  // a union would collapse them into "Expected (Object | unknown)".
+  client: v.pipe(
+    v.unknown(),
+    v.check(
+      (val) => typeof val === "function" || isPlainObject(val),
+      "client must be an { clientId, clientSecret } object or an (env) => … resolver",
     ),
-  ]),
+    v.check(
+      (val) =>
+        typeof val === "function" || isNonEmptyString(field(val, "clientId")),
+      "clientId must be non-empty",
+    ),
+    v.check(
+      (val) =>
+        typeof val === "function" ||
+        isNonEmptyString(field(val, "clientSecret")),
+      "clientSecret must be non-empty",
+    ),
+  ),
   parseProfile: v.pipe(
     v.unknown(),
     v.check(

--- a/packages/core/src/db/libsql.ts
+++ b/packages/core/src/db/libsql.ts
@@ -1,7 +1,10 @@
 import { createClient } from "@libsql/client";
 import { drizzle } from "drizzle-orm/libsql";
 
+import type { PlumixEnv } from "../runtime/bindings.js";
+import type { EnvInput } from "../runtime/env-input.js";
 import type { DatabaseAdapter } from "../runtime/slots.js";
+import { resolveEnvInput } from "../runtime/env-input.js";
 
 export interface LibsqlConfig {
   /**
@@ -13,14 +16,11 @@ export interface LibsqlConfig {
 }
 
 /**
- * Either literal connection config, or a resolver that derives it from the
- * runtime `env` at request time. The resolver form is required wherever the
- * connection secret only exists per-request — notably Cloudflare Workers,
- * where `env` (not `process.env`) carries bindings and the config module is
- * evaluated before any request. The literal form fits Node/Docker, where the
- * URL (including a `file:` path on shared storage) is known at config time.
+ * Literal connection config, or an `(env) => LibsqlConfig` resolver for the
+ * Workers case where the auth token only exists in the per-request `env`. See
+ * {@link EnvInput} for the shared union + the typed `env`.
  */
-export type LibsqlConfigInput = LibsqlConfig | ((env: unknown) => LibsqlConfig);
+export type LibsqlConfigInput = EnvInput<LibsqlConfig>;
 
 export interface LibsqlDatabaseAdapter extends DatabaseAdapter {
   readonly config: LibsqlConfigInput;
@@ -45,7 +45,7 @@ export function libsql(config: LibsqlConfigInput): LibsqlDatabaseAdapter {
     config,
     connect: (env, _request, schema) => {
       if (!client) {
-        const resolved = typeof config === "function" ? config(env) : config;
+        const resolved = resolveEnvInput(config, env as PlumixEnv);
         client = createClient({
           url: resolved.url,
           authToken: resolved.authToken,


### PR DESCRIPTION
A malformed OAuth provider `client` block now reports which field is wrong instead of an opaque valibot union error.

Previously the `client` schema was a `v.union([objectSchema, functionCheck])`. A bad literal — say an empty `clientSecret` — failed both branches, so valibot surfaced `Invalid type: Expected (Object | unknown) but received Object`, naming no field. The union collapsed the object branch's per-field `nonEmpty` messages.

This replaces the union with a bare `v.pipe` of checks. Each check short-circuits for resolver functions (an `(env) => client` resolver is validated at request time, not config time) and otherwise reads the field directly, so a bad literal now reports `clientSecret must be non-empty` against the correct `oauth.providers.<key>.client` dot-path. Error reporting is now first-failure-wins per field, consistent with the rest of the schema. New tests cover the empty-secret literal, the resolver path, and the missing-`client` case (the path where union and pipe diverge most).

Also folds `libsql` onto the shared `EnvInput`/`resolveEnvInput` helper from #1022, dropping its inline `(env: unknown)` union and `typeof` ternary so it matches the mailer/oauth/r2 secret slots. Behavior-preserving — the connection client is still built once per isolate on first `connect`.

Both are loose-end follow-ups from #1022.