### PR TITLE
feat(admin-editor): edit block HTML attributes in the Block tab

### DIFF
--- a/packages/admin-editor/locales/ar.po
+++ b/packages/admin-editor/locales/ar.po
@@ -59,6 +59,11 @@ msgid "editor.canvas.addBlock"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/style-declarations.tsx
 msgid "editor.styles.add"
 msgstr ""
@@ -76,6 +81,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/styles-tab.tsx
 msgid "editor.styles.align.right"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add.key"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -101,6 +111,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/styles-tab.tsx
 msgid "editor.styles.mark.bold"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add.create"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -154,6 +169,11 @@ msgid "editor.richtext.hint"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/block-inspector.tsx
+msgid "editor.htmlAttrs.title"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/styles-tab.tsx
 msgid "editor.styles.mark.italic"
 msgstr ""
@@ -181,6 +201,16 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.moveUp"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add.none"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.none"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -254,8 +284,18 @@ msgid "editor.inspector.refreshData"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.remove"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/style-declarations.tsx
 msgid "editor.styles.remove"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add.search"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -341,6 +381,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.header.untitled"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add.value"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/de.po
+++ b/packages/admin-editor/locales/de.po
@@ -59,6 +59,11 @@ msgid "editor.canvas.addBlock"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/style-declarations.tsx
 msgid "editor.styles.add"
 msgstr ""
@@ -76,6 +81,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/styles-tab.tsx
 msgid "editor.styles.align.right"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add.key"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -101,6 +111,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/styles-tab.tsx
 msgid "editor.styles.mark.bold"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add.create"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -154,6 +169,11 @@ msgid "editor.richtext.hint"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/block-inspector.tsx
+msgid "editor.htmlAttrs.title"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/styles-tab.tsx
 msgid "editor.styles.mark.italic"
 msgstr ""
@@ -181,6 +201,16 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.moveUp"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add.none"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.none"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -254,8 +284,18 @@ msgid "editor.inspector.refreshData"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.remove"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/style-declarations.tsx
 msgid "editor.styles.remove"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add.search"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -341,6 +381,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.header.untitled"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add.value"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/en.po
+++ b/packages/admin-editor/locales/en.po
@@ -59,6 +59,11 @@ msgid "editor.canvas.addBlock"
 msgstr "Add a block"
 
 #. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add"
+msgstr "Add attribute"
+
+#. js-lingui-explicit-id
 #: src/style-declarations.tsx
 msgid "editor.styles.add"
 msgstr "Add style"
@@ -77,6 +82,11 @@ msgstr "Align left"
 #: src/styles-tab.tsx
 msgid "editor.styles.align.right"
 msgstr "Align right"
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add.key"
+msgstr "attribute"
 
 #. js-lingui-explicit-id
 #: src/editor-header.tsx
@@ -102,6 +112,11 @@ msgstr "Blocks"
 #: src/styles-tab.tsx
 msgid "editor.styles.mark.bold"
 msgstr "Bold"
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add.create"
+msgstr "Create"
 
 #. js-lingui-explicit-id
 #: src/style-declarations.tsx
@@ -154,6 +169,11 @@ msgid "editor.richtext.hint"
 msgstr "Formatting applies to the selected text."
 
 #. js-lingui-explicit-id
+#: src/block-inspector.tsx
+msgid "editor.htmlAttrs.title"
+msgstr "HTML attributes"
+
+#. js-lingui-explicit-id
 #: src/styles-tab.tsx
 msgid "editor.styles.mark.italic"
 msgstr "Italic"
@@ -182,6 +202,16 @@ msgstr "Move down"
 #: src/selection-toolbar.tsx
 msgid "editor.selection.moveUp"
 msgstr "Move up"
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add.none"
+msgstr "No attribute."
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.none"
+msgstr "No attributes set."
 
 #. js-lingui-explicit-id
 #: src/block-catalog-tab.tsx
@@ -254,9 +284,19 @@ msgid "editor.inspector.refreshData"
 msgstr "Refresh data"
 
 #. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.remove"
+msgstr "Remove"
+
+#. js-lingui-explicit-id
 #: src/style-declarations.tsx
 msgid "editor.styles.remove"
 msgstr "Remove"
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add.search"
+msgstr "Search attribute…"
 
 #. js-lingui-explicit-id
 #: src/block-catalog-tab.tsx
