### PR TITLE
feat(admin-editor): editable CSS declarations section (token picker, var display)

### DIFF
--- a/packages/admin-editor/locales/ar.po
+++ b/packages/admin-editor/locales/ar.po
@@ -44,6 +44,11 @@ msgstr ""
 #~ msgstr ""
 
 #. js-lingui-explicit-id
+#: src/styles-tab.tsx
+#~ msgid "editor.styles.all"
+#~ msgstr ""
+
+#. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.count"
 msgstr ""
@@ -74,11 +79,6 @@ msgid "editor.styles.align.right"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/styles-tab.tsx
-msgid "editor.styles.all"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.header.back"
 msgstr ""
@@ -106,6 +106,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/style-declarations.tsx
 msgid "editor.styles.add.create"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.css"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/de.po
+++ b/packages/admin-editor/locales/de.po
@@ -44,6 +44,11 @@ msgstr ""
 #~ msgstr ""
 
 #. js-lingui-explicit-id
+#: src/styles-tab.tsx
+#~ msgid "editor.styles.all"
+#~ msgstr ""
+
+#. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.count"
 msgstr ""
@@ -74,11 +79,6 @@ msgid "editor.styles.align.right"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/styles-tab.tsx
-msgid "editor.styles.all"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.header.back"
 msgstr ""
@@ -106,6 +106,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/style-declarations.tsx
 msgid "editor.styles.add.create"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.css"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/en.po
+++ b/packages/admin-editor/locales/en.po
@@ -44,6 +44,11 @@ msgstr ""
 #~ msgstr "JSON"
 
 #. js-lingui-explicit-id
+#: src/styles-tab.tsx
+#~ msgid "editor.styles.all"
+#~ msgstr "All styles"
+
+#. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.count"
 msgstr "{count} selected"
@@ -74,11 +79,6 @@ msgid "editor.styles.align.right"
 msgstr "Align right"
 
 #. js-lingui-explicit-id
-#: src/styles-tab.tsx
-msgid "editor.styles.all"
-msgstr "All styles"
-
-#. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.header.back"
 msgstr "Back"
@@ -107,6 +107,11 @@ msgstr "Bold"
 #: src/style-declarations.tsx
 msgid "editor.styles.add.create"
 msgstr "Create"
+
+#. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.css"
+msgstr "CSS"
 
 #. js-lingui-explicit-id
 #: src/style-control.tsx

--- a/packages/admin-editor/locales/uk.po
+++ b/packages/admin-editor/locales/uk.po
@@ -44,6 +44,11 @@ msgstr ""
 #~ msgstr ""
 
 #. js-lingui-explicit-id
+#: src/styles-tab.tsx
+#~ msgid "editor.styles.all"
+#~ msgstr ""
+
+#. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.count"
 msgstr ""
@@ -74,11 +79,6 @@ msgid "editor.styles.align.right"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/styles-tab.tsx
-msgid "editor.styles.all"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.header.back"
 msgstr ""
@@ -106,6 +106,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/style-declarations.tsx
 msgid "editor.styles.add.create"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.css"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/zh-CN.po
+++ b/packages/admin-editor/locales/zh-CN.po
@@ -44,6 +44,11 @@ msgstr ""
 #~ msgstr ""
 
 #. js-lingui-explicit-id
+#: src/styles-tab.tsx
+#~ msgid "editor.styles.all"
+#~ msgstr ""
+
+#. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.count"
 msgstr ""
@@ -74,11 +79,6 @@ msgid "editor.styles.align.right"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: src/styles-tab.tsx
-msgid "editor.styles.all"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.header.back"
 msgstr ""
@@ -106,6 +106,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/style-declarations.tsx
 msgid "editor.styles.add.create"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.css"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/src/style-declarations.tsx
+++ b/packages/admin-editor/src/style-declarations.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from "react";
 import { useState } from "react";
 import { Trans, useLingui } from "@lingui/react";
 
