### PR TITLE
feat(admin-editor): add new CSS declarations from the Styles tab

### DIFF
--- a/packages/admin-editor/locales/ar.po
+++ b/packages/admin-editor/locales/ar.po
@@ -54,6 +54,11 @@ msgid "editor.canvas.addBlock"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/style-declarations.tsx
+msgid "editor.styles.add"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/styles-tab.tsx
 msgid "editor.styles.align.center"
 msgstr ""
@@ -214,6 +219,11 @@ msgid "editor.header.preview"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/style-declarations.tsx
+msgid "editor.styles.add.key"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.toolbar.publish"
 msgstr ""
@@ -311,6 +321,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.header.untitled"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/style-declarations.tsx
+msgid "editor.styles.add.value"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/de.po
+++ b/packages/admin-editor/locales/de.po
@@ -54,6 +54,11 @@ msgid "editor.canvas.addBlock"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/style-declarations.tsx
+msgid "editor.styles.add"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/styles-tab.tsx
 msgid "editor.styles.align.center"
 msgstr ""
@@ -214,6 +219,11 @@ msgid "editor.header.preview"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/style-declarations.tsx
+msgid "editor.styles.add.key"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.toolbar.publish"
 msgstr ""
@@ -311,6 +321,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.header.untitled"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/style-declarations.tsx
+msgid "editor.styles.add.value"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/en.po
+++ b/packages/admin-editor/locales/en.po
@@ -54,6 +54,11 @@ msgid "editor.canvas.addBlock"
 msgstr "Add a block"
 
 #. js-lingui-explicit-id
+#: src/style-declarations.tsx
+msgid "editor.styles.add"
+msgstr "Add style"
+
+#. js-lingui-explicit-id
 #: src/styles-tab.tsx
 msgid "editor.styles.align.center"
 msgstr "Align center"
@@ -214,6 +219,11 @@ msgid "editor.header.preview"
 msgstr "Preview"
 
 #. js-lingui-explicit-id
+#: src/style-declarations.tsx
+msgid "editor.styles.add.key"
+msgstr "property"
+
+#. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.toolbar.publish"
 msgstr "Publish"
@@ -312,6 +322,11 @@ msgstr "Undo"
 #: src/editor-header.tsx
 msgid "editor.header.untitled"
 msgstr "Untitled"
+
+#. js-lingui-explicit-id
+#: src/style-declarations.tsx
+msgid "editor.styles.add.value"
+msgstr "value"
 
 #. js-lingui-explicit-id
 #: src/editor-header.tsx

--- a/packages/admin-editor/locales/uk.po
+++ b/packages/admin-editor/locales/uk.po
@@ -54,6 +54,11 @@ msgid "editor.canvas.addBlock"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/style-declarations.tsx
+msgid "editor.styles.add"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/styles-tab.tsx
 msgid "editor.styles.align.center"
 msgstr ""
@@ -214,6 +219,11 @@ msgid "editor.header.preview"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/style-declarations.tsx
+msgid "editor.styles.add.key"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.toolbar.publish"
 msgstr ""
@@ -311,6 +321,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.header.untitled"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/style-declarations.tsx
+msgid "editor.styles.add.value"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/zh-CN.po
+++ b/packages/admin-editor/locales/zh-CN.po
@@ -54,6 +54,11 @@ msgid "editor.canvas.addBlock"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/style-declarations.tsx
+msgid "editor.styles.add"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/styles-tab.tsx
 msgid "editor.styles.align.center"
 msgstr ""
@@ -214,6 +219,11 @@ msgid "editor.header.preview"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/style-declarations.tsx
+msgid "editor.styles.add.key"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.toolbar.publish"
 msgstr ""
@@ -311,6 +321,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.header.untitled"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/style-declarations.tsx
+msgid "editor.styles.add.value"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/src/style-declarations.tsx
+++ b/packages/admin-editor/src/style-declarations.tsx
@@ -1,10 +1,15 @@
 import type { ReactElement } from "react";
-import { Trans } from "@lingui/react";
+import { useState } from "react";
+import { Trans, useLingui } from "@lingui/react";
 
 import type { StyleValue } from "@plumix/blocks";
 import { Button } from "@plumix/admin-ui/button";
