### PR TITLE
feat(admin-editor): two-way bind style controls to the value

### DIFF
--- a/packages/admin-editor/src/style-control.tsx
+++ b/packages/admin-editor/src/style-control.tsx
@@ -37,8 +37,13 @@ export function StyleControl({
   onChange,
 }: StyleControlProps): ReactElement {
   const testId = `style-control-${property}`;
-  const [custom, setCustom] = useState(value !== undefined && "raw" in value);
-  const isCustom = category === undefined || custom;
+  // Mode follows the current value's kind, so a value set elsewhere (the
+  // declarations list, another control) reflects here live. With no value, the
+  // user's last toggle (`pref`) decides which input to show for entry.
+  const [pref, setPref] = useState<"token" | "custom">("token");
+  const isCustom =
+    category === undefined ||
+    (value !== undefined ? "raw" in value : pref === "custom");
   const isColor = category === "colors";
   const group = category ? (tokens[category] ?? {}) : {};
   const raw = value && "raw" in value ? value.raw : "";
@@ -51,15 +56,23 @@ export function StyleControl({
           <div className="flex gap-0.5 text-xs">
             <ModeButton
               testId={`${testId}-mode-token`}
-              active={!custom}
-              onClick={() => setCustom(false)}
+              active={!isCustom}
+              // Clear a raw value when switching to token mode so the select
+              // isn't shadowed by a value it can't represent.
+              onClick={() => {
+                setPref("token");
+                if (value && "raw" in value) onChange(null);
+              }}
             >
               <Trans id="editor.styles.mode.token" message="Token" />
             </ModeButton>
             <ModeButton
               testId={`${testId}-mode-custom`}
-              active={custom}
-              onClick={() => setCustom(true)}
+              active={isCustom}
+              onClick={() => {
+                setPref("custom");
+                if (value && "token" in value) onChange(null);
+              }}
             >
               <Trans id="editor.styles.mode.custom" message="Custom" />
             </ModeButton>

--- a/packages/admin-editor/src/styles-tab.test.tsx
+++ b/packages/admin-editor/src/styles-tab.test.tsx
@@ -291,6 +291,43 @@ describe("StylesTab — declarations list", () => {
     expect(getByTestId("style-probe").textContent).not.toContain("99px");
   });
 
+  test("a raw value added in the list reflects in the matching control", () => {
+    // paddingTop's control defaults to token mode; adding a raw value via the
+    // list must flip it to its custom input showing that value (two-way bind).
+    const { getByTestId, queryByTestId } = renderTab(
+      [{ id: "a", name: "core/x" }],
+      "a",
+    );
+    expect(queryByTestId("style-control-paddingTop-custom")).toBeNull();
+
+    fireEvent.click(getByTestId("style-declaration-add-key"));
+    fireEvent.click(getByTestId("style-declaration-add-key-option-paddingTop"));
+    fireEvent.change(getByTestId("style-declaration-add-value"), {
+      target: { value: "7px" },
+    });
+    fireEvent.click(getByTestId("style-declaration-add-submit"));
+
+    const control = getByTestId(
+      "style-control-paddingTop-custom",
+    ) as HTMLInputElement;
+    expect(control.value).toBe("7px");
+  });
+
+  test("switching a token value to custom mode clears it and shows the input", () => {
+    const tokenStyled: BlockNode = {
+      id: "a",
+      name: "core/x",
+      style: { large: { color: { token: "lg" } } },
+    };
+    const { getByTestId, queryByTestId } = renderTab([tokenStyled], "a");
+    // Mounts in token mode (the value is a token), so the custom input is hidden.
+    expect(queryByTestId("style-control-color-custom")).toBeNull();
+    fireEvent.click(getByTestId("style-control-color-mode-custom"));
+    // The incompatible token is cleared and the raw input takes over.
+    expect(getByTestId("style-control-color-custom")).toBeDefined();
+    expect(getByTestId("style-probe").textContent).not.toContain('"color"');
+  });
+
   test("offers no create item for a case-variant of a known property", () => {
     const { getByTestId, queryByTestId } = renderTab(
       [{ id: "a", name: "core/x" }],


### PR DESCRIPTION
Closes the loop on the "All styles" declarations list: the structured style controls now reflect values set anywhere, not just ones they wrote themselves.

`StyleControl` previously latched its token/custom display mode in local state at mount. So a control sitting in token mode wouldn't show a raw value typed into the declarations list (or written by another surface) — the data was shared, but the control's view wasn't. Now the mode is derived from the current value's kind (`raw` → custom input, `token` → token select), falling back to the toggle preference only when the property is unset. Editing `marginTop: 10px` in the list flips the Spacing control's Top field to show `10px`, and vice versa.

The Token/Custom toggle now clears a conflicting value when switching modes, since a token id and a raw literal are different value kinds the other input can't represent (the editor's global undo covers a mis-click). The store remains the single source of truth.