### PR TITLE
feat(admin-editor): add a Size section and a 2-column Styles tab layout

### DIFF
--- a/packages/admin-editor/src/style-control.tsx
+++ b/packages/admin-editor/src/style-control.tsx
@@ -50,7 +50,9 @@ export function StyleControl({
 
   return (
     <div className="flex flex-col gap-1" data-testid={testId}>
-      <div className="flex items-center justify-between">
+      {/* Label over the Token/Custom toggle (not side-by-side) so the toggle
+          never clips in the narrow half-width grid cells. */}
+      <div className="flex flex-col gap-0.5">
         <Label className="text-xs">{label}</Label>
         {category ? (
           <div className="flex gap-0.5 text-xs">

--- a/packages/admin-editor/src/styles-tab.test.tsx
+++ b/packages/admin-editor/src/styles-tab.test.tsx
@@ -79,6 +79,25 @@ describe("StylesTab", () => {
     expect(margin.contains(padding)).toBe(false);
   });
 
+  test("exposes Size controls that write width/min-width to the active bucket", () => {
+    const { getByTestId } = renderTab([{ id: "a", name: "core/x" }], "a");
+
+    expect(getByTestId("styles-section-size")).toBeDefined();
+
+    // Sizing has no token scale, so the custom input shows directly (no mode
+    // toggle) — the same model as font-size.
+    fireEvent.change(getByTestId("style-control-width-custom"), {
+      target: { value: "280px" },
+    });
+    fireEvent.change(getByTestId("style-control-minWidth-custom"), {
+      target: { value: "280px" },
+    });
+
+    const probe = getByTestId("style-probe").textContent;
+    expect(probe).toContain('"width":{"raw":"280px"}');
+    expect(probe).toContain('"minWidth":{"raw":"280px"}');
+  });
+
   test("the italic mark toggles a fontStyle raw value", () => {
     const { getByTestId } = renderTab([{ id: "a", name: "core/x" }], "a");
 

--- a/packages/admin-editor/src/styles-tab.test.tsx
+++ b/packages/admin-editor/src/styles-tab.test.tsx
@@ -79,6 +79,16 @@ describe("StylesTab", () => {
     expect(margin.contains(padding)).toBe(false);
   });
 
+  test("leads the Styles tab with the Size section", () => {
+    const { container } = renderTab([{ id: "a", name: "core/x" }], "a", {
+      expandCss: false,
+    });
+    const sections = [
+      ...container.querySelectorAll('[data-testid^="styles-section-"]'),
+    ].map((el) => el.getAttribute("data-testid"));
+    expect(sections[0]).toBe("styles-section-size");
+  });
+
   test("exposes Size controls that write width/min-width to the active bucket", () => {
     const { getByTestId } = renderTab([{ id: "a", name: "core/x" }], "a");
 

--- a/packages/admin-editor/src/styles-tab.tsx
+++ b/packages/admin-editor/src/styles-tab.tsx
@@ -53,6 +53,20 @@ const SECTIONS: readonly {
   readonly controls: readonly ControlSpec[];
 }[] = [
   {
+    // Sizing has no token scale (widths are arbitrary px/%/rem), so these are
+    // custom-only — same model as font-size.
+    id: "size",
+    label: "Size",
+    controls: [
+      { property: "width", label: "Width" },
+      { property: "height", label: "Height" },
+      { property: "minWidth", label: "Min width" },
+      { property: "minHeight", label: "Min height" },
+      { property: "maxWidth", label: "Max width" },
+      { property: "maxHeight", label: "Max height" },
+    ],
+  },
+  {
     id: "typography",
     label: "Typography",
     controls: [
@@ -71,21 +85,6 @@ const SECTIONS: readonly {
     label: "Background",
     controls: [
       { property: "background", label: "Background", category: "colors" },
-    ],
-  },
-  {
-    // Sizing has no token scale (widths are arbitrary px/%/rem), so these are
-    // custom-only — same model as font-size.
-    id: "size",
-    label: "Size",
-    controls: [
-      { property: "width", label: "Width" },
-      { property: "height", label: "Height" },
-      { property: "aspectRatio", label: "Aspect ratio" },
-      { property: "minWidth", label: "Min width" },
-      { property: "minHeight", label: "Min height" },
-      { property: "maxWidth", label: "Max width" },
-      { property: "maxHeight", label: "Max height" },
     ],
   },
   {
@@ -189,17 +188,21 @@ export function StylesTab({ tokens }: StylesTabProps): ReactElement {
               {section.label}
             </AccordionTrigger>
             <AccordionContent className="flex flex-col gap-3">
-              {section.controls.map((c) => (
-                <StyleControl
-                  key={c.property}
-                  label={c.label}
-                  property={c.property}
-                  category={c.category}
-                  value={valueOf(c.property)}
-                  tokens={tokens}
-                  onChange={setter(c.property)}
-                />
-              ))}
+              {/* Two-per-row so the rail stays compact; each StyleControl is a
+                  self-contained cell (label + input stacked). */}
+              <div className="grid grid-cols-2 gap-x-2 gap-y-3">
+                {section.controls.map((c) => (
+                  <StyleControl
+                    key={c.property}
+                    label={c.label}
+                    property={c.property}
+                    category={c.category}
+                    value={valueOf(c.property)}
+                    tokens={tokens}
+                    onChange={setter(c.property)}
+                  />
+                ))}
+              </div>
               {section.id === "typography" && (
                 <TextStyleControls valueOf={valueOf} setter={setter} />
               )}
@@ -417,20 +420,22 @@ function SpacingControls({
           data-testid={group.testId}
         >
           <span className="text-muted-foreground text-xs">{group.label}</span>
-          {SIDES.map((side) => {
-            const property = `${group.prefix}${side}`;
-            return (
-              <StyleControl
-                key={property}
-                label={side}
-                property={property}
-                category="spacing"
-                value={valueOf(property)}
-                tokens={tokens}
-                onChange={setter(property)}
-              />
-            );
-          })}
+          <div className="grid grid-cols-2 gap-x-2 gap-y-2">
+            {SIDES.map((side) => {
+              const property = `${group.prefix}${side}`;
+              return (
+                <StyleControl
+                  key={property}
+                  label={side}
+                  property={property}
+                  category="spacing"
+                  value={valueOf(property)}
+                  tokens={tokens}
+                  onChange={setter(property)}
+                />
+              );
+            })}
+          </div>
         </div>
       ))}
     </div>

--- a/packages/admin-editor/src/styles-tab.tsx
+++ b/packages/admin-editor/src/styles-tab.tsx
@@ -74,6 +74,21 @@ const SECTIONS: readonly {
     ],
   },
   {
+    // Sizing has no token scale (widths are arbitrary px/%/rem), so these are
+    // custom-only — same model as font-size.
+    id: "size",
+    label: "Size",
+    controls: [
+      { property: "width", label: "Width" },
+      { property: "height", label: "Height" },
+      { property: "aspectRatio", label: "Aspect ratio" },
+      { property: "minWidth", label: "Min width" },
+      { property: "minHeight", label: "Min height" },
+      { property: "maxWidth", label: "Max width" },
+      { property: "maxHeight", label: "Max height" },
+    ],
+  },
+  {
     id: "border",
     label: "Border",
     controls: [


### PR DESCRIPTION
Adds a **Size** section to the editor Styles tab (Width, Height, Min/Max width & height) and reworks the tab's layout for density.

- **Size controls** — custom-only (no token scale — widths are arbitrary `px`/`%`/`rem`, the font-size model), responsive per device bucket, two-way bound with the CSS declarations repeater since both read the same `node.style[bucket]` slot. They apply to the block's own root, so the existing style-emitter handles them with no special casing. A fixed-width sidebar column is `min-width: 280px` here today.
- **Size leads the tab** — it's the most-reached layout control, so it sits above Typography.
- **2-column grid** — each section's controls (and the spacing Top/Right/Bottom/Left) lay out two-up to cut the rail's vertical footprint. `StyleControl` now stacks the Token/Custom toggle under its label so it doesn't clip in the narrow half-width cells.

This is the unblocked half of container layout; the flex/Box controls (which must reach a container's children) land separately. Tracked in #1222.

Refs #1222