-import { Trash2 } from "@plumix/admin-ui/icons";
+import { Plus, Trash2 } from "@plumix/admin-ui/icons";
 import { Input } from "@plumix/admin-ui/input";
+
+// A camelCase standard property (`marginTop`) or a CSS custom property
+// (`--brand-gap`) — stricter than the render guard, which also tolerates junk.
+const VALID_PROPERTY = /^(--)?[a-zA-Z][a-zA-Z-]*$/;
 
 export interface StyleDeclaration {
   /** CSS property (camelCase), as stored in the bucket. */
@@ -86,6 +91,78 @@ export function StyleDeclarations({
           />
         </p>
       ) : null}
+      <AddDeclaration
+        onAdd={onChange}
+        existingKeys={declarations.map((d) => d.property)}
+      />
     </div>
+  );
+}
+
+/** Key + value entry row that appends a raw declaration. Submit is gated on a
+ *  valid, non-duplicate CSS property name and a non-empty value, so it can't
+ *  clobber an existing row or write a declaration that drops at emit. */
+function AddDeclaration({
+  onAdd,
+  existingKeys,
+}: {
+  readonly onAdd: (property: string, value: StyleValue) => void;
+  readonly existingKeys: readonly string[];
+}): ReactElement {
+  const { i18n } = useLingui();
+  const [property, setProperty] = useState("");
+  const [value, setValue] = useState("");
+  const trimmed = property.trim();
+  const valid =
+    VALID_PROPERTY.test(trimmed) &&
+    value.trim() !== "" &&
+    !existingKeys.includes(trimmed);
+
+  return (
+    <form
+      className="flex items-center gap-2 pt-1"
+      data-testid="style-declaration-add"
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (!valid) return;
+        onAdd(trimmed, { raw: value });
+        setProperty("");
+        setValue("");
+      }}
+    >
+      <Input
+        className="h-8 w-1/3 shrink-0"
+        data-testid="style-declaration-add-key"
+        placeholder={i18n._({
+          id: "editor.styles.add.key",
+          message: "property",
+        })}
+        value={property}
+        onChange={(e) => setProperty(e.target.value)}
+      />
+      <Input
+        className="h-8"
+        data-testid="style-declaration-add-value"
+        placeholder={i18n._({
+          id: "editor.styles.add.value",
+          message: "value",
+        })}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+      <Button
+        type="submit"
+        variant="ghost"
+        size="icon"
+        className="size-8 shrink-0"
+        disabled={!valid}
+        data-testid="style-declaration-add-submit"
+      >
+        <Plus />
+        <span className="sr-only">
+          <Trans id="editor.styles.add" message="Add style" />
+        </span>
+      </Button>
+    </form>
   );
 }

--- a/packages/admin-editor/src/styles-tab.test.tsx
+++ b/packages/admin-editor/src/styles-tab.test.tsx
@@ -179,4 +179,74 @@ describe("StylesTab — declarations list", () => {
     const { getByTestId } = renderTab([{ id: "a", name: "core/x" }], "a");
     expect(getByTestId("style-declarations-empty")).toBeDefined();
   });
