### PR TITLE
feat(admin-editor): rename a style declaration property inline

### DIFF
--- a/packages/admin-editor/src/store.test.ts
+++ b/packages/admin-editor/src/store.test.ts
@@ -618,3 +618,88 @@ describe("updateBlockStyle", () => {
     expect(store.getState().tree).toBe(tree);
   });
 });
+
+describe("renameBlockStyleProperty", () => {
+  test("renames a property in place, preserving its value and position", () => {
+    const store = createEditorStore({
+      tree: [
+        {
+          id: "a",
+          name: "core/x",
+          style: {
+            large: {
+              color: { raw: "#333" },
+              marginTop: { raw: "8px" },
+            },
+          },
+        },
+      ],
+    });
+
+    store
+      .getState()
+      .renameBlockStyleProperty("a", "large", "color", "background");
+
+    // Value kept, order kept (background takes color's first slot).
+    expect(store.getState().tree[0]?.style).toEqual({
+      large: {
+        background: { raw: "#333" },
+        marginTop: { raw: "8px" },
+      },
+    });
+    expect(Object.keys(store.getState().tree[0]?.style?.large ?? {})).toEqual([
+      "background",
+      "marginTop",
+    ]);
+  });
+
+  test("is a no-op when the target name is already taken (no clobber)", () => {
+    const tree: readonly BlockNode[] = [
+      {
+        id: "a",
+        name: "core/x",
+        style: {
+          large: { color: { raw: "#333" }, background: { raw: "#fff" } },
+        },
+      },
+    ];
+    const store = createEditorStore({ tree });
+
+    store
+      .getState()
+      .renameBlockStyleProperty("a", "large", "color", "background");
+
+    expect(store.getState().tree).toBe(tree);
+  });
+
+  test("preserves a token value across a rename", () => {
+    const store = createEditorStore({
+      tree: [
+        {
+          id: "a",
+          name: "core/x",
+          style: { large: { color: { token: "primary" } } },
+        },
+      ],
+    });
+
+    store
+      .getState()
+      .renameBlockStyleProperty("a", "large", "color", "background");
+
+    expect(store.getState().tree[0]?.style).toEqual({
+      large: { background: { token: "primary" } },
+    });
+  });
+
+  test("is a no-op when the source property is missing", () => {
+    const tree: readonly BlockNode[] = [
+      { id: "a", name: "core/x", style: { large: { color: { raw: "#333" } } } },
+    ];
+    const store = createEditorStore({ tree });
+
+    store.getState().renameBlockStyleProperty("a", "large", "nope", "gap");
+
+    expect(store.getState().tree).toBe(tree);
+  });
+});

--- a/packages/admin-editor/src/store.ts
+++ b/packages/admin-editor/src/store.ts
@@ -132,6 +132,14 @@ export interface EditorActions {
     property: string,
     value: StyleValue | null,
   ) => void;
+  /** Rename one style property in a block's bucket, keeping its value and
+   *  position. No-op when the source is missing or the target name is taken. */
+  renameBlockStyleProperty: (
+    id: string,
+    bucket: StyleBucket,
+    from: string,
+    to: string,
+  ) => void;
   select: (id: string, options?: { readonly additive?: boolean }) => void;
   clearSelection: () => void;
   /** Delete every selected block (bulk) and clear the selection. */
@@ -240,6 +248,28 @@ function setNodeStyle(
       ? undefined
       : (nextSlot as ResponsiveStyleSlot);
   return { ...node, style };
+}
+
+// Rename one property in a bucket, rebuilding it so the renamed key holds its
+// old position (a fresh `{ ...bucket, [to]: ... }` would move it to the end).
+// Returns the same reference when the source is missing or the target is taken.
+function renameNodeStyleProperty(
+  node: BlockNode,
+  bucket: StyleBucket,
+  from: string,
+  to: string,
+): BlockNode {
+  const slot: ResponsiveStyleSlot = node.style ?? {};
+  const current: ResponsiveStyleBucket = slot[bucket] ?? {};
+  // Covers from===to too: the source key is then also the (taken) target.
+  if (!(from in current) || to in current) return node;
+  const nextBucket: Record<string, StyleValue | string> = {};
+  for (const [key, val] of Object.entries(current)) {
+    nextBucket[key === from ? to : key] = val;
+  }
+  const nextSlot: Record<string, ResponsiveStyleBucket> = { ...slot };
+  nextSlot[bucket] = nextBucket;
+  return { ...node, style: nextSlot };
 }
 
 export type EditorStore = EditorState & EditorActions;
