### PR TITLE
feat(admin-editor): copy / cut / paste blocks

### DIFF
--- a/packages/admin-editor/e2e/editor-visual.spec.ts
+++ b/packages/admin-editor/e2e/editor-visual.spec.ts
@@ -610,6 +610,27 @@ test.describe("editor playground", () => {
     await expect(root).toHaveAttribute("data-plumix-xray", "");
   });
 
+  test("copy + paste a block (Cmd/Ctrl+C/V) from canvas focus", async ({
+    page,
+  }) => {
+    await page
+      .context()
+      .grantPermissions(["clipboard-read", "clipboard-write"]);
+    await page.goto("/");
+    const canvas = page.frameLocator(CANVAS_FRAME);
+    const blocks = canvas.locator("[data-plumix-id]");
+    const before = await blocks.count();
+
+    // Clicking a block puts focus inside the iframe; the shortcuts must still
+    // work via the canvas:clipboard forward path.
+    await canvas.locator('[data-plumix-id="heading-1"]').click();
+    await page.keyboard.press("ControlOrMeta+KeyC");
+    await page.waitForTimeout(150); // let the async clipboard write settle
+    await page.keyboard.press("ControlOrMeta+KeyV");
+
+    await expect(blocks).toHaveCount(before + 1);
+  });
+
   test("the Layers tab outlines the nested structure", async ({ page }) => {
     await page.goto("/");
 

--- a/packages/admin-editor/src/block-tree-ops.test.ts
+++ b/packages/admin-editor/src/block-tree-ops.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import type { BlockNode } from "@plumix/blocks";
 
 import {
+  collectBlocks,
   duplicateBlock,
   findBlock,
   findParentId,
@@ -494,6 +495,25 @@ describe("selectionRoots", () => {
 
   test("returns an empty array for an empty set", () => {
     expect(selectionRoots(TREE, new Set())).toEqual([]);
+  });
+});
+
+describe("collectBlocks", () => {
+  test("returns the selected root nodes whole", () => {
+    expect(collectBlocks(TREE, new Set(["a"]))).toEqual([TREE[0]]);
+  });
+
+  test("returns roots in document order, not selection order", () => {
+    // Set iterates g before a, but copy must preserve the document sequence.
+    expect(collectBlocks(TREE, new Set(["g", "a"])).map((n) => n.id)).toEqual([
+      "a",
+      "g",
+    ]);
+  });
+
+  test("collapses a nested selection to its containing root (whole subtree)", () => {
+    const out = collectBlocks(TREE, new Set(["g", "deep"]));
+    expect(out.map((n) => n.id)).toEqual(["g"]);
   });
 });
 

--- a/packages/admin-editor/src/block-tree-ops.ts
+++ b/packages/admin-editor/src/block-tree-ops.ts
@@ -269,6 +269,59 @@ export function duplicateBlock(
 }
 
 /**
+ * Collect the selected blocks as whole nodes, reduced to selection roots and
+ * returned in document order (so a copy preserves the original sequence, unlike
+ * the set-insertion order of {@link selectionRoots}). For clipboard copy.
+ */
+export function collectBlocks(
+  tree: readonly BlockNode[],
+  ids: ReadonlySet<string>,
+): readonly BlockNode[] {
+  const roots = new Set(selectionRoots(tree, ids));
+  const out: BlockNode[] = [];
+  const walk = (nodes: readonly BlockNode[]): void => {
+    for (const node of nodes) {
+      if (roots.has(node.id)) {
+        out.push(node); // a root is taken whole — never descend into it
+        continue;
+      }
+      for (const key of slotKeys(node)) {
+        const slot = node.attrs?.[key];
+        if (isBlockNodeArray(slot)) walk(slot);
+      }
+    }
+  };
+  walk(tree);
+  return out;
+}
+
+/**
+ * Insert fresh-id clones of `nodes` after `afterId` (within its parent slot),
+ * or appended to the root when `afterId` is null. Ids are rewritten through each
+ * subtree so a paste is independent of its source and of repeated pastes.
+ * Returns the new tree and the inserted roots' ids.
+ */
+export function pasteBlocks(
+  tree: readonly BlockNode[],
+  nodes: readonly BlockNode[],
+  afterId: string | null,
+): { readonly tree: readonly BlockNode[]; readonly newIds: readonly string[] } {
+  const clones = rewriteBlockNodeIds(nodes);
+  if (clones.length === 0) return { tree, newIds: [] };
+  const parentId = afterId ? findParentId(tree, afterId) : null;
+  const siblings = siblingsOf(tree, parentId);
+  const after = afterId ? siblings.findIndex((n) => n.id === afterId) : -1;
+  const start = after >= 0 ? after + 1 : siblings.length;
+  let next = tree;
+  const newIds: string[] = [];
+  clones.forEach((clone, i) => {
+    next = insertNode(next, clone, { parentId, index: start + i });
+    newIds.push(clone.id);
+  });
+  return { tree: next, newIds };
+}
+
+/**
  * Reduce a selection to its roots: ids that have no selected ancestor. Used by
  * bulk duplicate so a block isn't cloned twice when both it and its container
  * are selected (the container's clone already carries a copy of the child).

--- a/packages/admin-editor/src/canvas-frame.tsx
+++ b/packages/admin-editor/src/canvas-frame.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -29,6 +30,7 @@ import {
   frameSelection,
   zoomToCursor,
 } from "./canvas-view.js";
+import { clipboardOpFromEvent, createClipboardOps } from "./clipboard-ops.js";
 import { connectCanvas } from "./connect-canvas.js";
 import { dropPlacement } from "./drop-index.js";
 import { overlayBox } from "./overlay.js";
@@ -98,6 +100,16 @@ export function CanvasFrame({
     message: "Add a block",
   });
   const store = useEditorStoreApi();
+  const clipboard = useMemo(
+    // requiresParent blocks can't live at the top level, where paste lands.
+    () =>
+      createClipboardOps(
+        store,
+        navigator.clipboard,
+        (node) => !registry.get(node.name)?.requiresParent,
+      ),
+    [store, registry],
+  );
   const loaderPushRef = useLoaderPushRef();
   const device = useEditorStore((s) => s.device);
   const zoom = useEditorStore((s) => s.zoom);
@@ -331,6 +343,7 @@ export function CanvasFrame({
       onKey: ({ down, code, shiftKey }) =>
         keyHandlerRef.current?.(down, code, shiftKey),
       onRequestAdd: ({ parentId, slotKey }) => requestAdd(parentId, slotKey),
+      onClipboard: (op) => void clipboard.run(op),
       config: { addBlockLabel },
     });
     // Expose the loader-data push to the inspector's refresh control.
@@ -348,7 +361,22 @@ export function CanvasFrame({
     handleWheel,
     requestAdd,
     addBlockLabel,
+    clipboard,
   ]);
+
+  // Block clipboard shortcuts while focus is on the host chrome (the iframe
+  // forwards its own via the bridge). Defers to native copy on a text selection
+  // and to fields while typing.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent): void => {
+      const op = clipboardOpFromEvent(e);
+      if (!op) return;
+      e.preventDefault();
+      void clipboard.run(op);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [clipboard]);
 
   // Keep frame/container fresh when the canvas moves without a block report:
   // column scroll, window resize, and rail collapse (which resizes the inset).

--- a/packages/admin-editor/src/clipboard-ops.test.ts
+++ b/packages/admin-editor/src/clipboard-ops.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "vitest";
+
+import type { BlockNode } from "@plumix/blocks";
+
+import { createClipboardOps } from "./clipboard-ops.js";
+import { parseClipboardBlocks } from "./clipboard.js";
+import { createEditorStore } from "./store.js";
+
+// In-memory clipboard so the ops are testable without the browser API.
+function fakeClipboard(initial = "") {
+  let text = initial;
+  return {
+    text: () => text,
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async readText() {
+      return text;
+    },
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async writeText(next: string) {
+      text = next;
+    },
+  };
+}
+
+const seeded = (): readonly BlockNode[] => [
+  { id: "a", name: "core/heading", attrs: { text: "Hi" } },
+  { id: "b", name: "core/text" },
+];
+
+describe("clipboard ops", () => {
+  test("copy writes the selected blocks to the clipboard", async () => {
+    const store = createEditorStore({ tree: seeded() });
+    store.getState().select("a");
+    const clip = fakeClipboard();
+
+    await createClipboardOps(store, clip).copy();
+
+    expect(parseClipboardBlocks(clip.text())?.map((n) => n.id)).toEqual(["a"]);
+  });
+
+  test("copy with nothing selected leaves the clipboard untouched", async () => {
+    const store = createEditorStore({ tree: seeded() });
+    const clip = fakeClipboard("prior");
+
+    await createClipboardOps(store, clip).copy();
+
+    expect(clip.text()).toBe("prior");
+  });
+
+  test("cut copies then removes the selected blocks", async () => {
+    const store = createEditorStore({ tree: seeded() });
+    store.getState().select("a");
+    const clip = fakeClipboard();
+
+    await createClipboardOps(store, clip).cut();
+
+    expect(parseClipboardBlocks(clip.text())?.map((n) => n.id)).toEqual(["a"]);
+    expect(store.getState().tree.map((n) => n.id)).toEqual(["b"]);
+  });
+
+  test("paste inserts the clipboard blocks with fresh ids", async () => {
+    const store = createEditorStore();
+    const clip = fakeClipboard();
+    // Seed the clipboard via a copy from another store.
+    const source = createEditorStore({ tree: seeded() });
+    source.getState().select("a");
+    await createClipboardOps(source, clip).copy();
+
+    await createClipboardOps(store, clip).paste();
+
+    const tree = store.getState().tree;
+    expect(tree).toHaveLength(1);
+    expect(tree[0]?.name).toBe("core/heading");
+    expect(tree[0]?.id).not.toBe("a");
+  });
+
+  test("paste ignores clipboard text that isn't a plumix payload", async () => {
+    const store = createEditorStore({ tree: seeded() });
+    const clip = fakeClipboard("copied from somewhere else");
+
+    await createClipboardOps(store, clip).paste();
+
+    expect(store.getState().tree.map((n) => n.id)).toEqual(["a", "b"]);
+  });
+
+  test("paste drops nodes the canPaste predicate rejects", async () => {
+    const clip = fakeClipboard();
+    const source = createEditorStore({
+      tree: [{ id: "col", name: "core/column" }],
+    });
+    source.getState().select("col");
+    await createClipboardOps(source, clip).copy();
+
+    const store = createEditorStore();
+    // e.g. core/column requiresParent → can't land at the top level.
+    await createClipboardOps(
+      store,
+      clip,
+      (n) => n.name !== "core/column",
+    ).paste();
+
+    expect(store.getState().tree).toHaveLength(0);
+  });
+});

--- a/packages/admin-editor/src/clipboard-ops.ts
+++ b/packages/admin-editor/src/clipboard-ops.ts
@@ -1,0 +1,94 @@
+import type { BlockNode } from "@plumix/blocks";
+
+import type { EditorStoreApi } from "./store.js";
+import { collectBlocks } from "./block-tree-ops.js";
+import { parseClipboardBlocks, serializeBlocks } from "./clipboard.js";
+
+/** The subset of the Clipboard API the ops need — injectable for testing. */
+export interface ClipboardLike {
+  readText: () => Promise<string>;
+  writeText: (text: string) => Promise<void>;
+}
+
+export type ClipboardOp = "copy" | "cut" | "paste";
+
+export interface ClipboardOps {
+  readonly copy: () => Promise<void>;
+  readonly cut: () => Promise<void>;
+  readonly paste: () => Promise<void>;
+  readonly run: (op: ClipboardOp) => Promise<void>;
+}
+
+/** Lowercased shortcut key → clipboard op (Cmd/Ctrl + c/x/v). */
+export const CLIPBOARD_KEYS: Readonly<Record<string, ClipboardOp | undefined>> =
+  { c: "copy", x: "cut", v: "paste" };
+
+/**
+ * Resolve a keydown to a block clipboard op, or `null` when it isn't one. Bails
+ * on form fields / contenteditable (let them own their clipboard) and, for
+ * copy/cut, on a real text selection (the author wants text, not a block). The
+ * caller does preventDefault + performs the op — this is the shared decision the
+ * host and the iframe both use, reading each context's own `window`.
+ */
+export function clipboardOpFromEvent(e: KeyboardEvent): ClipboardOp | null {
+  if (!(e.metaKey || e.ctrlKey)) return null;
+  const op = CLIPBOARD_KEYS[e.key.toLowerCase()];
+  if (!op) return null;
+  const target = e.target as HTMLElement | null;
+  if (
+    target?.isContentEditable ||
+    /^(INPUT|TEXTAREA|SELECT)$/.test(target?.tagName ?? "")
+  ) {
+    return null;
+  }
+  if (op !== "paste" && !(window.getSelection()?.isCollapsed ?? true)) {
+    return null;
+  }
+  return op;
+}
+
+/**
+ * Block clipboard operations over the editor store, async because the Clipboard
+ * API is. `copy`/`cut` no-op when nothing is selected; `paste` no-ops when the
+ * clipboard doesn't hold a plumix payload. `canPaste` filters pasted root nodes
+ * (e.g. dropping `requiresParent` blocks, which can't live at the top level).
+ */
+export function createClipboardOps(
+  store: EditorStoreApi,
+  clipboard: ClipboardLike = navigator.clipboard,
+  canPaste?: (node: BlockNode) => boolean,
+): ClipboardOps {
+  const copy = async (): Promise<boolean> => {
+    const { tree, selectedIds } = store.getState();
+    const blocks = collectBlocks(tree, selectedIds);
+    if (blocks.length === 0) return false;
+    await clipboard.writeText(serializeBlocks(blocks));
+    return true;
+  };
+
+  const cut = async (): Promise<void> => {
+    // Remove only after the write resolves, so a failed/denied write keeps the
+    // blocks rather than losing them.
+    if (await copy()) store.getState().removeSelected();
+  };
+
+  const paste = async (): Promise<void> => {
+    const parsed = parseClipboardBlocks(await clipboard.readText());
+    if (!parsed) return;
+    const nodes = canPaste ? parsed.filter(canPaste) : parsed;
+    if (nodes.length > 0) store.getState().pasteBlocks(nodes);
+  };
+
+  const run = (op: ClipboardOp): Promise<void> => {
+    switch (op) {
+      case "copy":
+        return copy().then(() => undefined);
+      case "cut":
+        return cut();
+      case "paste":
+        return paste();
+    }
+  };
+
+  return { copy: () => copy().then(() => undefined), cut, paste, run };
+}

--- a/packages/admin-editor/src/clipboard.test.ts
+++ b/packages/admin-editor/src/clipboard.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "vitest";
+
+import type { BlockNode } from "@plumix/blocks";
+
+import { parseClipboardBlocks, serializeBlocks } from "./clipboard.js";
+
+const node: BlockNode = {
+  id: "a",
+  name: "core/heading",
+  attrs: { text: "Hi", level: 2 },
+};
+
+describe("clipboard blocks", () => {
+  test("round-trips serialized blocks back to the same nodes", () => {
+    const text = serializeBlocks([node]);
+    expect(parseClipboardBlocks(text)).toEqual([node]);
+  });
+
+  test("returns null for non-JSON clipboard text", () => {
+    expect(parseClipboardBlocks("just some copied prose")).toBeNull();
+  });
+
+  test("returns null for foreign JSON without our envelope", () => {
+    expect(parseClipboardBlocks(JSON.stringify({ blocks: [node] }))).toBeNull();
+  });
+
+  test("returns null when the payload's blocks aren't well-formed nodes", () => {
+    const text = JSON.stringify({
+      kind: "plumix/blocks",
+      version: 1,
+      blocks: [42, {}],
+    });
+    expect(parseClipboardBlocks(text)).toBeNull();
+  });
+});

--- a/packages/admin-editor/src/clipboard.ts
+++ b/packages/admin-editor/src/clipboard.ts
@@ -1,0 +1,43 @@
+import type { BlockNode } from "@plumix/blocks";
+import { isBlockNodeArray } from "@plumix/blocks";
+
+// Envelope written to the system clipboard for block copy/paste. The `kind`
+// discriminator lets paste tell our payload apart from arbitrary clipboard
+// text (and `version` leaves room to migrate the shape later).
+interface ClipboardEnvelope {
+  readonly kind: "plumix/blocks";
+  readonly version: 1;
+  readonly blocks: readonly BlockNode[];
+}
+
+/** Serialize blocks to the clipboard text payload. */
+export function serializeBlocks(blocks: readonly BlockNode[]): string {
+  return JSON.stringify({
+    kind: "plumix/blocks",
+    version: 1,
+    blocks,
+  } satisfies ClipboardEnvelope);
+}
+
+/** Parse clipboard text back to blocks, or `null` when it isn't our payload. */
+export function parseClipboardBlocks(
+  text: string,
+): readonly BlockNode[] | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    (parsed as { kind?: unknown }).kind !== "plumix/blocks"
+  ) {
+    return null;
+  }
+  // Validate the element shape too (not just that it's an array): the payload
+  // is attacker-influenceable, so reject anything that isn't real block nodes.
+  const blocks = (parsed as { blocks?: unknown }).blocks;
+  return isBlockNodeArray(blocks) ? blocks : null;
+}

--- a/packages/admin-editor/src/connect-canvas.ts
+++ b/packages/admin-editor/src/connect-canvas.ts
@@ -54,6 +54,9 @@ interface ConnectCanvasOptions {
     readonly parentId?: string;
     readonly slotKey?: string;
   }) => void;
