### PR TITLE
feat(admin-editor): x-ray toolbar icon + left-cluster tooltips

### DIFF
--- a/packages/admin-editor/locales/ar.po
+++ b/packages/admin-editor/locales/ar.po
@@ -364,6 +364,11 @@ msgid "editor.header.title"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.rails"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/style-control.tsx
 msgid "editor.styles.mode.token"
 msgstr ""

--- a/packages/admin-editor/locales/de.po
+++ b/packages/admin-editor/locales/de.po
@@ -364,6 +364,11 @@ msgid "editor.header.title"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.rails"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/style-control.tsx
 msgid "editor.styles.mode.token"
 msgstr ""

--- a/packages/admin-editor/locales/en.po
+++ b/packages/admin-editor/locales/en.po
@@ -364,6 +364,11 @@ msgid "editor.header.title"
 msgstr "Title"
 
 #. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.rails"
+msgstr "Toggle panels"
+
+#. js-lingui-explicit-id
 #: src/style-control.tsx
 msgid "editor.styles.mode.token"
 msgstr "Token"

--- a/packages/admin-editor/locales/uk.po
+++ b/packages/admin-editor/locales/uk.po
@@ -364,6 +364,11 @@ msgid "editor.header.title"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.rails"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/style-control.tsx
 msgid "editor.styles.mode.token"
 msgstr ""

--- a/packages/admin-editor/locales/zh-CN.po
+++ b/packages/admin-editor/locales/zh-CN.po
@@ -364,6 +364,11 @@ msgid "editor.header.title"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/editor-toolbar.tsx
+msgid "editor.toolbar.rails"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/style-control.tsx
 msgid "editor.styles.mode.token"
 msgstr ""

--- a/packages/admin-editor/src/editor-toolbar.tsx
+++ b/packages/admin-editor/src/editor-toolbar.tsx
@@ -1,13 +1,13 @@
 import type { I18n } from "@lingui/core";
 import type { ReactElement } from "react";
 import { useEffect } from "react";
-import { useLingui } from "@lingui/react";
+import { Trans, useLingui } from "@lingui/react";
 
 import { Button } from "@plumix/admin-ui/button";
 import {
-  Layout,
   Monitor,
   Smartphone,
+  SquareDashed,
   Tablet,
   ZoomIn,
   ZoomOut,
@@ -15,6 +15,11 @@ import {
 import { SidebarTrigger } from "@plumix/admin-ui/sidebar";
 import { Toggle } from "@plumix/admin-ui/toggle";
 import { ToggleGroup, ToggleGroupItem } from "@plumix/admin-ui/toggle-group";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@plumix/admin-ui/tooltip";
 
 import type { EditorDevice } from "./store.js";
 import { useEditorStore, useEditorStoreApi } from "./provider.js";
@@ -78,10 +83,17 @@ export function EditorToolbar(): ReactElement {
     >
       {/* Left cluster: rails toggle (also Cmd/Ctrl+B) + the X-ray view toggle. */}
       <div className="flex flex-1 items-center gap-1">
-        <SidebarTrigger
-          data-testid="plumix-rails-toggle"
-          className="shrink-0"
-        />
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <SidebarTrigger
+              data-testid="plumix-rails-toggle"
+              className="shrink-0"
+            />
+          </TooltipTrigger>
+          <TooltipContent>
+            <Trans id="editor.toolbar.rails" message="Toggle panels" />
+          </TooltipContent>
+        </Tooltip>
         <XrayToggle />
       </div>
       <DeviceZoomControls />
@@ -97,19 +109,32 @@ function XrayToggle(): ReactElement {
   const xray = useEditorStore((s) => s.xray);
   const toggleXray = useEditorStore((s) => s.toggleXray);
   return (
-    <Toggle
-      variant="outline"
-      size="sm"
-      pressed={xray}
-      onPressedChange={toggleXray}
-      data-testid="plumix-xray-toggle"
-      aria-label={i18n._({
-        id: "editor.toolbar.xray",
-        message: "X-ray: outline all blocks",
-      })}
-    >
-      <Layout />
-    </Toggle>
+    <Tooltip>
+      {/* The trigger is a wrapper span, not the Toggle itself: TooltipTrigger
+          asChild would merge its own data-state onto the child and clobber the
+          Toggle's on/off state (and its pressed styling). */}
+      <TooltipTrigger asChild>
+        <span className="inline-flex">
+          <Toggle
+            variant="outline"
+            size="sm"
+            pressed={xray}
+            onPressedChange={toggleXray}
+            data-testid="plumix-xray-toggle"
+            aria-label={i18n._({
+              id: "editor.toolbar.xray",
+              message: "X-ray: outline all blocks",
+            })}
+          >
+            <SquareDashed />
+          </Toggle>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>
+        <Trans id="editor.toolbar.xray" message="X-ray: outline all blocks" />{" "}
+        <kbd className="text-muted-foreground ms-1">⇧X</kbd>
+      </TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/packages/admin-ui/src/icons.ts
+++ b/packages/admin-ui/src/icons.ts
@@ -94,6 +94,7 @@ export {
   SettingsIcon,
   Smartphone,
   Square,
+  SquareDashed,
   Strikethrough,
   Tablet,
   Tag,


### PR DESCRIPTION
Two small polish changes to the X-ray toggle (#1220):

- Swaps the icon from `Layout` to **`SquareDashed`** — a dashed square that mirrors the dashed outline the toggle draws (added to the curated icon re-export in admin-ui).
- Adds tooltips to the two left-cluster buttons: "Toggle panels" on the rails/sidebar toggle and "X-ray: outline all blocks ⇧X" on the x-ray toggle (with the keyboard hint).

The x-ray `Toggle` is wrapped in a `span` as the `TooltipTrigger` child: `TooltipTrigger asChild` merges its own `data-state` (open/closed) onto the child, which would clobber the Toggle's `on/off` `data-state` and break its pressed styling. The rails trigger is a plain `Button` (no `data-state`), so it uses `asChild` directly. `TooltipProvider` is already supplied by `SidebarProvider`.