-import type { StyleValue } from "@plumix/blocks";
+import type { StyleValue, ThemeTokens } from "@plumix/blocks";
 import { Button } from "@plumix/admin-ui/button";
 import {
   Command,
@@ -20,6 +20,7 @@ import {
   PopoverTrigger,
 } from "@plumix/admin-ui/popover";
 import { cn } from "@plumix/admin-ui/utils";
+import { tokenCategoryForProperty } from "@plumix/blocks";
 
 import { CSS_PROPERTIES } from "./css-properties.js";
 
@@ -35,6 +36,8 @@ export interface StyleDeclaration {
 
 interface StyleDeclarationsProps {
   readonly declarations: readonly StyleDeclaration[];
+  /** Theme tokens, for the per-property token picker on token-valued rows. */
+  readonly tokens: ThemeTokens;
   /** Set a property's raw value, or clear it with `null`. */
   readonly onChange: (property: string, value: StyleValue | null) => void;
   /** Rename a property in place, keeping its value. */
@@ -43,12 +46,13 @@ interface StyleDeclarationsProps {
 
 /**
  * The compiled list of every declaration in the active bucket — the escape
- * hatch that mirrors what the structured controls write. Raw declarations are
- * editable inline; token declarations (set via a control's token mode) show
- * their token id read-only, since their value lives in the theme.
+ * hatch that mirrors what the structured controls write. Raw declarations edit
+ * as a text value; token declarations edit through an inline token picker of
+ * the property's theme scale.
  */
 export function StyleDeclarations({
   declarations,
+  tokens,
   onChange,
   onRename,
 }: StyleDeclarationsProps): ReactElement {
@@ -61,6 +65,7 @@ export function StyleDeclarations({
           property={property}
           value={value}
           siblingKeys={keys}
+          tokens={tokens}
           onChange={onChange}
           onRename={onRename}
         />
@@ -82,22 +87,26 @@ export function StyleDeclarations({
 }
 
 /** One declaration row: an editable property name (renamed on commit), the raw
- *  value input (or read-only token id), and a remove button. Keyed by property
- *  in the parent, so the draft re-inits when the row's identity changes. */
+ *  value input (or a token picker), and a remove button. Keyed by property in
+ *  the parent, so the draft re-inits when the row's identity changes. */
 function DeclarationRow({
   property,
   value,
   siblingKeys,
+  tokens,
   onChange,
   onRename,
 }: {
   readonly property: string;
   readonly value: StyleValue;
   readonly siblingKeys: readonly string[];
+  readonly tokens: ThemeTokens;
   readonly onChange: (property: string, value: StyleValue | null) => void;
   readonly onRename: (from: string, to: string) => void;
 }): ReactElement {
   const [keyDraft, setKeyDraft] = useState(property);
+  const category = tokenCategoryForProperty(property);
+  const tokenGroup = category ? (tokens[category] ?? {}) : {};
 
   const commitRename = (): void => {
     const next = keyDraft.trim();
@@ -135,12 +144,30 @@ function DeclarationRow({
           onChange={(e) => onChange(property, { raw: e.target.value })}
         />
       ) : (
-        <span
-          className="text-muted-foreground flex-1 truncate text-xs italic"
+        <select
+          className="border-input flex h-8 w-full rounded-md border bg-transparent px-2 text-sm"
           data-testid={`style-declaration-${property}-token`}
+          value={value.token}
+          onChange={(e) =>
+            onChange(
+              property,
+              e.target.value === "" ? null : { token: e.target.value },
+            )
+          }
         >
-          {value.token}
-        </span>
+          <option value="">—</option>
+          {/* Keep an unknown token (stale id, or a property with no token
+              scale) visible + selected — a controlled select with no matching
+              option would render blank, hiding the stored value. */}
+          {value.token !== "" && !(value.token in tokenGroup) ? (
+            <option value={value.token}>{value.token}</option>
+          ) : null}
+          {Object.keys(tokenGroup).map((id) => (
+            <option key={id} value={id}>
+              {tokenGroup[id]?.label ?? id}
+            </option>
+          ))}
+        </select>
       )}
       <Button
         type="button"

--- a/packages/admin-editor/src/style-declarations.tsx
+++ b/packages/admin-editor/src/style-declarations.tsx
@@ -20,7 +20,7 @@ import {
   PopoverTrigger,
 } from "@plumix/admin-ui/popover";
 import { cn } from "@plumix/admin-ui/utils";
-import { tokenCategoryForProperty } from "@plumix/blocks";
+import { tokenCategoryForProperty, tokenCssVar } from "@plumix/blocks";
 
 import { CSS_PROPERTIES } from "./css-properties.js";
 
@@ -107,6 +107,10 @@ function DeclarationRow({
   const [keyDraft, setKeyDraft] = useState(property);
   const category = tokenCategoryForProperty(property);
   const tokenGroup = category ? (tokens[category] ?? {}) : {};
+  // Show a token as the CSS variable it emits (`var(--plumix-color-primary)`),
+  // not its label or resolved literal — this is the raw-CSS view.
+  const tokenVar = (id: string): string =>
+    category ? tokenCssVar(id, category) : id;
 
   const commitRename = (): void => {
     const next = keyDraft.trim();
@@ -160,11 +164,11 @@ function DeclarationRow({
               scale) visible + selected — a controlled select with no matching
               option would render blank, hiding the stored value. */}
           {value.token !== "" && !(value.token in tokenGroup) ? (
-            <option value={value.token}>{value.token}</option>
+            <option value={value.token}>{tokenVar(value.token)}</option>
           ) : null}
           {Object.keys(tokenGroup).map((id) => (
             <option key={id} value={id}>
-              {tokenGroup[id]?.label ?? id}
+              {tokenVar(id)}
             </option>
           ))}
         </select>

--- a/packages/admin-editor/src/style-declarations.tsx
+++ b/packages/admin-editor/src/style-declarations.tsx
@@ -177,7 +177,7 @@ function DeclarationRow({
         type="button"
         variant="ghost"
         size="icon"
-        className="size-8 shrink-0"
+        className="text-destructive hover:text-destructive size-8 shrink-0"
         data-testid={`style-declaration-${property}-remove`}
         onClick={() => onChange(property, null)}
       >

--- a/packages/admin-editor/src/styles-tab.test.tsx
+++ b/packages/admin-editor/src/styles-tab.test.tsx
@@ -24,8 +24,12 @@ function StyleProbe({ id }: { readonly id: string }): ReactElement {
   return <output data-testid="style-probe">{JSON.stringify(style)}</output>;
 }
 
-function renderTab(tree: readonly BlockNode[], activeId?: string) {
-  return render(
+function renderTab(
+  tree: readonly BlockNode[],
+  activeId?: string,
+  { expandCss = true }: { readonly expandCss?: boolean } = {},
+) {
+  const utils = render(
     <I18nProvider i18n={i18n}>
       <EditorProvider initialTree={tree}>
         <ActiveSeed activeId={activeId} />
@@ -34,6 +38,12 @@ function renderTab(tree: readonly BlockNode[], activeId?: string) {
       </EditorProvider>
     </I18nProvider>,
   );
+  // The raw-CSS "declarations" section is collapsed by default; open it so its
+  // content is queryable. Tests asserting the default pass `expandCss: false`.
+  if (activeId && expandCss) {
+    fireEvent.click(utils.getByTestId("styles-section-declarations"));
+  }
+  return utils;
 }
 
 function ActiveSeed({ activeId }: { readonly activeId?: string }): null {
@@ -124,6 +134,15 @@ describe("StylesTab — declarations list", () => {
     name: "core/x",
     style: { large: { color: { raw: "#0c2238" } } },
   };
+
+  test("keeps the CSS section collapsed by default (dev escape hatch)", () => {
+    const { getByTestId, queryByTestId } = renderTab([styled], "a", {
+      expandCss: false,
+    });
+    // The section trigger renders, but its content stays unmounted until opened.
+    expect(getByTestId("styles-section-declarations")).toBeDefined();
+    expect(queryByTestId("style-declaration-color-key")).toBeNull();
+  });
 
   test("lists each declaration in the active bucket with its raw value", () => {
     const { getByTestId } = renderTab([styled], "a");
@@ -221,6 +240,17 @@ describe("StylesTab — declarations list", () => {
     expect(options).toContain("lg");
     expect(options).toContain("sm");
     expect(queryByTestId("style-declaration-fontFamily-value")).toBeNull();
+  });
+
+  test("displays the chosen token as its CSS variable reference", () => {
+    const { getByTestId } = renderTab([fontToken], "a");
+    const picker = getByTestId(
+      "style-declaration-fontFamily-token",
+    ) as HTMLSelectElement;
+    // The selected option reads as the emitted var(), not the label or literal.
+    expect(picker.options[picker.selectedIndex]?.text).toBe(
+      "var(--plumix-typography-lg)",
+    );
   });
 
   test("changing the token picker writes the new token", () => {

--- a/packages/admin-editor/src/styles-tab.test.tsx
+++ b/packages/admin-editor/src/styles-tab.test.tsx
@@ -15,8 +15,8 @@ beforeAll(() => {
 afterEach(cleanup);
 
 const tokens: ThemeTokens = {
-  spacing: { lg: { value: "24px" } },
-  typography: { lg: { value: "20px" } },
+  spacing: { lg: { value: "24px" }, sm: { value: "8px" } },
+  typography: { lg: { value: "20px" }, sm: { value: "14px" } },
 };
 
 function StyleProbe({ id }: { readonly id: string }): ReactElement {
@@ -204,17 +204,56 @@ describe("StylesTab — declarations list", () => {
     expect(getByTestId("style-probe").textContent).toBe("");
   });
 
-  test("a token declaration shows its token id read-only (value lives in theme)", () => {
-    const tokenStyled: BlockNode = {
+  const fontToken: BlockNode = {
+    id: "a",
+    name: "core/x",
+    style: { large: { fontFamily: { token: "lg" } } },
+  };
+
+  test("a token declaration renders a token picker, no raw value input", () => {
+    const { getByTestId, queryByTestId } = renderTab([fontToken], "a");
+    const picker = getByTestId(
+      "style-declaration-fontFamily-token",
+    ) as HTMLSelectElement;
+    expect(picker.value).toBe("lg");
+    // The category's tokens are the options; raw input is absent for a token row.
+    const options = [...picker.options].map((o) => o.value);
+    expect(options).toContain("lg");
+    expect(options).toContain("sm");
+    expect(queryByTestId("style-declaration-fontFamily-value")).toBeNull();
+  });
+
+  test("changing the token picker writes the new token", () => {
+    const { getByTestId } = renderTab([fontToken], "a");
+    fireEvent.change(getByTestId("style-declaration-fontFamily-token"), {
+      target: { value: "sm" },
+    });
+    expect(getByTestId("style-probe").textContent).toContain(
+      '"fontFamily":{"token":"sm"}',
+    );
+  });
+
+  test("keeps an unknown token visible and selected in the picker", () => {
+    const ghost: BlockNode = {
       id: "a",
       name: "core/x",
-      style: { large: { color: { token: "primary" } } },
+      style: { large: { fontFamily: { token: "ghost" } } },
     };
-    const { getByTestId, queryByTestId } = renderTab([tokenStyled], "a");
-    expect(getByTestId("style-declaration-color-token").textContent).toBe(
-      "primary",
-    );
-    expect(queryByTestId("style-declaration-color-value")).toBeNull();
+    const { getByTestId } = renderTab([ghost], "a");
+    const picker = getByTestId(
+      "style-declaration-fontFamily-token",
+    ) as HTMLSelectElement;
+    // "ghost" isn't in the theme, but the select still shows it (not blank).
+    expect(picker.value).toBe("ghost");
+    expect([...picker.options].map((o) => o.value)).toContain("ghost");
+  });
+
+  test("clearing the token picker removes the declaration", () => {
+    const { getByTestId } = renderTab([fontToken], "a");
+    fireEvent.change(getByTestId("style-declaration-fontFamily-token"), {
+      target: { value: "" },
+    });
+    expect(getByTestId("style-probe").textContent).toBe("");
   });
 
   test("shows an empty hint when the block has no styles for the device", () => {

--- a/packages/admin-editor/src/styles-tab.tsx
+++ b/packages/admin-editor/src/styles-tab.tsx
@@ -181,6 +181,7 @@ export function StylesTab({ tokens }: StylesTabProps): ReactElement {
           <AccordionContent>
             <StyleDeclarations
               declarations={declarations}
+              tokens={tokens}
               onChange={(property, value) => setter(property)(value)}
               onRename={(from, to) =>
                 renameBlockStyleProperty(activeId, bucket, from, to)

--- a/packages/admin-editor/src/styles-tab.tsx
+++ b/packages/admin-editor/src/styles-tab.tsx
@@ -86,7 +86,9 @@ const SECTIONS: readonly {
   },
 ];
 
-const SECTION_IDS = [...SECTIONS.map((s) => s.id), "spacing", "declarations"];
+// The visual sections open by default; the raw-CSS "declarations" section is a
+// dev-facing escape hatch, so it starts collapsed.
+const SECTION_IDS = [...SECTIONS.map((s) => s.id), "spacing"];
 
 /**
  * Right-rail Styles tab: collapsible sections of token-or-custom controls plus a
@@ -176,7 +178,7 @@ export function StylesTab({ tokens }: StylesTabProps): ReactElement {
         </AccordionItem>
         <AccordionItem value="declarations">
           <AccordionTrigger data-testid="styles-section-declarations">
-            <Trans id="editor.styles.all" message="All styles" />
+            <Trans id="editor.styles.css" message="CSS" />
           </AccordionTrigger>
           <AccordionContent>
             <StyleDeclarations

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -110,6 +110,7 @@ export {
   DEFAULT_BREAKPOINTS,
   emitBlockStyleCss,
   normalizeStyleValue,
+  tokenCategoryForProperty,
   tokenIdToCssVar,
   VIEWPORT_MAX_PX,
 } from "./styles/style-emitter.js";

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -111,6 +111,7 @@ export {
   emitBlockStyleCss,
   normalizeStyleValue,
   tokenCategoryForProperty,
+  tokenCssVar,
   tokenIdToCssVar,
   VIEWPORT_MAX_PX,
 } from "./styles/style-emitter.js";

--- a/packages/blocks/src/styles/style-emitter.test.ts
+++ b/packages/blocks/src/styles/style-emitter.test.ts
@@ -6,6 +6,7 @@ import {
   emitBlockStyleCss,
   normalizeStyleValue,
   tokenCategoryForProperty,
+  tokenCssVar,
   tokenIdToCssVar,
 } from "./style-emitter.js";
 
@@ -214,6 +215,14 @@ describe("emitBlockStyleCss", () => {
     expect(
       emitBlockStyleCss("b", style, { typography: { lg: { value: "20px" } } }),
     ).toBe(".b { font-size: var(--plumix-typography-lg, 20px); }");
+  });
+
+  test("builds a bare token CSS variable reference (no resolved fallback)", () => {
+    // `colors` maps to the `color` segment; no fallback value is appended.
+    expect(tokenCssVar("primary", "colors")).toBe(
+      "var(--plumix-color-primary)",
+    );
+    expect(tokenCssVar("lg", "spacing")).toBe("var(--plumix-spacing-lg)");
   });
 
   test("resolves the token category for a known property, undefined otherwise", () => {

--- a/packages/blocks/src/styles/style-emitter.test.ts
+++ b/packages/blocks/src/styles/style-emitter.test.ts
@@ -5,6 +5,7 @@ import type { ThemeTokens } from "./types.js";
 import {
   emitBlockStyleCss,
   normalizeStyleValue,
+  tokenCategoryForProperty,
   tokenIdToCssVar,
 } from "./style-emitter.js";
 
@@ -213,6 +214,15 @@ describe("emitBlockStyleCss", () => {
     expect(
       emitBlockStyleCss("b", style, { typography: { lg: { value: "20px" } } }),
     ).toBe(".b { font-size: var(--plumix-typography-lg, 20px); }");
+  });
+
+  test("resolves the token category for a known property, undefined otherwise", () => {
+    expect(tokenCategoryForProperty("marginTop")).toBe("spacing");
+    expect(tokenCategoryForProperty("color")).toBe("colors");
+    expect(tokenCategoryForProperty("borderRadius")).toBe("radius");
+    // A property with no token scale (or an arbitrary custom one) has none.
+    expect(tokenCategoryForProperty("display")).toBeUndefined();
+    expect(tokenCategoryForProperty("--brand")).toBeUndefined();
   });
 
   test("preserves the case of custom properties (they are case-sensitive)", () => {

--- a/packages/blocks/src/styles/style-emitter.ts
+++ b/packages/blocks/src/styles/style-emitter.ts
@@ -97,12 +97,18 @@ export function tokenIdToCssVar(
   category: TokenCategory,
   tokens: ThemeTokens,
 ): string {
-  const cssVar = `--plumix-${categoryToSegment(category)}-${id}`;
   const entry = tokens[category]?.[id];
   if (entry?.value !== undefined) {
-    return `var(${cssVar}, ${entry.value})`;
+    return `var(--plumix-${categoryToSegment(category)}-${id}, ${entry.value})`;
   }
-  return `var(${cssVar})`;
+  return tokenCssVar(id, category);
+}
+
+/** The bare CSS variable reference for a token — `var(--plumix-color-primary)`,
+ *  no resolved fallback. The editor shows this as a token declaration's value so
+ *  the list reads like the emitted CSS rather than the literal it resolves to. */
+export function tokenCssVar(id: string, category: TokenCategory): string {
+  return `var(--plumix-${categoryToSegment(category)}-${id})`;
 }
 
 export function emitBlockStyleCss(

--- a/packages/blocks/src/styles/style-emitter.ts
+++ b/packages/blocks/src/styles/style-emitter.ts
@@ -59,6 +59,15 @@ const PROPERTY_TO_CATEGORY: Readonly<Record<string, TokenCategory>> = {
   boxShadow: "shadow",
 };
 
+/** The token category a property reads from (e.g. `marginTop` → `spacing`), or
+ *  `undefined` for a property with no token scale. The editor uses this to offer
+ *  the right token picker for a declaration. */
+export function tokenCategoryForProperty(
+  property: string,
+): TokenCategory | undefined {
+  return PROPERTY_TO_CATEGORY[property];
+}
+
 const SAFE_CSS_TOKEN_RE = /^[A-Za-z0-9_-]+$/;
 
 export const VIEWPORT_MAX_PX: Readonly<Record<"medium" | "small", number>> = {


### PR DESCRIPTION
Finalizes the editor Styles tab's raw-CSS declaration list (the "All styles" section from #1211), based on review feedback.

- **Token picker.** Token-valued rows were read-only; they now render an inline token `<select>` of the property's theme scale, so a token can be swapped, re-picked, or cleared in the list. Raw rows keep their text input. An unknown token (stale id, or one on a property with no token scale) stays visible/selected via a fallback option rather than rendering blank.
- **`var(…)` display.** A token row shows the CSS variable it emits — `var(--plumix-color-primary)` — not the label or the resolved literal, so the section reads like the shipped CSS. New `tokenCssVar(id, category)` helper exported from `@plumix/blocks`; `tokenIdToCssVar` reuses it.
- **Renamed to "CSS" and collapsed by default.** It's a dev-facing escape hatch distinct from the visual controls above, so it no longer carries the generic "All styles" name and starts collapsed.
- **`tokenCategoryForProperty`** exported from `@plumix/blocks` as the single source of truth for property→token-category (already backs the SSR emitter).

Last of the deferred styles-repeater follow-ups (inline rename landed in #1215).