+  /** A clipboard shortcut fired with focus inside the iframe; the host performs
+   *  the copy/cut/paste against its tree + the system clipboard. */
+  readonly onClipboard?: (op: "copy" | "cut" | "paste") => void;
   /** Host-resolved canvas chrome (localized labels) pushed once the canvas is
    *  ready. The canvas has no i18n runtime, so the host owns these strings. */
   readonly config?: { readonly addBlockLabel: string };
@@ -75,6 +78,7 @@ export function connectCanvas({
   onWheel,
   onKey,
   onRequestAdd,
+  onClipboard,
   config,
 }: ConnectCanvasOptions): CanvasConnection {
   const post = (message: object): void => {
@@ -151,6 +155,9 @@ export function connectCanvas({
         break;
       case "canvas:requestAdd":
         onRequestAdd?.({ parentId: canvas.parentId, slotKey: canvas.slotKey });
+        break;
+      case "canvas:clipboard":
+        onClipboard?.(canvas.op);
         break;
     }
   };

--- a/packages/admin-editor/src/connect-runtime.ts
+++ b/packages/admin-editor/src/connect-runtime.ts
@@ -36,6 +36,9 @@ export interface RuntimeConnection {
   /** An in-canvas "Add a block" affordance was clicked — root (no args) or an
    *  empty slot. The host resolves the insert. */
   readonly reportRequestAdd: (parentId?: string, slotKey?: string) => void;
+  /** Forward a clipboard shortcut (focus is inside the iframe); the host owns
+   *  the tree + clipboard and performs the op. */
+  readonly reportClipboard: (op: "copy" | "cut" | "paste") => void;
   readonly dispose: () => void;
 }
 
@@ -145,6 +148,8 @@ export function connectRuntime({
         ...(parentId !== undefined && { parentId }),
         ...(slotKey !== undefined && { slotKey }),
       } satisfies CanvasMessage),
+    reportClipboard: (op) =>
+      post({ type: "canvas:clipboard", op } satisfies CanvasMessage),
     dispose: () => window.removeEventListener("message", onMessage),
   };
 }