@@ -342,6 +382,11 @@ msgstr "Undo"
 #: src/editor-header.tsx
 msgid "editor.header.untitled"
 msgstr "Untitled"
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add.value"
+msgstr "value"
 
 #. js-lingui-explicit-id
 #: src/style-declarations.tsx

--- a/packages/admin-editor/locales/uk.po
+++ b/packages/admin-editor/locales/uk.po
@@ -59,6 +59,11 @@ msgid "editor.canvas.addBlock"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/style-declarations.tsx
 msgid "editor.styles.add"
 msgstr ""
@@ -76,6 +81,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/styles-tab.tsx
 msgid "editor.styles.align.right"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add.key"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -101,6 +111,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/styles-tab.tsx
 msgid "editor.styles.mark.bold"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add.create"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -154,6 +169,11 @@ msgid "editor.richtext.hint"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/block-inspector.tsx
+msgid "editor.htmlAttrs.title"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/styles-tab.tsx
 msgid "editor.styles.mark.italic"
 msgstr ""
@@ -181,6 +201,16 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.moveUp"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add.none"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.none"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -254,8 +284,18 @@ msgid "editor.inspector.refreshData"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.remove"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/style-declarations.tsx
 msgid "editor.styles.remove"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add.search"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -341,6 +381,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.header.untitled"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add.value"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/locales/zh-CN.po
+++ b/packages/admin-editor/locales/zh-CN.po
@@ -59,6 +59,11 @@ msgid "editor.canvas.addBlock"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/style-declarations.tsx
 msgid "editor.styles.add"
 msgstr ""
@@ -76,6 +81,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/styles-tab.tsx
 msgid "editor.styles.align.right"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add.key"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -101,6 +111,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/styles-tab.tsx
 msgid "editor.styles.mark.bold"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add.create"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -154,6 +169,11 @@ msgid "editor.richtext.hint"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/block-inspector.tsx
+msgid "editor.htmlAttrs.title"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/styles-tab.tsx
 msgid "editor.styles.mark.italic"
 msgstr ""
@@ -181,6 +201,16 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/selection-toolbar.tsx
 msgid "editor.selection.moveUp"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add.none"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.none"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -254,8 +284,18 @@ msgid "editor.inspector.refreshData"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.remove"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/style-declarations.tsx
 msgid "editor.styles.remove"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add.search"
 msgstr ""
 
 #. js-lingui-explicit-id
@@ -341,6 +381,11 @@ msgstr ""
 #. js-lingui-explicit-id
 #: src/editor-header.tsx
 msgid "editor.header.untitled"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/html-attributes.tsx
+msgid "editor.htmlAttrs.add.value"
 msgstr ""
 
 #. js-lingui-explicit-id

--- a/packages/admin-editor/src/block-inspector.test.tsx
+++ b/packages/admin-editor/src/block-inspector.test.tsx
@@ -10,7 +10,11 @@ import type { SerializedLoaderData } from "@plumix/blocks/renderer";
 import { createBlockRegistry } from "@plumix/blocks";
 
 import { BlockInspector } from "./block-inspector.js";