@@ -356,6 +386,15 @@ export function createEditorStore(
         // Coalesce edits to one property+bucket (e.g. typing a raw value).
         const key = `style:${id}:${bucket}:${property}`;
         return { tree, history: recordHistory(state.history, tree, key) };
+      }),
+    renameBlockStyleProperty: (id, bucket, from, to) =>
+      set((state) => {
+        const tree = mapNodeById(state.tree, id, (node) =>
+          renameNodeStyleProperty(node, bucket, from, to),
+        );
+        if (tree === state.tree) return {};
+        // A blur-committed rename is one atomic action — never coalesced.
+        return { tree, history: recordHistory(state.history, tree, null) };
       }),
     select: (id, options) =>
       set((state) => {

--- a/packages/admin-editor/src/style-declarations.tsx
+++ b/packages/admin-editor/src/style-declarations.tsx
@@ -37,6 +37,8 @@ interface StyleDeclarationsProps {
   readonly declarations: readonly StyleDeclaration[];
   /** Set a property's raw value, or clear it with `null`. */
   readonly onChange: (property: string, value: StyleValue | null) => void;
+  /** Rename a property in place, keeping its value. */
+  readonly onRename: (from: string, to: string) => void;
 }
 
 /**
@@ -48,53 +50,20 @@ interface StyleDeclarationsProps {
 export function StyleDeclarations({
   declarations,
   onChange,
+  onRename,
 }: StyleDeclarationsProps): ReactElement {
+  const keys = declarations.map((d) => d.property);
   return (
     <div className="flex flex-col gap-1" data-testid="style-declarations">
       {declarations.map(({ property, value }) => (
-        <div
+        <DeclarationRow
           key={property}
-          className="flex items-center gap-2"
-          data-testid={`style-declaration-${property}`}
-        >
-          <span
-            className="text-muted-foreground w-1/3 shrink-0 truncate text-xs"
-            title={property}
-          >
-            {property}
-          </span>
-          {"raw" in value ? (
-            <Input
-              className="h-8"
-              data-testid={`style-declaration-${property}-value`}
-              value={value.raw}
-              // Empty-string stays a (raw) declaration rather than clearing —
-              // otherwise clearing the field to retype unmounts the focused row.
-              // The Trash button is the sole delete affordance.
-              onChange={(e) => onChange(property, { raw: e.target.value })}
-            />
-          ) : (
-            <span
-              className="text-muted-foreground flex-1 truncate text-xs italic"
-              data-testid={`style-declaration-${property}-token`}
-            >
-              {value.token}
-            </span>
-          )}
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="size-8 shrink-0"
-            data-testid={`style-declaration-${property}-remove`}
-            onClick={() => onChange(property, null)}
-          >
-            <Trash2 />
-            <span className="sr-only">
-              <Trans id="editor.styles.remove" message="Remove" />
-            </span>
-          </Button>
-        </div>
+          property={property}
+          value={value}
+          siblingKeys={keys}
+          onChange={onChange}
+          onRename={onRename}
+        />
       ))}
       {declarations.length === 0 ? (
         <p
@@ -107,10 +76,85 @@ export function StyleDeclarations({
           />
         </p>
       ) : null}
-      <AddDeclaration
-        onAdd={onChange}
-        existingKeys={declarations.map((d) => d.property)}
+      <AddDeclaration onAdd={onChange} existingKeys={keys} />
+    </div>
+  );
+}
+
+/** One declaration row: an editable property name (renamed on commit), the raw
+ *  value input (or read-only token id), and a remove button. Keyed by property
+ *  in the parent, so the draft re-inits when the row's identity changes. */
+function DeclarationRow({
+  property,
+  value,
+  siblingKeys,
+  onChange,
+  onRename,
+}: {
+  readonly property: string;
+  readonly value: StyleValue;
+  readonly siblingKeys: readonly string[];
+  readonly onChange: (property: string, value: StyleValue | null) => void;
+  readonly onRename: (from: string, to: string) => void;
+}): ReactElement {
+  const [keyDraft, setKeyDraft] = useState(property);
+
+  const commitRename = (): void => {
+    const next = keyDraft.trim();
+    const valid =
+      next !== property &&
+      VALID_PROPERTY.test(next) &&
+      !siblingKeys.includes(next);
+    if (valid) onRename(property, next);
+    else setKeyDraft(property); // snap back on a no-op / invalid edit
+  };
+
+  return (
+    <div
+      className="flex items-center gap-2"
+      data-testid={`style-declaration-${property}`}
+    >
+      <Input
+        className="h-8 w-1/3 shrink-0"
+        data-testid={`style-declaration-${property}-key`}
+        value={keyDraft}
+        onChange={(e) => setKeyDraft(e.target.value)}
+        onBlur={commitRename}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") e.currentTarget.blur();
+        }}
       />
+      {"raw" in value ? (
+        <Input
+          className="h-8"
+          data-testid={`style-declaration-${property}-value`}
+          value={value.raw}
+          // Empty-string stays a (raw) declaration rather than clearing —
+          // otherwise clearing the field to retype unmounts the focused row.
+          // The Trash button is the sole delete affordance.
+          onChange={(e) => onChange(property, { raw: e.target.value })}
+        />
+      ) : (
+        <span
+          className="text-muted-foreground flex-1 truncate text-xs italic"
+          data-testid={`style-declaration-${property}-token`}
+        >
+          {value.token}
+        </span>
+      )}
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="size-8 shrink-0"
+        data-testid={`style-declaration-${property}-remove`}
+        onClick={() => onChange(property, null)}
+      >
+        <Trash2 />
+        <span className="sr-only">
+          <Trans id="editor.styles.remove" message="Remove" />
+        </span>
+      </Button>
     </div>
   );
 }