+
+  test("adds a new declaration from the key + value fields", () => {
+    const { getByTestId } = renderTab([{ id: "a", name: "core/x" }], "a");
+    fireEvent.change(getByTestId("style-declaration-add-key"), {
+      target: { value: "letterSpacing" },
+    });
+    fireEvent.change(getByTestId("style-declaration-add-value"), {
+      target: { value: "0.05em" },
+    });
+    fireEvent.click(getByTestId("style-declaration-add-submit"));
+    expect(getByTestId("style-probe").textContent).toContain(
+      '"letterSpacing":{"raw":"0.05em"}',
+    );
+  });
+
+  test("clears the add fields after a successful add", () => {
+    const { getByTestId } = renderTab([{ id: "a", name: "core/x" }], "a");
+    fireEvent.change(getByTestId("style-declaration-add-key"), {
+      target: { value: "opacity" },
+    });
+    fireEvent.change(getByTestId("style-declaration-add-value"), {
+      target: { value: "0.5" },
+    });
+    fireEvent.click(getByTestId("style-declaration-add-submit"));
+    expect(
+      (getByTestId("style-declaration-add-key") as HTMLInputElement).value,
+    ).toBe("");
+    expect(
+      (getByTestId("style-declaration-add-value") as HTMLInputElement).value,
+    ).toBe("");
+  });
+
+  test("does not add a declaration with an invalid key", () => {
+    const { getByTestId } = renderTab([{ id: "a", name: "core/x" }], "a");
+    fireEvent.change(getByTestId("style-declaration-add-key"), {
+      target: { value: "bad key!" },
+    });
+    fireEvent.change(getByTestId("style-declaration-add-value"), {
+      target: { value: "1px" },
+    });
+    fireEvent.click(getByTestId("style-declaration-add-submit"));
+    // Invalid CSS property name → no write, slot stays undefined.
+    expect(getByTestId("style-probe").textContent).toBe("");
+  });
+
+  test("does not add a declaration with an empty value", () => {
+    const { getByTestId } = renderTab([{ id: "a", name: "core/x" }], "a");
+    fireEvent.change(getByTestId("style-declaration-add-key"), {
+      target: { value: "opacity" },
+    });
+    fireEvent.click(getByTestId("style-declaration-add-submit"));
+    // A blank value would drop at emit, so submit stays gated.
+    expect(getByTestId("style-probe").textContent).toBe("");
+  });
+
+  test("does not add a key that already exists (no silent overwrite)", () => {
+    const { getByTestId } = renderTab([styled], "a");
+    fireEvent.change(getByTestId("style-declaration-add-key"), {
+      target: { value: "color" },
+    });
+    fireEvent.change(getByTestId("style-declaration-add-value"), {
+      target: { value: "red" },
+    });
+    fireEvent.click(getByTestId("style-declaration-add-submit"));
+    // The existing color declaration is untouched.
+    expect(getByTestId("style-probe").textContent).toContain(
+      '"color":{"raw":"#0c2238"}',
+    );
+    expect(getByTestId("style-probe").textContent).not.toContain("red");
+  });
 });

--- a/packages/blocks/src/styles/style-emitter.test.ts
+++ b/packages/blocks/src/styles/style-emitter.test.ts
@@ -214,4 +214,14 @@ describe("emitBlockStyleCss", () => {
       emitBlockStyleCss("b", style, { typography: { lg: { value: "20px" } } }),
     ).toBe(".b { font-size: var(--plumix-typography-lg, 20px); }");
   });
+
+  test("preserves the case of custom properties (they are case-sensitive)", () => {
+    const style: ResponsiveStyleSlot = {
+      large: { "--brandColor": { raw: "#0c2238" } },
+    };
+
+    expect(emitBlockStyleCss("b", style, {})).toBe(
+      ".b { --brandColor: #0c2238; }",
+    );
+  });
 });

--- a/packages/blocks/src/styles/style-emitter.ts
+++ b/packages/blocks/src/styles/style-emitter.ts
@@ -157,6 +157,9 @@ function declarationValue(
 }
 
 function propertyToCss(property: string): string {
+  // CSS custom properties are case-sensitive (`--brandColor` ≠ `--brand-color`),
+  // so pass them through verbatim; only camelCase standard props get kebab-cased.
+  if (property.startsWith("--")) return property;
   return property.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
 }
 


### PR DESCRIPTION
Builds on the "All styles" list (#1211) with a key + value entry row, so authors can set any CSS property — not just the ones with a dedicated control. It writes a raw declaration through the same `updateBlockStyle` action.

Submit is gated on a valid, non-duplicate property name (camelCase standard props or `--custom` properties) and a non-empty value. That prevents two sharp edges: adding a key that already exists would silently overwrite the row (and downgrade a token binding to a raw value), and a blank value would write a declaration that's dropped at emit, leaving a confusing dead row. The form submits on Enter as well as the button.

Also fixes a latent emitter bug this path exposes: `propertyToCss` kebab-cased every camelCase name, but CSS custom properties are case-sensitive — `--brandColor` was emitted as `--brand-color`, a different (dead) variable. Custom properties now pass through verbatim, so the custom-property path is correct end to end.

Next slices: key autocomplete (`margin` → `marginTop/…`) and key rename.