-import { EditorProvider, useEditorStoreApi } from "./provider.js";
+import {
+  EditorProvider,
+  useEditorStore,
+  useEditorStoreApi,
+} from "./provider.js";
 
 beforeAll(() => {
   i18n.loadAndActivate({ locale: "en", messages: {} });
@@ -162,5 +166,145 @@ describe("BlockInspector", () => {
       "lp1",
     );
     expect(queryByTestId("refresh-block-loader")).toBeNull();
+  });
+});
+
+function HtmlAttrProbe({ id }: { readonly id: string }): ReactElement {
+  const attrs = useEditorStore(
+    (s) => s.tree.find((n) => n.id === id)?.htmlAttrs,
+  );
+  return <output data-testid="html-attr-probe">{JSON.stringify(attrs)}</output>;
+}
+
+function renderHtmlAttrs(tree: readonly BlockNode[], selectId: string) {
+  const utils = render(
+    <I18nProvider i18n={i18n}>
+      <EditorProvider initialTree={tree}>
+        <Selector id={selectId} />
+        <BlockInspector registry={registry} />
+        <HtmlAttrProbe id={tree[0]?.id ?? ""} />
+      </EditorProvider>
+    </I18nProvider>,
+  );
+  // The HTML attributes section is collapsed by default — open it.
+  fireEvent.click(utils.getByTestId("block-section-html"));
+  return utils;
+}
+
+describe("BlockInspector — HTML attributes", () => {
+  const withAttrs: BlockNode = {
+    id: "h1",
+    name: "core/heading",
+    htmlAttrs: { id: "hero", "data-track": "cta" },
+  };
+
+  test("lists existing attributes as editable key/value rows", () => {
+    const { getByTestId } = renderHtmlAttrs([withAttrs], "h1");
+    expect((getByTestId("html-attr-id-key") as HTMLInputElement).value).toBe(
+      "id",
+    );
+    expect((getByTestId("html-attr-id-value") as HTMLInputElement).value).toBe(
+      "hero",
+    );
+  });
+
+  test("the section is collapsed by default", () => {
+    const { getByTestId, queryByTestId } = render(
+      <I18nProvider i18n={i18n}>
+        <EditorProvider initialTree={[withAttrs]}>
+          <Selector id="h1" />
+          <BlockInspector registry={registry} />
+        </EditorProvider>
+      </I18nProvider>,
+    );
+    expect(getByTestId("block-section-html")).toBeDefined();
+    expect(queryByTestId("html-attr-id-key")).toBeNull();
+  });
+
+  test("editing a value writes it back to the block", () => {
+    const { getByTestId } = renderHtmlAttrs([withAttrs], "h1");
+    fireEvent.change(getByTestId("html-attr-id-value"), {
+      target: { value: "main" },
+    });
+    expect(getByTestId("html-attr-probe").textContent).toContain('"id":"main"');
+  });
+
+  test("removing an attribute clears it", () => {
+    const single: BlockNode = {
+      id: "h1",
+      name: "core/heading",
+      htmlAttrs: { id: "hero" },
+    };
+    const { getByTestId } = renderHtmlAttrs([single], "h1");
+    fireEvent.click(getByTestId("html-attr-id-remove"));
+    expect(getByTestId("html-attr-probe").textContent).toBe("");
+  });
+
+  test("adds an attribute via the combobox and value", () => {
+    const { getByTestId } = renderHtmlAttrs(
+      [{ id: "h1", name: "core/heading" }],
+      "h1",
+    );
+    fireEvent.click(getByTestId("html-attr-add-key"));
+    fireEvent.click(getByTestId("html-attr-add-key-option-role"));
+    fireEvent.change(getByTestId("html-attr-add-value"), {
+      target: { value: "banner" },
+    });
+    fireEvent.click(getByTestId("html-attr-add-submit"));
+    expect(getByTestId("html-attr-probe").textContent).toContain(
+      '"role":"banner"',
+    );
+  });
+
+  test("offers no create item for a disallowed attribute name", () => {
+    const { getByTestId, queryByTestId } = renderHtmlAttrs(
+      [{ id: "h1", name: "core/heading" }],
+      "h1",
+    );
+    fireEvent.click(getByTestId("html-attr-add-key"));
+    fireEvent.change(getByTestId("html-attr-add-key-search"), {
+      target: { value: "onclick" },
+    });
+    expect(queryByTestId("html-attr-add-key-create")).toBeNull();
+  });
+
+  test("normalizes a typed key to lowercase so the renderer keeps it", () => {
+    const { getByTestId } = renderHtmlAttrs(
+      [{ id: "h1", name: "core/heading" }],
+      "h1",
+    );
+    fireEvent.click(getByTestId("html-attr-add-key"));
+    fireEvent.change(getByTestId("html-attr-add-key-search"), {
+      target: { value: "Data-Track" },
+    });
+    fireEvent.click(getByTestId("html-attr-add-key-create"));
+    fireEvent.change(getByTestId("html-attr-add-value"), {
+      target: { value: "cta" },
+    });
+    fireEvent.click(getByTestId("html-attr-add-submit"));
+    expect(getByTestId("html-attr-probe").textContent).toContain(
+      '"data-track":"cta"',
+    );
+  });
+
+  test("won't add a case-variant of an existing attribute", () => {
+    const { getByTestId, queryByTestId } = renderHtmlAttrs([withAttrs], "h1");
+    fireEvent.click(getByTestId("html-attr-add-key"));
+    fireEvent.change(getByTestId("html-attr-add-key-search"), {
+      target: { value: "DATA-TRACK" },
+    });
+    // `data-track` already exists, so no create item for its uppercase variant.
+    expect(queryByTestId("html-attr-add-key-create")).toBeNull();
+  });
+
+  test("renames an attribute via the key field on commit", () => {
+    const { getByTestId } = renderHtmlAttrs([withAttrs], "h1");
+    const key = getByTestId("html-attr-id-key") as HTMLInputElement;
+    fireEvent.change(key, { target: { value: "title" } });
+    fireEvent.blur(key);
+    expect(getByTestId("html-attr-probe").textContent).toContain(
+      '"title":"hero"',
+    );
+    expect(getByTestId("html-attr-probe").textContent).not.toContain('"id"');
   });
 });