--- a/packages/admin-editor/src/editor-canvas.tsx
+++ b/packages/admin-editor/src/editor-canvas.tsx
@@ -19,6 +19,7 @@ import { editAppender, parseLoaderData, renderBlockTree } from "@plumix/blocks";
 import { PlumixProvider } from "@plumix/blocks/renderer";
 
 import type { RuntimeConnection } from "./connect-runtime.js";
+import { clipboardOpFromEvent } from "./clipboard-ops.js";
 import { connectRuntime } from "./connect-runtime.js";
 import { mergeLoaderData } from "./merge-loader-data.js";
 
@@ -187,6 +188,20 @@ export function EditorCanvas({
       window.removeEventListener("keydown", onKeyDown);
       window.removeEventListener("keyup", onKeyUp);
     };
+  }, []);
+
+  // Forward block clipboard shortcuts (Cmd/Ctrl+C/X/V) to the host, which owns
+  // the tree + clipboard. Defers to native copy when there's a real text
+  // selection, and to the field's own clipboard while typing.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent): void => {
+      const op = clipboardOpFromEvent(e);
+      if (!op) return;
+      e.preventDefault();
+      connectionRef.current?.reportClipboard(op);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
   }, []);
 
   // Layer 1 — navigation guard. The canvas renders the entry's real themed

