### PR TITLE
feat(admin-editor): list all style declarations in the Styles tab

### DIFF
--- a/packages/admin-editor/locales/ar.po
+++ b/packages/admin-editor/locales/ar.po
@@ -69,6 +69,11 @@ msgid "editor.styles.align.right"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.all"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.header.back"
 msgstr ""
@@ -179,6 +184,11 @@ msgid "editor.page.empty"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/style-declarations.tsx
+msgid "editor.styles.none"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/styles-tab.tsx
 msgid "editor.styles.padding"
 msgstr ""
@@ -216,6 +226,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/block-inspector.tsx
 msgid "editor.inspector.refreshData"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/style-declarations.tsx
+msgid "editor.styles.remove"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/de.po
+++ b/packages/admin-editor/locales/de.po
@@ -69,6 +69,11 @@ msgid "editor.styles.align.right"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.all"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.header.back"
 msgstr ""
@@ -179,6 +184,11 @@ msgid "editor.page.empty"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/style-declarations.tsx
+msgid "editor.styles.none"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/styles-tab.tsx
 msgid "editor.styles.padding"
 msgstr ""
@@ -216,6 +226,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/block-inspector.tsx
 msgid "editor.inspector.refreshData"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/style-declarations.tsx
+msgid "editor.styles.remove"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/en.po
+++ b/packages/admin-editor/locales/en.po
@@ -69,6 +69,11 @@ msgid "editor.styles.align.right"
 msgstr "Align right"
 
 #. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.all"
+msgstr "All styles"
+
+#. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.header.back"
 msgstr "Back"
@@ -179,6 +184,11 @@ msgid "editor.page.empty"
 msgstr "No document settings."
 
 #. js-lingui-explicit-id
+#: src/style-declarations.tsx
+msgid "editor.styles.none"
+msgstr "No styles set for this device."
+
+#. js-lingui-explicit-id
 #: src/styles-tab.tsx
 msgid "editor.styles.padding"
 msgstr "Padding"
@@ -217,6 +227,11 @@ msgstr "Redo"
 #: src/block-inspector.tsx
 msgid "editor.inspector.refreshData"
 msgstr "Refresh data"
+
+#. js-lingui-explicit-id
+#: src/style-declarations.tsx
+msgid "editor.styles.remove"
+msgstr "Remove"
 
 #. js-lingui-explicit-id
 #: src/block-catalog-tab.tsx

--- a/packages/admin-editor/locales/uk.po
+++ b/packages/admin-editor/locales/uk.po
@@ -69,6 +69,11 @@ msgid "editor.styles.align.right"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.all"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.header.back"
 msgstr ""
@@ -179,6 +184,11 @@ msgid "editor.page.empty"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/style-declarations.tsx
+msgid "editor.styles.none"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/styles-tab.tsx
 msgid "editor.styles.padding"
 msgstr ""
@@ -216,6 +226,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/block-inspector.tsx
 msgid "editor.inspector.refreshData"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/style-declarations.tsx
+msgid "editor.styles.remove"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/zh-CN.po
+++ b/packages/admin-editor/locales/zh-CN.po
@@ -69,6 +69,11 @@ msgid "editor.styles.align.right"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.all"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.header.back"
 msgstr ""
@@ -179,6 +184,11 @@ msgid "editor.page.empty"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/style-declarations.tsx
+msgid "editor.styles.none"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/styles-tab.tsx
 msgid "editor.styles.padding"
 msgstr ""
@@ -216,6 +226,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/block-inspector.tsx
 msgid "editor.inspector.refreshData"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/style-declarations.tsx
