### PR TITLE
feat(blocks): apply allowlisted HTML attributes to a block root

### DIFF
--- a/packages/blocks/src/html/attrs.test.ts
+++ b/packages/blocks/src/html/attrs.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "vitest";
+
+import { isAllowedHtmlAttr, safeHtmlAttrs } from "./attrs.js";
+
+describe("isAllowedHtmlAttr", () => {
+  test("allows safe global, aria-*, and data-* attributes", () => {
+    expect(isAllowedHtmlAttr("id")).toBe(true);
+    expect(isAllowedHtmlAttr("title")).toBe(true);
+    expect(isAllowedHtmlAttr("role")).toBe(true);
+    expect(isAllowedHtmlAttr("aria-label")).toBe(true);
+    expect(isAllowedHtmlAttr("data-track")).toBe(true);
+  });
+
+  test("rejects event handlers (the XSS surface), case-insensitively", () => {
+    expect(isAllowedHtmlAttr("onclick")).toBe(false);
+    expect(isAllowedHtmlAttr("onClick")).toBe(false);
+    expect(isAllowedHtmlAttr("onerror")).toBe(false);
+  });
+
+  test("rejects React-special, style, and class keys", () => {
+    expect(isAllowedHtmlAttr("dangerouslySetInnerHTML")).toBe(false);
+    expect(isAllowedHtmlAttr("style")).toBe(false);
+    expect(isAllowedHtmlAttr("class")).toBe(false);
+    expect(isAllowedHtmlAttr("className")).toBe(false);
+  });
+
+  test("reserves the framework's data-plumix-* seam", () => {
+    expect(isAllowedHtmlAttr("data-plumix-id")).toBe(false);
+    expect(isAllowedHtmlAttr("data-plumix-block")).toBe(false);
+  });
+
+  test("rejects malformed names that smuggle a second attribute or markup", () => {
+    expect(isAllowedHtmlAttr("data-y onmouseover=alert(1)")).toBe(false);
+    expect(isAllowedHtmlAttr('data-x"><script>')).toBe(false);
+    expect(isAllowedHtmlAttr("aria-label x")).toBe(false);
+  });
+});
+
+describe("safeHtmlAttrs", () => {
+  test("keeps allowed string attributes, drops the rest", () => {
+    expect(
+      safeHtmlAttrs({
+        id: "hero",
+        "aria-label": "Hero",
+        "data-x": "1",
+        onclick: "alert(1)",
+        style: "color:red",
+        class: "evil",
+      }),
+    ).toEqual({ id: "hero", "aria-label": "Hero", "data-x": "1" });
+  });
+
+  test("drops non-string values and handles undefined input", () => {
+    expect(safeHtmlAttrs({ id: "ok", bad: 5 as unknown as string })).toEqual({
+      id: "ok",
+    });
+    expect(safeHtmlAttrs(undefined)).toEqual({});
+  });
+});