--- a/packages/admin-editor/src/store.test.ts
+++ b/packages/admin-editor/src/store.test.ts
@@ -787,3 +787,78 @@ describe("renameBlockHtmlAttr", () => {
     expect(store.getState().tree).toBe(tree);
   });
 });
+
+describe("pasteBlocks", () => {
+  const copied: BlockNode = {
+    id: "a",
+    name: "core/heading",
+    attrs: { text: "Hi" },
+  };
+
+  test("appends pasted blocks with fresh ids and selects them", () => {
+    const store = createEditorStore();
+
+    store.getState().pasteBlocks([copied]);
+
+    const tree = store.getState().tree;
+    expect(tree).toHaveLength(1);
+    expect(tree[0]?.name).toBe("core/heading");
+    // A fresh id — never the copied source's id (would collide on a re-paste).
+    expect(tree[0]?.id).not.toBe("a");
+    expect(store.getState().activeId).toBe(tree[0]?.id);
+    expect(store.getState().selectedIds.has(tree[0]?.id ?? "")).toBe(true);
+  });
+
+  test("inserts after the active block, not at the end", () => {
+    const store = createEditorStore({
+      tree: [
+        { id: "a", name: "core/x" },
+        { id: "b", name: "core/y" },
+      ],
+    });
+    store.getState().select("a");
+
+    store.getState().pasteBlocks([copied]);
+
+    const names = store.getState().tree.map((n) => n.name);
+    expect(names).toEqual(["core/x", "core/heading", "core/y"]);
+  });
+
+  test("rewrites ids through nested children (no source-id collision)", () => {
+    const store = createEditorStore();
+    const group: BlockNode = {
+      id: "g",
+      name: "core/group",
+      attrs: { content: [{ id: "child", name: "core/x" }] },
+    };
+
+    store.getState().pasteBlocks([group]);
+
+    const pasted = store.getState().tree[0];
+    const child = (pasted?.attrs?.content as BlockNode[])[0];
+    expect(pasted?.id).not.toBe("g");
+    expect(child?.id).not.toBe("child");
+  });
+
+  test("pastes at the top level even when a nested block is active", () => {
+    const store = createEditorStore({
+      tree: [
+        {
+          id: "g",
+          name: "core/group",
+          attrs: { content: [{ id: "child", name: "core/x" }] },
+        },
+      ],
+    });
+    store.getState().select("child");
+
+    store.getState().pasteBlocks([copied]);
+
+    // Lands at the root after the group — never inside the group's slot, whose
+    // allowedBlocks the clipboard can't honor.
+    expect(store.getState().tree.map((n) => n.name)).toEqual([
+      "core/group",
+      "core/heading",
+    ]);
+  });
+});