+msgid "editor.styles.remove"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/src/style-declarations.tsx
+++ b/packages/admin-editor/src/style-declarations.tsx
@@ -1,0 +1,91 @@
+import type { ReactElement } from "react";
+import { Trans } from "@lingui/react";
+
+import type { StyleValue } from "@plumix/blocks";
+import { Button } from "@plumix/admin-ui/button";
+import { Trash2 } from "@plumix/admin-ui/icons";
+import { Input } from "@plumix/admin-ui/input";
+
+export interface StyleDeclaration {
+  /** CSS property (camelCase), as stored in the bucket. */
+  readonly property: string;
+  readonly value: StyleValue;
+}
+
+interface StyleDeclarationsProps {
+  readonly declarations: readonly StyleDeclaration[];
+  /** Set a property's raw value, or clear it with `null`. */
+  readonly onChange: (property: string, value: StyleValue | null) => void;
+}
+
+/**
+ * The compiled list of every declaration in the active bucket — the escape
+ * hatch that mirrors what the structured controls write. Raw declarations are
+ * editable inline; token declarations (set via a control's token mode) show
+ * their token id read-only, since their value lives in the theme.
+ */
+export function StyleDeclarations({
+  declarations,
+  onChange,
+}: StyleDeclarationsProps): ReactElement {
+  return (
+    <div className="flex flex-col gap-1" data-testid="style-declarations">
+      {declarations.map(({ property, value }) => (
+        <div
+          key={property}
+          className="flex items-center gap-2"
+          data-testid={`style-declaration-${property}`}
+        >
+          <span
+            className="text-muted-foreground w-1/3 shrink-0 truncate text-xs"
+            title={property}
+          >
+            {property}
+          </span>
+          {"raw" in value ? (
+            <Input
+              className="h-8"
+              data-testid={`style-declaration-${property}-value`}
+              value={value.raw}
+              // Empty-string stays a (raw) declaration rather than clearing —
+              // otherwise clearing the field to retype unmounts the focused row.
+              // The Trash button is the sole delete affordance.
+              onChange={(e) => onChange(property, { raw: e.target.value })}
+            />
+          ) : (
+            <span
+              className="text-muted-foreground flex-1 truncate text-xs italic"
+              data-testid={`style-declaration-${property}-token`}
+            >
+              {value.token}
+            </span>
+          )}
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-8 shrink-0"
+            data-testid={`style-declaration-${property}-remove`}
+            onClick={() => onChange(property, null)}
+          >
+            <Trash2 />
+            <span className="sr-only">
+              <Trans id="editor.styles.remove" message="Remove" />
+            </span>
+          </Button>
+        </div>
+      ))}
+      {declarations.length === 0 ? (
+        <p
+          className="text-muted-foreground text-xs"
+          data-testid="style-declarations-empty"
+        >
+          <Trans
+            id="editor.styles.none"
+            message="No styles set for this device."
+          />
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/admin-editor/src/styles-tab.test.tsx
+++ b/packages/admin-editor/src/styles-tab.test.tsx
@@ -117,3 +117,66 @@ describe("StylesTab", () => {
     );
   });
 });
+
+describe("StylesTab — declarations list", () => {
+  const styled: BlockNode = {
+    id: "a",
+    name: "core/x",
+    style: { large: { color: { raw: "#0c2238" } } },
+  };
+
+  test("lists each declaration in the active bucket with its raw value", () => {
+    const { getByTestId } = renderTab([styled], "a");
+    const value = getByTestId(
+      "style-declaration-color-value",
+    ) as HTMLInputElement;
+    expect(value.value).toBe("#0c2238");
+  });
+
+  test("editing a declaration's value writes it back to the bucket", () => {
+    const { getByTestId } = renderTab([styled], "a");
+    fireEvent.change(getByTestId("style-declaration-color-value"), {
+      target: { value: "rebeccapurple" },
+    });
+    expect(getByTestId("style-probe").textContent).toContain(
+      '"color":{"raw":"rebeccapurple"}',
+    );
+  });
+
+  test("clearing the value keeps the row (only the Trash button deletes)", () => {
+    const { getByTestId } = renderTab([styled], "a");
+    fireEvent.change(getByTestId("style-declaration-color-value"), {
+      target: { value: "" },
+    });
+    // Row survives an empty value so retyping doesn't unmount the focused input.
+    expect(getByTestId("style-declaration-color-value")).toBeDefined();
+    expect(getByTestId("style-probe").textContent).toContain(
+      '"color":{"raw":""}',
+    );
+  });
+
+  test("removing a declaration clears the property", () => {
+    const { getByTestId } = renderTab([styled], "a");
+    fireEvent.click(getByTestId("style-declaration-color-remove"));
+    // The only property is gone, so the style slot prunes to undefined.
+    expect(getByTestId("style-probe").textContent).toBe("");
+  });
+
+  test("a token declaration shows its token id read-only (value lives in theme)", () => {
+    const tokenStyled: BlockNode = {
+      id: "a",
+      name: "core/x",
+      style: { large: { color: { token: "primary" } } },
+    };
+    const { getByTestId, queryByTestId } = renderTab([tokenStyled], "a");
+    expect(getByTestId("style-declaration-color-token").textContent).toBe(
+      "primary",
+    );
+    expect(queryByTestId("style-declaration-color-value")).toBeNull();
+  });
+
+  test("shows an empty hint when the block has no styles for the device", () => {
+    const { getByTestId } = renderTab([{ id: "a", name: "core/x" }], "a");
+    expect(getByTestId("style-declarations-empty")).toBeDefined();
+  });
+});

--- a/packages/admin-editor/src/styles-tab.tsx
+++ b/packages/admin-editor/src/styles-tab.tsx
@@ -22,10 +22,12 @@ import { ToggleGroup, ToggleGroupItem } from "@plumix/admin-ui/toggle-group";
 import { normalizeStyleValue } from "@plumix/blocks";
 
 import type { StyleBucket } from "./store.js";
+import type { StyleDeclaration } from "./style-declarations.js";
 import { findBlock } from "./block-tree-ops.js";
 import { useEditorStore } from "./provider.js";
 import { deviceBucket } from "./store.js";
 import { StyleControl } from "./style-control.js";
+import { StyleDeclarations } from "./style-declarations.js";
 
 interface StylesTabProps {
   readonly tokens: ThemeTokens;
@@ -84,7 +86,7 @@ const SECTIONS: readonly {
   },
 ];
 
-const SECTION_IDS = [...SECTIONS.map((s) => s.id), "spacing"];
+const SECTION_IDS = [...SECTIONS.map((s) => s.id), "spacing", "declarations"];
 
 /**
  * Right-rail Styles tab: collapsible sections of token-or-custom controls plus a
@@ -114,6 +116,12 @@ export function StylesTab({ tokens }: StylesTabProps): ReactElement {
   const current = block.style?.[bucket];
   const valueOf = (property: string): StyleValue | undefined =>
     normalizeStyleValue(current?.[property]) ?? undefined;
+  const declarations: StyleDeclaration[] = Object.entries(
+    current ?? {},
+  ).flatMap(([property, stored]) => {
+    const value = normalizeStyleValue(stored);
+    return value ? [{ property, value }] : [];
+  });
   const setter =
     (property: string) =>
     (value: StyleValue | null): void =>
@@ -160,6 +168,17 @@ export function StylesTab({ tokens }: StylesTabProps): ReactElement {
               tokens={tokens}
               valueOf={valueOf}
               setter={setter}
+            />
+          </AccordionContent>
+        </AccordionItem>
+        <AccordionItem value="declarations">
+          <AccordionTrigger data-testid="styles-section-declarations">
+            <Trans id="editor.styles.all" message="All styles" />
+          </AccordionTrigger>
+          <AccordionContent>
+            <StyleDeclarations
+              declarations={declarations}
+              onChange={(property, value) => setter(property)(value)}
             />
           </AccordionContent>
         </AccordionItem>


### PR DESCRIPTION
Adds an "All styles" section at the bottom of the editor's Styles tab that lists every CSS declaration set on the active block for the current device — the compiled view of the same flat `node.style[bucket]` map (camelCase prop → `{raw}|{token}`) the structured controls already write to.

Raw declarations are editable inline; the value input deliberately keeps the row through an empty value (so clearing to retype doesn't unmount the focused field), leaving the Trash button as the sole delete affordance. Token-valued declarations show their token id read-only, since the value lives in the theme. Everything routes through the existing `updateBlockStyle` store action — which is already property-agnostic and prunes empty buckets — so list/edit/remove of any property works with no schema or render change.

This is the first slice toward a Builder.io-style key/value editor. Adding new declarations, key autocomplete (`margin` → `marginTop/…`), and key rename land in follow-up slices.