--- a/packages/admin-editor/src/block-inspector.tsx
+++ b/packages/admin-editor/src/block-inspector.tsx
@@ -4,11 +4,18 @@ import { Trans } from "@lingui/react";
 
 import type { BlockRegistry } from "@plumix/blocks";
 import type { SerializedLoaderData } from "@plumix/blocks/renderer";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@plumix/admin-ui/accordion";
 import { Button } from "@plumix/admin-ui/button";
 import { RefreshCw } from "@plumix/admin-ui/icons";
 
 import { BlockInputControl } from "./block-input-control.js";
 import { findBlock } from "./block-tree-ops.js";
+import { HtmlAttributes } from "./html-attributes.js";
 import { useEditorStore, useLoaderPushRef } from "./provider.js";
 
 interface BlockInspectorProps {
@@ -34,6 +41,8 @@ export function BlockInspector({
   const activeId = useEditorStore((s) => s.activeId);
   const tree = useEditorStore((s) => s.tree);
   const updateBlockAttrs = useEditorStore((s) => s.updateBlockAttrs);
+  const updateBlockHtmlAttr = useEditorStore((s) => s.updateBlockHtmlAttr);
+  const renameBlockHtmlAttr = useEditorStore((s) => s.renameBlockHtmlAttr);
   const loaderPushRef = useLoaderPushRef();
 
   const block = activeId ? findBlock(tree, activeId) : undefined;
@@ -92,6 +101,23 @@ export function BlockInspector({
           <Trans id="editor.inspector.refreshData" message="Refresh data" />
         </Button>
       )}
+      {/* Raw HTML attributes — a dev escape hatch, collapsed by default. */}
+      <Accordion type="multiple">
+        <AccordionItem value="html">
+          <AccordionTrigger data-testid="block-section-html">
+            <Trans id="editor.htmlAttrs.title" message="HTML attributes" />
+          </AccordionTrigger>
+          <AccordionContent>
+            <HtmlAttributes
+              attributes={block.htmlAttrs ?? {}}
+              onChange={(key, value) =>
+                updateBlockHtmlAttr(block.id, key, value)
+              }
+              onRename={(from, to) => renameBlockHtmlAttr(block.id, from, to)}
+            />
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
     </div>
   );
 }

--- a/packages/admin-editor/src/html-attributes.tsx
+++ b/packages/admin-editor/src/html-attributes.tsx
@@ -1,0 +1,292 @@
+import type { ReactElement } from "react";
+import { useState } from "react";
+import { Trans, useLingui } from "@lingui/react";
+
+import { Button } from "@plumix/admin-ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@plumix/admin-ui/command";
+import { ChevronsUpDown, Plus, Trash2 } from "@plumix/admin-ui/icons";
+import { Input } from "@plumix/admin-ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@plumix/admin-ui/popover";
+import { cn } from "@plumix/admin-ui/utils";
+import { isAllowedHtmlAttr } from "@plumix/blocks";
+
+// Common allowlisted attributes offered as suggestions. The field still accepts
+// any name `isAllowedHtmlAttr` permits (e.g. an arbitrary `data-*`/`aria-*`).
+const COMMON_ATTRS: readonly string[] = [
+  "id",
+  "title",
+  "role",
+  "lang",
+  "dir",
+  "aria-label",
+  "aria-describedby",
+  "aria-hidden",
+  "aria-live",
+  "data-testid",
+];
+
+interface HtmlAttributesProps {
+  readonly attributes: Readonly<Record<string, string>>;
+  /** Set an attribute's value, or clear it with `null`. */
+  readonly onChange: (key: string, value: string | null) => void;
+  /** Rename an attribute in place, keeping its value. */
+  readonly onRename: (from: string, to: string) => void;
+}
+
+/**
+ * Key/value editor for a block's HTML attributes — the same repeater as the CSS
+ * section, but flat string values. Keys are constrained to the render-time
+ * allowlist (`isAllowedHtmlAttr`); the value flows verbatim (React escapes it).
+ */
+export function HtmlAttributes({
+  attributes,
+  onChange,
+  onRename,
+}: HtmlAttributesProps): ReactElement {
+  const keys = Object.keys(attributes);
+  return (
+    <div className="flex flex-col gap-1" data-testid="html-attributes">
+      {keys.map((key) => (
+        <AttrRow
+          key={key}
+          name={key}
+          value={attributes[key] ?? ""}
+          siblingKeys={keys}
+          onChange={onChange}
+          onRename={onRename}
+        />
+      ))}
+      {keys.length === 0 ? (
+        <p
+          className="text-muted-foreground text-xs"
+          data-testid="html-attributes-empty"
+        >
+          <Trans id="editor.htmlAttrs.none" message="No attributes set." />
+        </p>
+      ) : null}
+      <AddAttr onAdd={onChange} existingKeys={keys} />
+    </div>
+  );
+}
+
+/** One attribute row: an editable name (renamed on commit), the value input,
+ *  and a remove button. Keyed by name in the parent, so the draft re-inits when
+ *  the row's identity changes. */
+function AttrRow({
+  name,
+  value,
+  siblingKeys,
+  onChange,
+  onRename,
+}: {
+  readonly name: string;
+  readonly value: string;
+  readonly siblingKeys: readonly string[];
+  readonly onChange: (key: string, value: string | null) => void;
+  readonly onRename: (from: string, to: string) => void;
+}): ReactElement {
+  const [keyDraft, setKeyDraft] = useState(name);
+
+  const commitRename = (): void => {
+    // Normalize to lowercase: a mixed-case data-/aria- key passes the allowlist
+    // check but React drops it at render, so the editor must store the form the
+    // renderer keeps. Collision is checked case-insensitively to match.
+    const next = keyDraft.trim().toLowerCase();
+    const valid =
+      next !== name.toLowerCase() &&
+      isAllowedHtmlAttr(next) &&
+      !siblingKeys.some((k) => k.toLowerCase() === next);
+    if (valid) onRename(name, next);
+    else setKeyDraft(name);
+  };
+
+  return (
+    <div className="flex items-center gap-2" data-testid={`html-attr-${name}`}>
+      <Input
+        className="h-8 w-1/3 shrink-0"
+        data-testid={`html-attr-${name}-key`}
+        value={keyDraft}
+        onChange={(e) => setKeyDraft(e.target.value)}
+        onBlur={commitRename}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") e.currentTarget.blur();
+        }}
+      />
+      <Input
+        className="h-8"
+        data-testid={`html-attr-${name}-value`}
+        value={value}
+        onChange={(e) => onChange(name, e.target.value)}
+      />
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="text-destructive hover:text-destructive size-8 shrink-0"
+        data-testid={`html-attr-${name}-remove`}
+        onClick={() => onChange(name, null)}
+      >
+        <Trash2 />
+        <span className="sr-only">
+          <Trans id="editor.htmlAttrs.remove" message="Remove" />
+        </span>
+      </Button>
+    </div>
+  );
+}
+
+/** Key + value entry row. The key is picked from the common-attribute combobox
+ *  or typed; only allowlisted, non-duplicate names with a non-empty value can
+ *  be added. */
+function AddAttr({
+  onAdd,
+  existingKeys,
+}: {
+  readonly onAdd: (key: string, value: string) => void;
+  readonly existingKeys: readonly string[];
+}): ReactElement {
+  const { i18n } = useLingui();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [name, setName] = useState("");
+  const [value, setValue] = useState("");
+
+  // Lowercase throughout: the renderer keeps only the lowercased form (React
+  // drops mixed-case data-/aria- props), so the editor offers and stores that.
+  const taken = new Set(existingKeys.map((k) => k.toLowerCase()));
+  const options = COMMON_ATTRS.filter((attr) => !taken.has(attr));
+  const custom = query.trim().toLowerCase();
+  const canCreate =
+    isAllowedHtmlAttr(custom) &&
+    !taken.has(custom) &&
+    !COMMON_ATTRS.includes(custom);
+
+  const pick = (attr: string): void => {
+    setName(attr);
+    setQuery("");
+    setOpen(false);
+  };
+
+  const valid = name !== "" && !taken.has(name) && value.trim() !== "";
+
+  return (
+    <form
+      className="flex items-center gap-2 pt-1"
+      data-testid="html-attr-add"
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (!valid) return;
+        onAdd(name, value);
+        setName("");
+        setValue("");
+      }}
+    >
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            role="combobox"
+            aria-expanded={open}
+            data-testid="html-attr-add-key"
+            className={cn(
+              "h-8 w-1/3 shrink-0 justify-between gap-1 font-normal",
+              name === "" && "text-muted-foreground",
+            )}
+          >
+            <span className="truncate">
+              {name === "" ? (
+                <Trans id="editor.htmlAttrs.add.key" message="attribute" />
+              ) : (
+                name
+              )}
+            </span>
+            <ChevronsUpDown className="opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-56 p-0" align="start">
+          <Command>
+            <CommandInput
+              value={query}
+              onValueChange={setQuery}
+              placeholder={i18n._({
+                id: "editor.htmlAttrs.add.search",
+                message: "Search attribute…",
+              })}
+              data-testid="html-attr-add-key-search"
+            />
+            <CommandList>
+              {canCreate ? (
+                <CommandItem
+                  value={custom}
+                  onSelect={() => pick(custom)}
+                  data-testid="html-attr-add-key-create"
+                >
+                  <Plus className="me-2 size-4" />
+                  <span className="sr-only">
+                    <Trans id="editor.htmlAttrs.add.create" message="Create" />
+                  </span>
+                  {custom}
+                </CommandItem>
+              ) : (
+                <CommandEmpty>
+                  <Trans
+                    id="editor.htmlAttrs.add.none"
+                    message="No attribute."
+                  />
+                </CommandEmpty>
+              )}
+              <CommandGroup>
+                {options.map((attr) => (
+                  <CommandItem
+                    key={attr}
+                    value={attr}
+                    onSelect={() => pick(attr)}
+                    data-testid={`html-attr-add-key-option-${attr}`}
+                  >
+                    {attr}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+      <Input
+        className="h-8"
+        data-testid="html-attr-add-value"
+        placeholder={i18n._({
+          id: "editor.htmlAttrs.add.value",
+          message: "value",
+        })}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+      <Button
+        type="submit"
+        variant="ghost"
+        size="icon"
+        className="size-8 shrink-0"
+        disabled={!valid}
+        data-testid="html-attr-add-submit"
+      >
+        <Plus />
+        <span className="sr-only">
+          <Trans id="editor.htmlAttrs.add" message="Add attribute" />
+        </span>
+      </Button>
+    </form>
+  );
+}


### PR DESCRIPTION
Final slice of block HTML attributes: the editor UI.

Adds an "HTML attributes" repeater to the Block inspector — the same key/value editor as the CSS section, but flat string values. It lists a block's `htmlAttrs` as editable name/value rows (rename on commit, red remove) plus an add row whose key is a shadcn combobox of common attributes or any name the render allowlist permits. It lives in a collapsed-by-default accordion section, since raw attributes are a dev escape hatch.

Keys are normalized to lowercase and deduped case-insensitively, so a mixed-case `Data-Track`/`Aria-Label` (which React drops at render) can't be added as a confusing dead attribute. Wired to the `updateBlockHtmlAttr`/`renameBlockHtmlAttr` store actions; `isAllowedHtmlAttr` is shared with the renderer so the editor never offers a key render would strip.

Completes the feature (render boundary #1217, store actions #1218, this UI).