### PR TITLE
feat(admin-editor): x-ray toggle to outline all blocks

### DIFF
--- a/packages/admin-editor/e2e/editor-visual.spec.ts
+++ b/packages/admin-editor/e2e/editor-visual.spec.ts
@@ -547,6 +547,48 @@ test.describe("editor playground", () => {
     await expect(page.getByTestId("refresh-block-loader")).toHaveCount(0);
   });
 
+  test("x-ray toggle outlines every block in the canvas", async ({ page }) => {
+    await page.goto("/");
+    const canvas = page.frameLocator(CANVAS_FRAME);
+    const root = canvas.locator('[data-testid="plumix-editor-canvas"]');
+    // The flag crosses the bridge into the iframe and gates the outline CSS.
+    await expect(root).not.toHaveAttribute("data-plumix-xray", "");
+
+    await page.getByTestId("plumix-xray-toggle").click();
+    await expect(root).toHaveAttribute("data-plumix-xray", "");
+
+    await page.getByTestId("plumix-xray-toggle").click();
+    await expect(root).not.toHaveAttribute("data-plumix-xray", "");
+  });
+
+  test("Shift+X toggles x-ray from the keyboard", async ({ page }) => {
+    await page.goto("/");
+    const root = page
+      .frameLocator(CANVAS_FRAME)
+      .locator('[data-testid="plumix-editor-canvas"]');
+
+    await page.keyboard.press("Shift+KeyX");
+    await expect(root).toHaveAttribute("data-plumix-xray", "");
+    await expect(page.getByTestId("plumix-xray-toggle")).toHaveAttribute(
+      "data-state",
+      "on",
+    );
+  });
+
+  test("Shift+X works with focus inside the canvas iframe (forwarded)", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const canvas = page.frameLocator(CANVAS_FRAME);
+    const root = canvas.locator('[data-testid="plumix-editor-canvas"]');
+
+    // Click a block so focus lands inside the iframe, then the shortcut must
+    // still toggle via the canvas:key forward path.
+    await canvas.locator('[data-plumix-id="heading-1"]').click();
+    await page.keyboard.press("Shift+KeyX");
+    await expect(root).toHaveAttribute("data-plumix-xray", "");
+  });
+
   test("the Layers tab outlines the nested structure", async ({ page }) => {
     await page.goto("/");
 

--- a/packages/admin-editor/e2e/editor-visual.spec.ts
+++ b/packages/admin-editor/e2e/editor-visual.spec.ts
@@ -561,6 +561,27 @@ test.describe("editor playground", () => {
     await expect(root).not.toHaveAttribute("data-plumix-xray", "");
   });
 
+  test("x-ray outlines nested blocks, not just top-level ones", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const canvas = page.frameLocator(CANVAS_FRAME);
+    // group-heading sits inside the seeded group; heading-1 is top-level.
+    const nested = canvas.locator('[data-plumix-id="group-heading"]');
+    const top = canvas.locator('[data-plumix-id="heading-1"]');
+
+    // Off: no outline at any depth (toHaveCSS reads computed style).
+    await expect(nested).toHaveCSS("outline-style", "none");
+
+    await page.getByTestId("plumix-xray-toggle").click();
+    await expect(top).toHaveCSS("outline-style", "dashed");
+    // The nested block paints its own outline (descendant selector, any depth).
+    await expect(nested).toHaveCSS("outline-style", "dashed");
+
+    await page.getByTestId("plumix-xray-toggle").click();
+    await expect(nested).toHaveCSS("outline-style", "none");
+  });
+
   test("Shift+X toggles x-ray from the keyboard", async ({ page }) => {
     await page.goto("/");
     const root = page

--- a/packages/admin-editor/locales/ar.po
+++ b/packages/admin-editor/locales/ar.po
@@ -410,6 +410,11 @@ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
+msgid "editor.toolbar.xray"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
 msgid "editor.toolbar.zoomIn"
 msgstr ""
 

--- a/packages/admin-editor/locales/de.po
+++ b/packages/admin-editor/locales/de.po
@@ -410,6 +410,11 @@ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
+msgid "editor.toolbar.xray"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
 msgid "editor.toolbar.zoomIn"
 msgstr ""
 

--- a/packages/admin-editor/locales/en.po
+++ b/packages/admin-editor/locales/en.po
@@ -410,6 +410,11 @@ msgstr "View source"
 
 #. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
+msgid "editor.toolbar.xray"
+msgstr "X-ray: outline all blocks"
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
 msgid "editor.toolbar.zoomIn"
 msgstr "Zoom in"
 

--- a/packages/admin-editor/locales/uk.po
+++ b/packages/admin-editor/locales/uk.po
@@ -410,6 +410,11 @@ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
+msgid "editor.toolbar.xray"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
 msgid "editor.toolbar.zoomIn"
 msgstr ""
 

--- a/packages/admin-editor/locales/zh-CN.po
+++ b/packages/admin-editor/locales/zh-CN.po
@@ -410,6 +410,11 @@ msgstr ""
 
 #. js-lingui-explicit-id
 #: src/editor-toolbar.tsx
+msgid "editor.toolbar.xray"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
 msgid "editor.toolbar.zoomIn"
 msgstr ""
 

--- a/packages/admin-editor/src/canvas-frame.tsx
+++ b/packages/admin-editor/src/canvas-frame.tsx
@@ -487,6 +487,7 @@ export function CanvasFrame({
       if (code === "Digit1") store.getState().enableZoomFit();
       else if (code === "Digit2") zoomToSelection();
       else if (code === "Digit0") store.getState().zoomToCenter(1);
+      else if (code === "KeyX") store.getState().toggleXray();
     };
     keyHandlerRef.current = handleKey;
 
@@ -496,9 +497,13 @@ export function CanvasFrame({
     const isViewKey = (e: KeyboardEvent): boolean =>
       e.code === "Space" ||
       (e.shiftKey &&
-        (e.code === "Digit0" || e.code === "Digit1" || e.code === "Digit2"));
+        (e.code === "Digit0" ||
+          e.code === "Digit1" ||
+          e.code === "Digit2" ||
+          e.code === "KeyX"));
     const onKeyDown = (e: KeyboardEvent): void => {
-      if (isTyping(e.target) || !isViewKey(e)) return;
+      // Skip auto-repeat: a held key must not re-fire the x-ray toggle.
+      if (e.repeat || isTyping(e.target) || !isViewKey(e)) return;
       if (e.code === "Space") e.preventDefault();
       handleKey(true, e.code, e.shiftKey);
     };

--- a/packages/admin-editor/src/connect-canvas.ts
+++ b/packages/admin-editor/src/connect-canvas.ts
@@ -98,6 +98,13 @@ export function connectCanvas({
     }
   };
 
+  const pushXray = (): void => {
+    post({
+      type: "host:xray",
+      enabled: store.getState().xray,
+    } satisfies HostMessage);
+  };
+
   const onMessage = (event: MessageEvent): void => {
     const message = parseEnvelope<object>(
       EDITOR_BRIDGE_CHANNEL,
@@ -114,6 +121,7 @@ export function connectCanvas({
     switch (canvas.type) {
       case "canvas:ready":
         pushConfig();
+        pushXray();
         pushTree();
         break;
       case "canvas:select":
@@ -150,10 +158,15 @@ export function connectCanvas({
   window.addEventListener("message", onMessage);
 
   let previousTree = store.getState().tree;
+  let previousXray = store.getState().xray;
   const unsubscribe = store.subscribe((state) => {
     if (state.tree !== previousTree) {
       previousTree = state.tree;
       pushTree();
+    }
+    if (state.xray !== previousXray) {
+      previousXray = state.xray;
+      pushXray();
     }
   });
 

--- a/packages/admin-editor/src/connect-runtime.ts
+++ b/packages/admin-editor/src/connect-runtime.ts
@@ -50,6 +50,8 @@ interface ConnectRuntimeOptions {
   readonly onLoaderData?: (data: SerializedLoaderData) => void;
   /** Called with the host's resolved canvas chrome (e.g. localized labels). */
   readonly onConfig?: (config: { readonly addBlockLabel: string }) => void;
+  /** Called when the host toggles the X-ray (outline-all-blocks) view. */
+  readonly onXray?: (enabled: boolean) => void;
 }
 
 /**
@@ -64,6 +66,7 @@ export function connectRuntime({
   onTree,
   onLoaderData,
   onConfig,
+  onXray,
 }: ConnectRuntimeOptions): RuntimeConnection {
   const post = (message: object): void => {
     parentWindow.postMessage(encode(EDITOR_BRIDGE_CHANNEL, message), origin);
@@ -99,6 +102,9 @@ export function connectRuntime({
         break;
       case "host:config":
         onConfig?.({ addBlockLabel: host.addBlockLabel });
+        break;
+      case "host:xray":
+        onXray?.(host.enabled);
         break;
     }
   };

--- a/packages/admin-editor/src/editor-canvas.tsx
+++ b/packages/admin-editor/src/editor-canvas.tsx
@@ -37,6 +37,13 @@ interface EditorCanvasProps {
   readonly breakpoints?: ThemeBreakpoints;
 }
 
+// X-ray outline rule, gated by data-plumix-xray on the content root. Static, so
+// the toggle is a pure attribute flip — no per-block geometry.
+const XRAY_STYLE = `[data-plumix-xray] [data-plumix-block] {
+  outline: 1px dashed rgba(59, 130, 246, 0.5);
+  outline-offset: -1px;
+}`;
+
 /**
  * The canvas that runs inside the editor iframe. Renders the host's tree via
  * the real BlockRenderer in edit mode (so blocks are tagged with
@@ -63,6 +70,9 @@ export function EditorCanvas({
   // Undefined until config arrives, so editAppender's own default is the single
   // English fallback for the pre-config window.
   const [addBlockLabel, setAddBlockLabel] = useState<string>();
+  // X-ray view: the host pushes the toggle over the bridge; a CSS rule (gated by
+  // the data-plumix-xray attribute below) then outlines every block.
+  const [xray, setXray] = useState(false);
   const connectionRef = useRef<RuntimeConnection | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -74,6 +84,7 @@ export function EditorCanvas({
       onLoaderData: (data) =>
         setLoaderData((prior) => mergeLoaderData(prior, data)),
       onConfig: (config) => setAddBlockLabel(config.addBlockLabel),
+      onXray: setXray,
     });
     connectionRef.current = connection;
     return () => {
@@ -149,12 +160,20 @@ export function EditorCanvas({
   // in the canvas is otherwise untouched. Space is prevented so it doesn't
   // scroll the iframe document.
   useEffect(() => {
+    const isTyping = (t: EventTarget | null): boolean =>
+      t instanceof HTMLElement &&
+      (t.isContentEditable || /^(INPUT|TEXTAREA|SELECT)$/.test(t.tagName));
     const isViewKey = (e: KeyboardEvent): boolean =>
       e.code === "Space" ||
       (e.shiftKey &&
-        (e.code === "Digit0" || e.code === "Digit1" || e.code === "Digit2"));
+        (e.code === "Digit0" ||
+          e.code === "Digit1" ||
+          e.code === "Digit2" ||
+          e.code === "KeyX"));
     const onKeyDown = (e: KeyboardEvent): void => {
-      if (!isViewKey(e)) return;
+      // Skip auto-repeat (a held key must not re-fire the toggle) and typing in
+      // a field, so a view shortcut never fires while the author edits content.
+      if (e.repeat || isTyping(e.target) || !isViewKey(e)) return;
       if (e.code === "Space") e.preventDefault();
       connectionRef.current?.reportKey(true, e.code, e.shiftKey);
     };
@@ -270,10 +289,13 @@ export function EditorCanvas({
       <div
         ref={containerRef}
         data-testid="plumix-editor-canvas"
+        data-plumix-xray={xray ? "" : undefined}
         onClick={handleClick}
         onMouseOver={handleMouseOver}
         onMouseOut={handleMouseOut}
       >
+        {/* X-ray outline rule; the data-plumix-xray attribute above gates it. */}
+        <style>{XRAY_STYLE}</style>
         {/* renderBlockTree (not BlockRenderer) so the canvas doesn't re-emit
             the SSR content-root boundary it was mounted into — just the
             per-block data-plumix-id seam for selection. tokens/breakpoints feed

--- a/packages/admin-editor/src/editor-toolbar.test.tsx
+++ b/packages/admin-editor/src/editor-toolbar.test.tsx
@@ -57,6 +57,20 @@ describe("EditorToolbar", () => {
     fireEvent.click(getByTestId("plumix-zoom-percent"));
     expect(storeApi?.getState().zoomFit).toBe(true);
   });
+
+  test("the X-ray toggle flips the store and reflects its pressed state", () => {
+    const { getByTestId } = renderToolbar();
+    const toggle = getByTestId("plumix-xray-toggle");
+
+    expect(storeApi?.getState().xray).toBe(false);
+    expect(toggle.getAttribute("data-state")).toBe("off");
+
+    fireEvent.click(toggle);
+    expect(storeApi?.getState().xray).toBe(true);
+    expect(getByTestId("plumix-xray-toggle").getAttribute("data-state")).toBe(
+      "on",
+    );
+  });
 });
 
 describe("EditorShortcuts", () => {

--- a/packages/admin-editor/src/editor-toolbar.tsx
+++ b/packages/admin-editor/src/editor-toolbar.tsx
@@ -5,6 +5,7 @@ import { useLingui } from "@lingui/react";
 
 import { Button } from "@plumix/admin-ui/button";
 import {
+  Layout,
   Monitor,
   Smartphone,
   Tablet,
@@ -12,6 +13,7 @@ import {
   ZoomOut,
 } from "@plumix/admin-ui/icons";
 import { SidebarTrigger } from "@plumix/admin-ui/sidebar";
+import { Toggle } from "@plumix/admin-ui/toggle";
 import { ToggleGroup, ToggleGroupItem } from "@plumix/admin-ui/toggle-group";
 
 import type { EditorDevice } from "./store.js";
@@ -91,7 +93,9 @@ function DeviceZoomControls(): ReactElement {
   const { i18n } = useLingui();
   const device = useEditorStore((s) => s.device);
   const zoom = useEditorStore((s) => s.zoom);
+  const xray = useEditorStore((s) => s.xray);
   const setDevice = useEditorStore((s) => s.setDevice);
+  const toggleXray = useEditorStore((s) => s.toggleXray);
   const zoomToCenter = useEditorStore((s) => s.zoomToCenter);
   const enableZoomFit = useEditorStore((s) => s.enableZoomFit);
 
@@ -108,6 +112,19 @@ function DeviceZoomControls(): ReactElement {
       className="flex items-center gap-1"
       data-testid="plumix-canvas-controls"
     >
+      <Toggle
+        variant="outline"
+        size="sm"
+        pressed={xray}
+        onPressedChange={toggleXray}
+        data-testid="plumix-xray-toggle"
+        aria-label={i18n._({
+          id: "editor.toolbar.xray",
+          message: "X-ray: outline all blocks",
+        })}
+      >
+        <Layout />
+      </Toggle>
       <ToggleGroup
         type="single"
         variant="outline"

--- a/packages/admin-editor/src/editor-toolbar.tsx
+++ b/packages/admin-editor/src/editor-toolbar.tsx
@@ -76,14 +76,40 @@ export function EditorToolbar(): ReactElement {
       className="bg-background flex items-center gap-2 border-b p-2"
       data-testid="plumix-editor-toolbar"
     >
-      {/* Collapses both rails for a focused canvas (also Cmd/Ctrl+B). */}
-      <SidebarTrigger data-testid="plumix-rails-toggle" className="shrink-0" />
-      <div className="flex flex-1 justify-center">
-        <DeviceZoomControls />
+      {/* Left cluster: rails toggle (also Cmd/Ctrl+B) + the X-ray view toggle. */}
+      <div className="flex flex-1 items-center gap-1">
+        <SidebarTrigger
+          data-testid="plumix-rails-toggle"
+          className="shrink-0"
+        />
+        <XrayToggle />
       </div>
-      {/* Balances the rails toggle so the device/zoom cluster reads as centered. */}
-      <div className="w-7 shrink-0" aria-hidden />
+      <DeviceZoomControls />
+      {/* Empty flex-1 mirror so the device/zoom cluster stays centered. */}
+      <div className="flex-1" aria-hidden />
     </header>
+  );
+}
+
+/** Toggles the X-ray view that outlines every block in the canvas. */
+function XrayToggle(): ReactElement {
+  const { i18n } = useLingui();
+  const xray = useEditorStore((s) => s.xray);
+  const toggleXray = useEditorStore((s) => s.toggleXray);
+  return (
+    <Toggle
+      variant="outline"
+      size="sm"
+      pressed={xray}
+      onPressedChange={toggleXray}
+      data-testid="plumix-xray-toggle"
+      aria-label={i18n._({
+        id: "editor.toolbar.xray",
+        message: "X-ray: outline all blocks",
+      })}
+    >
+      <Layout />
+    </Toggle>
   );
 }
 
@@ -93,9 +119,7 @@ function DeviceZoomControls(): ReactElement {
   const { i18n } = useLingui();
   const device = useEditorStore((s) => s.device);
   const zoom = useEditorStore((s) => s.zoom);
-  const xray = useEditorStore((s) => s.xray);
   const setDevice = useEditorStore((s) => s.setDevice);
-  const toggleXray = useEditorStore((s) => s.toggleXray);
   const zoomToCenter = useEditorStore((s) => s.zoomToCenter);
   const enableZoomFit = useEditorStore((s) => s.enableZoomFit);
 
@@ -112,19 +136,6 @@ function DeviceZoomControls(): ReactElement {
       className="flex items-center gap-1"
       data-testid="plumix-canvas-controls"
     >
-      <Toggle
-        variant="outline"
-        size="sm"
-        pressed={xray}
-        onPressedChange={toggleXray}
-        data-testid="plumix-xray-toggle"
-        aria-label={i18n._({
-          id: "editor.toolbar.xray",
-          message: "X-ray: outline all blocks",
-        })}
-      >
-        <Layout />
-      </Toggle>
       <ToggleGroup
         type="single"
         variant="outline"

--- a/packages/admin-editor/src/store.test.ts
+++ b/packages/admin-editor/src/store.test.ts
@@ -704,6 +704,19 @@ describe("renameBlockStyleProperty", () => {
   });
 });
 
+describe("xray", () => {
+  test("defaults off and toggles", () => {
+    const store = createEditorStore();
+    expect(store.getState().xray).toBe(false);
+
+    store.getState().toggleXray();
+    expect(store.getState().xray).toBe(true);
+
+    store.getState().toggleXray();
+    expect(store.getState().xray).toBe(false);
+  });
+});
+
 describe("updateBlockHtmlAttr", () => {
   test("sets an attribute on a block", () => {
     const store = createEditorStore({ tree: [{ id: "a", name: "core/x" }] });

--- a/packages/admin-editor/src/store.ts
+++ b/packages/admin-editor/src/store.ts
@@ -72,6 +72,9 @@ export interface EditorState {
   readonly hoverId: string | null;
   readonly device: EditorDevice;
   readonly zoom: number;
+  /** X-ray view: when on, the canvas outlines every block. Transient view
+   *  state (like zoom), not persisted to the document. */
+  readonly xray: boolean;
   /** Free-canvas pan offset (px, host/container space) of the device frame's
    *  top-left. The canvas is a Figma-style pannable stage, not a scroll area. */
   readonly panX: number;
@@ -159,6 +162,8 @@ export interface EditorActions {
   setHover: (id: string | null) => void;
   /** Switch device; re-enables fit-to-width so the new width fits the viewport. */
   setDevice: (device: EditorDevice) => void;
+  /** Flip the X-ray (outline-all-blocks) view. */
+  toggleXray: () => void;
   setRightPanel: (panel: RightPanel) => void;
   setJsonOpen: (open: boolean) => void;
   /** Set (or clear, with an empty string) a block's Layers-tree instance name. */
@@ -329,6 +334,7 @@ export function createEditorStore(
     activeId: null,
     hoverId: null,
     device: initial?.device ?? "desktop",
+    xray: false,
     zoom: initial?.zoom ?? 1,
     panX: 0,
     panY: 0,
@@ -524,6 +530,7 @@ export function createEditorStore(
       }),
     setHover: (hoverId) => set({ hoverId }),
     setDevice: (device) => set({ device, zoomFit: true }),
+    toggleXray: () => set((s) => ({ xray: !s.xray })),
     setRightPanel: (rightPanel) => set({ rightPanel }),
     setJsonOpen: (jsonOpen) => set({ jsonOpen }),
     enableZoomFit: () => set({ zoomFit: true }),

--- a/packages/blocks/src/renderer/editor-protocol.ts
+++ b/packages/blocks/src/renderer/editor-protocol.ts
@@ -46,6 +46,12 @@ export type HostMessage =
       // `serializeLoaderData` emits). The canvas merges it into its loader map.
       readonly type: "host:loader-data";
       readonly data: SerializedLoaderData;
+    }
+  | {
+      // X-ray view toggle — the canvas outlines every block while on. Pushed on
+      // change and once the canvas is ready (initial sync).
+      readonly type: "host:xray";
+      readonly enabled: boolean;
     };
 
 /** Canvas (iframe) → parent (admin shell). */


### PR DESCRIPTION
Adds an X-ray view toggle to the canvas top strip (left of the device/zoom controls). When on, every block in the canvas is outlined so the author can see all boundaries at once — the same affordance Builder.io has.

It's a single in-iframe CSS rule (`[data-plumix-xray] [data-plumix-block] { outline … }`) gated by a `data-plumix-xray` attribute on the content root. The flag crosses the editor bridge (new `host:xray` message, synced on `canvas:ready` and on change). This deliberately avoids the host-side overlay approach (which is geometry-driven and right for highlighting *one* block) — a CSS rule needs no per-block geometry, scales to any block count, and stays correct at any zoom since it lives in the iframe's coordinate space. The outline matches both wrapper and `selfSeam` blocks uniformly, and never touches the inert theme chrome (which carries no `data-plumix-block`).

X-ray is transient view state (like zoom), not persisted to the document. It also toggles with **Shift+X**, forwarded from the iframe via the existing `canvas:key` path and handled host-side; both key handlers gained an `e.repeat` guard so a held key doesn't re-fire the toggle, plus an `isTyping` guard on the canvas path for consistency.

Tested: store toggle (unit), toolbar pressed-state (unit), and e2e for the bridge round-trip, the keyboard shortcut, and the iframe-focus forward path.