--- a/packages/blocks/src/html/attrs.ts
+++ b/packages/blocks/src/html/attrs.ts
@@ -1,0 +1,42 @@
+// Allowlist for author-supplied HTML attributes spread onto a block's root
+// element. Attributes reach the DOM as React props, so the threat isn't the
+// value (React escapes it) but the KEY: a `dangerouslySetInnerHTML` injects
+// markup, and a lowercase `onclick`/`onerror` is rendered as a live handler.
+// An allowlist makes both impossible — only inert, presentational/metadata
+// attributes pass. Enforced at render (the security boundary), like CSS
+// sanitization at emit time; the editor only mirrors it for UX.
+
+// Safe global attributes that work as-is when spread as lowercase React props.
+// (`tabindex`/`contenteditable` etc. are intentionally omitted — they need
+// React's camelCase prop names, and aren't worth the casing dance here.)
+const ALLOWED_GLOBAL = new Set(["id", "title", "role", "lang", "dir"]);
+
+// A well-formed attribute name. Rejecting anything else means a key can't smuggle
+// a second attribute (`data-x onmouseover=…`) or markup (`data-x"><script>`) —
+// so the allowlist stands on its own, not only because React drops bad names.
+const ATTR_NAME = /^[a-z][a-z0-9-]*$/;
+
+/** Whether an author may set this attribute on a block. Allows the safe global
+ *  set plus `aria-*` and `data-*` wildcards, minus the framework's reserved
+ *  `data-plumix-*` seam. Everything else (event handlers, `style`, `class`,
+ *  `dangerouslySetInnerHTML`, malformed names, …) is rejected. */
+export function isAllowedHtmlAttr(name: string): boolean {
+  const n = name.toLowerCase();
+  if (!ATTR_NAME.test(n)) return false;
+  if (n.startsWith("data-plumix-")) return false;
+  if (n.startsWith("aria-") || n.startsWith("data-")) return true;
+  return ALLOWED_GLOBAL.has(n);
+}
+
+/** Filter an author-supplied attribute map down to the allowlisted, string-
+ *  valued entries safe to spread onto a block element. */
+export function safeHtmlAttrs(
+  attrs: Readonly<Record<string, unknown>> | undefined,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!attrs) return out;
+  for (const [key, value] of Object.entries(attrs)) {
+    if (typeof value === "string" && isAllowedHtmlAttr(key)) out[key] = value;
+  }
+  return out;
+}

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -132,6 +132,7 @@ export type {
 } from "./styles/types.js";
 
 // ─── HTML sanitisation ──────────────────────────────────────────────────────
+export { isAllowedHtmlAttr, safeHtmlAttrs } from "./html/attrs.js";
 export { BASELINE_HTML_ALLOWLIST, sanitizeHtml } from "./html/sanitize.js";
 export type { HtmlAllowlist } from "./html/sanitize.js";
 export { buildHtmlAllowlist } from "./html/build-allowlist.js";

--- a/packages/blocks/src/render-block-tree.test.tsx
+++ b/packages/blocks/src/render-block-tree.test.tsx
@@ -36,6 +36,67 @@ const headingRegistry = createBlockRegistry([
   },
 ]);
 
