### PR TITLE
feat(admin-editor): hide-on-device toggle in the Styles tab

### DIFF
--- a/packages/admin-editor/locales/ar.po
+++ b/packages/admin-editor/locales/ar.po
@@ -174,6 +174,11 @@ msgid "editor.selection.group"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.hideOnDevice"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/block-inspector.tsx
 msgid "editor.htmlAttrs.title"
 msgstr ""

--- a/packages/admin-editor/locales/de.po
+++ b/packages/admin-editor/locales/de.po
@@ -174,6 +174,11 @@ msgid "editor.selection.group"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.hideOnDevice"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/block-inspector.tsx
 msgid "editor.htmlAttrs.title"
 msgstr ""

--- a/packages/admin-editor/locales/en.po
+++ b/packages/admin-editor/locales/en.po
@@ -174,6 +174,11 @@ msgid "editor.selection.group"
 msgstr "Group"
 
 #. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.hideOnDevice"
+msgstr "Hide on this device"
+
+#. js-lingui-explicit-id
 #: src/block-inspector.tsx
 msgid "editor.htmlAttrs.title"
 msgstr "HTML attributes"

--- a/packages/admin-editor/locales/uk.po
+++ b/packages/admin-editor/locales/uk.po
@@ -174,6 +174,11 @@ msgid "editor.selection.group"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.hideOnDevice"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/block-inspector.tsx
 msgid "editor.htmlAttrs.title"
 msgstr ""

--- a/packages/admin-editor/locales/zh-CN.po
+++ b/packages/admin-editor/locales/zh-CN.po
@@ -174,6 +174,11 @@ msgid "editor.selection.group"
 msgstr ""
 
 #. js-lingui-explicit-id
+#: src/styles-tab.tsx
+msgid "editor.styles.hideOnDevice"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: src/block-inspector.tsx
 msgid "editor.htmlAttrs.title"
 msgstr ""

--- a/packages/admin-editor/src/styles-tab.test.tsx
+++ b/packages/admin-editor/src/styles-tab.test.tsx
@@ -114,6 +114,55 @@ describe("StylesTab", () => {
     );
   });
 
+  test("the hide toggle sets display:none in the active device bucket", () => {
+    const { getByTestId } = renderTab([{ id: "a", name: "core/x" }], "a");
+
+    fireEvent.click(getByTestId("style-hide-on-device"));
+
+    expect(getByTestId("style-probe").textContent).toContain(
+      '"display":{"raw":"none"}',
+    );
+  });
+
+  test("the hide toggle reads pressed from an existing display:none (raw or token)", () => {
+    const raw: BlockNode = {
+      id: "a",
+      name: "core/x",
+      style: { large: { display: { raw: "none" } } },
+    };
+    expect(
+      renderTab([raw], "a")
+        .getByTestId("style-hide-on-device")
+        .getAttribute("data-state"),
+    ).toBe("on");
+
+    cleanup();
+    const token: BlockNode = {
+      id: "a",
+      name: "core/x",
+      style: { large: { display: { token: "none" } } },
+    };
+    expect(
+      renderTab([token], "a")
+        .getByTestId("style-hide-on-device")
+        .getAttribute("data-state"),
+    ).toBe("on");
+  });
+
+  test("the hide toggle clears display:none when turned off", () => {
+    const hidden: BlockNode = {
+      id: "a",
+      name: "core/x",
+      style: { large: { display: { raw: "none" } } },
+    };
+    const { getByTestId } = renderTab([hidden], "a");
+
+    fireEvent.click(getByTestId("style-hide-on-device"));
+
+    // The only declaration is gone, so the style slot prunes to undefined.
+    expect(getByTestId("style-probe").textContent).toBe("");
+  });
+
   test("box-model writes a per-side custom padding value", () => {
     const { getByTestId } = renderTab([{ id: "a", name: "core/x" }], "a");
 

--- a/packages/admin-editor/src/styles-tab.tsx
+++ b/packages/admin-editor/src/styles-tab.tsx
@@ -14,10 +14,13 @@ import {
   AlignLeft,
   AlignRight,
   Bold,
+  Eye,
+  EyeOff,
   Italic,
   Strikethrough,
   Underline,
 } from "@plumix/admin-ui/icons";
+import { Toggle } from "@plumix/admin-ui/toggle";
 import { ToggleGroup, ToggleGroupItem } from "@plumix/admin-ui/toggle-group";
 import { normalizeStyleValue } from "@plumix/blocks";
 
@@ -96,6 +99,7 @@ const SECTION_IDS = [...SECTIONS.map((s) => s.id), "spacing"];
  * responsive bucket, so styles are set per breakpoint.
  */
 export function StylesTab({ tokens }: StylesTabProps): ReactElement {
+  const { i18n } = useLingui();
   const activeId = useEditorStore((s) => s.activeId);
   const device = useEditorStore((s) => s.device);
   const block = useEditorStore((s) =>
@@ -131,15 +135,38 @@ export function StylesTab({ tokens }: StylesTabProps): ReactElement {
     (property: string) =>
     (value: StyleValue | null): void =>
       updateBlockStyle(activeId, bucket, property, value);
+  // Hidden when display resolves to "none" in either form — a value typed in
+  // the CSS section is raw, but a legacy/token "none" should read as hidden too.
+  const display = valueOf("display");
+  const hidden =
+    (display && ("raw" in display ? display.raw : display.token)) === "none";
 
   return (
     <div className="flex flex-col gap-2 p-3" data-testid="styles-tab">
-      <p
-        className="text-muted-foreground text-xs"
-        data-testid="styles-tab-scope"
-      >
-        <Trans id="editor.styles.scope" message="Editing" /> · {device}
-      </p>
+      <div className="flex items-center justify-between">
+        <p
+          className="text-muted-foreground text-xs"
+          data-testid="styles-tab-scope"
+        >
+          <Trans id="editor.styles.scope" message="Editing" /> · {device}
+        </p>
+        {/* Writes display:none into the active device's bucket only. */}
+        <Toggle
+          variant="outline"
+          size="sm"
+          pressed={hidden}
+          onPressedChange={(next) =>
+            setter("display")(next ? { raw: "none" } : null)
+          }
+          data-testid="style-hide-on-device"
+          aria-label={i18n._({
+            id: "editor.styles.hideOnDevice",
+            message: "Hide on this device",
+          })}
+        >
+          {hidden ? <EyeOff /> : <Eye />}
+        </Toggle>
+      </div>
       <Accordion type="multiple" defaultValue={SECTION_IDS}>
         {SECTIONS.map((section) => (
           <AccordionItem key={section.id} value={section.id}>

--- a/packages/admin-ui/src/icons.ts
+++ b/packages/admin-ui/src/icons.ts
@@ -62,6 +62,7 @@ export {
   CornerLeftUp,
   Eye,
   EyeIcon,
+  EyeOff,
   FileText,
   Folder,
   Globe,


### PR DESCRIPTION
An explicit "hide on this device" toggle (Eye/EyeOff) next to the per-device scope line in the Styles tab — the one-click affordance over what the raw CSS section already allowed (you could type `display: none`). P0 polish from the editor roadmap (#1222).

It sets `display: none` in the **active device's** style bucket only (so a block can be hidden on mobile but shown on desktop) and clears it when turned off. The toggle reads pressed from a `display` of `none` in either raw or token form, staying two-way consistent with the CSS declarations list (both read/write the same bucket `display`).

Note: turning it off clears `display` outright — a prior custom `display` (e.g. `flex`) isn't restored, consistent with the tab's other clear-to-null toggles (no hidden visibility state machine).