--- a/packages/admin-editor/src/styles-tab.test.tsx
+++ b/packages/admin-editor/src/styles-tab.test.tsx
@@ -133,6 +133,48 @@ describe("StylesTab — declarations list", () => {
     expect(value.value).toBe("#0c2238");
   });
 
+  test("renames a declaration's property via the key field on commit", () => {
+    const { getByTestId } = renderTab([styled], "a");
+    const key = getByTestId("style-declaration-color-key") as HTMLInputElement;
+    fireEvent.change(key, { target: { value: "background" } });
+    fireEvent.blur(key);
+    expect(getByTestId("style-probe").textContent).toContain(
+      '"background":{"raw":"#0c2238"}',
+    );
+    expect(getByTestId("style-probe").textContent).not.toContain('"color"');
+  });
+
+  test("reverts an invalid rename, leaving the property unchanged", () => {
+    const { getByTestId } = renderTab([styled], "a");
+    const key = getByTestId("style-declaration-color-key") as HTMLInputElement;
+    fireEvent.change(key, { target: { value: "bad key!" } });
+    fireEvent.blur(key);
+    expect(getByTestId("style-probe").textContent).toContain('"color"');
+    // The field snaps back to the original property name.
+    expect(
+      (getByTestId("style-declaration-color-key") as HTMLInputElement).value,
+    ).toBe("color");
+  });
+
+  test("won't rename onto an existing property (no clobber)", () => {
+    const twoProps: BlockNode = {
+      id: "a",
+      name: "core/x",
+      style: { large: { color: { raw: "#333" }, background: { raw: "#fff" } } },
+    };
+    const { getByTestId } = renderTab([twoProps], "a");
+    const key = getByTestId("style-declaration-color-key") as HTMLInputElement;
+    fireEvent.change(key, { target: { value: "background" } });
+    fireEvent.blur(key);
+    // Both originals survive; the collision is rejected.
+    expect(getByTestId("style-probe").textContent).toContain(
+      '"color":{"raw":"#333"}',
+    );
+    expect(getByTestId("style-probe").textContent).toContain(
+      '"background":{"raw":"#fff"}',
+    );
+  });
+
   test("editing a declaration's value writes it back to the bucket", () => {
     const { getByTestId } = renderTab([styled], "a");
     fireEvent.change(getByTestId("style-declaration-color-value"), {

--- a/packages/admin-editor/src/styles-tab.tsx
+++ b/packages/admin-editor/src/styles-tab.tsx
@@ -100,6 +100,9 @@ export function StylesTab({ tokens }: StylesTabProps): ReactElement {
     s.activeId ? findBlock(s.tree, s.activeId) : null,
   );
   const updateBlockStyle = useEditorStore((s) => s.updateBlockStyle);
+  const renameBlockStyleProperty = useEditorStore(
+    (s) => s.renameBlockStyleProperty,
+  );
 
   if (!activeId || !block) {
     return (
@@ -179,6 +182,9 @@ export function StylesTab({ tokens }: StylesTabProps): ReactElement {
             <StyleDeclarations
               declarations={declarations}
               onChange={(property, value) => setter(property)(value)}
+              onRename={(from, to) =>
+                renameBlockStyleProperty(activeId, bucket, from, to)
+              }
             />
           </AccordionContent>
         </AccordionItem>


### PR DESCRIPTION
The "All styles" list showed each property name as read-only text. This makes it an editable field so a declaration can be renamed without removing and re-adding it.

Each row is now a `DeclarationRow` with a local draft that commits on blur or Enter: the rename is applied only when the new name is valid, changed, and doesn't collide with a sibling property — otherwise the field snaps back. Rows are keyed by property, so the draft re-initializes cleanly after a rename and typing never remounts the focused input.

It's backed by an atomic `renameBlockStyleProperty` store action that rebuilds the bucket so the renamed key keeps its original position (a plain `{ ...bucket, [to]: v }` would move it to the end) and no-ops when the source is missing or the target is taken. The rename records a single, non-coalesced undo step. Token-valued declarations rename too, preserving the token binding.

Second-to-last of the deferred follow-ups; the inline token picker for token rows is next.