+const selfSeamRegistry = createBlockRegistry([
+  {
+    name: "core/box",
+    selfSeam: true,
+    render: ({ blockProps }) => <section {...blockProps}>box</section>,
+  },
+]);
+
+describe("renderBlockTree — htmlAttrs", () => {
+  test("spreads allowlisted attributes onto the wrapper, dropping unsafe keys", () => {
+    const node: BlockNode = {
+      id: "abc",
+      name: "core/heading",
+      attrs: { text: "Hi", level: 2 },
+      htmlAttrs: {
+        id: "hero",
+        "data-track": "cta",
+        onclick: "alert(1)",
+        style: "color:red",
+      },
+    };
+
+    const html = renderToStaticMarkup(renderBlockTree([node], headingRegistry));
+
+    expect(html).toContain('id="hero"');
+    expect(html).toContain('data-track="cta"');
+    expect(html).not.toContain("onclick");
+    expect(html).not.toContain("style=");
+  });
+
+  test("never lets an attribute clobber the framework data-plumix seam", () => {
+    const node: BlockNode = {
+      id: "abc",
+      name: "core/heading",
+      attrs: { text: "Hi", level: 2 },
+      htmlAttrs: { "data-plumix-block": "evil" },
+    };
+
+    const html = renderToStaticMarkup(renderBlockTree([node], headingRegistry));
+
+    expect(html).toContain('data-plumix-block="core/heading"');
+    expect(html).not.toContain("evil");
+  });
+
+  test("applies attributes to a selfSeam block's own root element", () => {
+    const node: BlockNode = {
+      id: "abc",
+      name: "core/box",
+      htmlAttrs: { id: "panel", "aria-label": "Panel" },
+    };
+
+    const html = renderToStaticMarkup(
+      renderBlockTree([node], selfSeamRegistry),
+    );
+
+    expect(html).toContain("<section");
+    expect(html).toContain('id="panel"');
+    expect(html).toContain('aria-label="Panel"');
+  });
+});
+
 describe("renderBlockTree", () => {
   test("renders a single heading block with its text attribute", () => {
     const heading: BlockNode = {

--- a/packages/blocks/src/render-block-tree.ts
+++ b/packages/blocks/src/render-block-tree.ts
@@ -15,6 +15,7 @@ import type {
 } from "./styles/style-emitter.js";
 import type { ThemeTokens } from "./styles/types.js";
 import { editAppender } from "./edit-appender.js";
+import { safeHtmlAttrs } from "./html/attrs.js";
 import { emitBlockStyleCss } from "./styles/style-emitter.js";
 
 const PATTERN_REF_BLOCK = "core/pattern-ref";
@@ -46,6 +47,10 @@ export interface BlockNode {
   readonly name: string;
   readonly attrs?: Readonly<Record<string, unknown>>;
   readonly style?: ResponsiveStyleSlot;
+  /** Author-supplied HTML attributes spread onto the block's root element.
+   *  Filtered through {@link safeHtmlAttrs} at render — only allowlisted, inert
+   *  keys (id, title, role, aria-, data- prefixes) survive. Not responsive. */
+  readonly htmlAttrs?: Readonly<Record<string, string>>;
   /** Author-given instance name shown in the Layers tree; falls back to the
    *  block type's title when absent. Editor-only metadata, ignored at render. */
   readonly label?: string;
@@ -89,11 +94,16 @@ export interface RenderBlockTreeOptions {
 
 /** Editor/style seam attributes a block spreads onto its root element when it
  *  opts into `selfSeam`. `data-plumix-id` is present only in edit mode. */
-interface BlockProps {
+/** The framework seam keys a block spreads onto its root element. */
+interface BlockSeamProps {
   readonly "data-plumix-block": string;
   readonly "data-plumix-id"?: string;
   readonly className?: string;
 }
+
+// Seam props plus author HTML attributes. The seam keys are spread last when
+// built, so they always win a key collision.
+type BlockProps = Readonly<Record<string, string | undefined>> & BlockSeamProps;
 
 export interface BlockNodeRenderProps<
   Attrs = Readonly<Record<string, unknown>>,
@@ -297,6 +307,7 @@ function renderNode(
     ? createElement("style", { key: "style" }, styleCss)
     : null;
   const blockProps: BlockProps = {
+    ...safeHtmlAttrs(node.htmlAttrs),
     "data-plumix-block": node.name,
     "data-plumix-id": env.editing && safeId ? safeId : undefined,
     className,


### PR DESCRIPTION
First slice of block-level HTML attributes (analogous to the CSS declarations section). Adds an `htmlAttrs` field to `BlockNode` and applies it to the block's rendered root — the wrapper `<div>` for normal blocks, the block's own root for `selfSeam` blocks (heading, table cells).

Author-supplied attributes reach the DOM as React props, which is an XSS surface: a lowercase `onclick` renders as a live handler and `dangerouslySetInnerHTML` injects markup. So they pass an **allowlist at render time** — the security boundary, mirroring CSS sanitization at emit, so even imported/legacy data is safe. Only `id`/`title`/`role`/`lang`/`dir` plus `aria-*` and `data-*` survive, minus the reserved `data-plumix-*` seam, and only well-formed attribute names with string values (a malformed name like `data-x onmouseover=…` can't smuggle a second attribute). Framework seam keys are spread last, so an attribute can never clobber `data-plumix-*` or the generated style class.

This reuses our allowlist *model* (the same approach `sanitize-html` uses for rich-text content) rather than the string purifier, which doesn't fit a React prop map.

Next: the `updateBlockHtmlAttrs` store action, then the repeater UI in the Block inspector.