--- a/packages/admin-editor/src/store.ts
+++ b/packages/admin-editor/src/store.ts
@@ -18,6 +18,7 @@ import {
   insertBlockAt,
   moveBlockBy,
   moveBlock as moveBlockOp,
+  pasteBlocks as pasteBlocksOp,
   removeBlocks,
   selectionRoots,
 } from "./block-tree-ops.js";
@@ -155,6 +156,9 @@ export interface EditorActions {
   removeSelected: () => void;
   /** Clone every selected block after itself and select the clones (bulk). */
   duplicateSelected: () => void;
+  /** Insert fresh-id clones of `nodes` after the active block (or appended to
+   *  the root), then select them. Used by clipboard paste. */
+  pasteBlocks: (nodes: readonly BlockNode[]) => void;
   /** Select the active block's container, walking one level up. */
   selectParent: () => void;
   /** Move the active block by `delta` positions among its siblings. */
@@ -506,6 +510,26 @@ export function createEditorStore(
           tree = result.tree;
           if (result.newId) newIds.push(result.newId);
         }
+        if (tree === state.tree) return {};
+        return {
+          tree,
+          selectedIds: new Set(newIds),
+          activeId: newIds.at(-1) ?? null,
+          history: recordHistory(state.history, tree, null),
+        };
+      }),
+    pasteBlocks: (nodes) =>
+      set((state) => {
+        // Paste at the top level (the open container), after the active block's
+        // root ancestor — never into a nested slot, whose allowedBlocks the
+        // clipboard can't honor. (Smart paste-as-sibling is a follow-up.)
+        let afterId = state.activeId;
+        while (afterId !== null) {
+          const parent = findParentId(state.tree, afterId);
+          if (parent === null) break;
+          afterId = parent;
+        }
+        const { tree, newIds } = pasteBlocksOp(state.tree, nodes, afterId);
         if (tree === state.tree) return {};
         return {
           tree,

--- a/packages/blocks/src/renderer/editor-protocol.ts
+++ b/packages/blocks/src/renderer/editor-protocol.ts
@@ -103,6 +103,13 @@ export type CanvasMessage =
       readonly type: "canvas:requestAdd";
       readonly parentId?: string;
       readonly slotKey?: string;
+    }
+  | {
+      // A clipboard shortcut (Cmd/Ctrl+C/X/V) fired while focus was inside the
+      // iframe. The host owns the tree + clipboard, so the canvas just forwards
+      // the intent and the host performs it.
+      readonly type: "canvas:clipboard";
+      readonly op: "copy" | "cut" | "paste";
     };
 
 export type EditorBridgeMessage = HostMessage | CanvasMessage;


### PR DESCRIPTION
First P0 item from the editor roadmap (#1222): block copy/cut/paste.

`Cmd/Ctrl+C/X/V` copy, cut, and paste blocks through the system clipboard — including cross-page — and work whether focus is on the host chrome or inside the canvas iframe (a `canvas:clipboard` bridge message forwards the shortcut to the host, which owns the tree + clipboard). The shortcuts defer to native behavior when there's a real text selection or focus is in a field.

Design:
- **`clipboard.ts`** — a `plumix/blocks` clipboard envelope; paste rejects foreign or malformed text (validated as real block nodes, not just any JSON array).
- **`block-tree-ops`** — `collectBlocks` (selected roots, document order) and `pasteBlocks` (fresh ids through the whole subtree via `rewriteBlockNodeIds`, so paste/re-paste never collide).
- **`store.pasteBlocks`** — inserts at the **top level** (after the active block's root ancestor) and selects the result. This keeps paste always-valid: it never lands in a nested slot whose `allowedBlocks` the clipboard can't honor, and `requiresParent` blocks (invalid at the top level) are dropped via a registry predicate.
- **`clipboard-ops`** — `createClipboardOps` over the store with an injectable clipboard (so the behavior is unit-tested without browser flakiness); `cut` removes only after the write resolves.

Tested: clipboard round-trip + rejection, `collectBlocks`/`pasteBlocks` tree ops, the ops (copy/cut/paste/filter) against a fake clipboard, and an e2e exercising the real Cmd/Ctrl+C/V path from canvas focus.

Follow-ups (noted in #1222): smart paste-as-sibling into a valid nested slot (per-slot `allowedBlocks` validation), and a toolbar/discoverability affordance.