### PR TITLE
fix(admin-editor): attach the canvas frame header to the device frame

### DIFF
--- a/packages/admin-editor/e2e/editor-visual.spec.ts
+++ b/packages/admin-editor/e2e/editor-visual.spec.ts
@@ -476,6 +476,11 @@ test.describe("editor playground", () => {
     const handle = await page.getByTestId("plumix-canvas-handle").boundingBox();
     if (!before || !handle) throw new Error("expected frame + handle boxes");
 
+    // The strip rides just above the frame (inside the panned/zoomed stage),
+    // left-aligned to it — not a fixed band welded to the viewport top.
+    expect(handle.y + handle.height).toBeLessThanOrEqual(before.y + 1);
+    expect(Math.abs(handle.x - before.x)).toBeLessThan(2);
+
     // Press-drag the strip (no Space) — the frame should follow the pointer.
     await page.mouse.move(
       handle.x + handle.width / 2,

--- a/packages/admin-editor/src/canvas-frame.tsx
+++ b/packages/admin-editor/src/canvas-frame.tsx
@@ -903,210 +903,210 @@ export function CanvasFrame({
 
   return (
     <div
-      data-testid="plumix-canvas-frame-shell"
+      ref={containerRef}
+      data-testid="plumix-canvas-frame"
+      // A Figma-style pannable stage: the device frame floats in this surface
+      // and is panned/zoomed via a transform (no scrollbars). `overflow:hidden`
+      // clips the off-stage frame; `touch-action:none` lets us own wheel/touch
+      // gestures. `var(--muted)` reads as canvas, not a void.
       style={{
-        display: "flex",
-        flexDirection: "column",
+        position: "relative",
         flex: 1,
-        minHeight: 0,
+        overflow: "hidden",
+        touchAction: "none",
+        background: "var(--muted)",
+        cursor: panReady ? "grab" : "default",
       }}
     >
-      {!readOnly && (
-        <CanvasHandle device={device} onPointerDown={onHandlePointerDown} />
-      )}
-      <div
-        ref={containerRef}
-        data-testid="plumix-canvas-frame"
-        // A Figma-style pannable stage: the device frame floats in this surface
-        // and is panned/zoomed via a transform (no scrollbars). `overflow:hidden`
-        // clips the off-stage frame; `touch-action:none` lets us own wheel/touch
-        // gestures. `var(--muted)` reads as canvas, not a void.
-        style={{
-          position: "relative",
-          flex: 1,
-          minHeight: 0,
-          overflow: "hidden",
-          touchAction: "none",
-          background: "var(--muted)",
-          cursor: panReady ? "grab" : "default",
-        }}
-      >
-        {/* The stage: positioned at the container origin and moved as a whole by
+      {/* The stage: positioned at the container origin and moved as a whole by
           `translate(pan) scale(zoom)`. The iframe sits at natural size; the
           transform does the panning + zooming, and the overlays track it by
           re-reading the iframe's live on-screen rect. */}
-        <div
-          ref={stageRef}
+      <div
+        ref={stageRef}
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          width: frameWidth,
+          height: contentHeight ?? CANVAS_HEIGHT,
+          // Committed transform. During a gesture the live transform is written
+          // imperatively (applyLive) and re-asserted after any incidental render
+          // by the layout effect below, so this stale value never paints.
+          transform: `translate(${String(panX)}px, ${String(panY)}px) scale(${String(zoom)})`,
+          transformOrigin: "top left",
+        }}
+      >
+        {!readOnly && (
+          <CanvasHandle
+            device={device}
+            frameWidth={frameWidth}
+            onPointerDown={onHandlePointerDown}
+          />
+        )}
+        <iframe
+          ref={iframeRef}
+          src={previewUrl}
+          title="plumix-editor-canvas"
+          onLoad={measureContent}
           style={{
-            position: "absolute",
-            top: 0,
-            left: 0,
+            display: "block",
             width: frameWidth,
             height: contentHeight ?? CANVAS_HEIGHT,
-            // Committed transform. During a gesture the live transform is written
-            // imperatively (applyLive) and re-asserted after any incidental render
-            // by the layout effect below, so this stale value never paints.
-            transform: `translate(${String(panX)}px, ${String(panY)}px) scale(${String(zoom)})`,
-            transformOrigin: "top left",
+            border: 0,
+            // Click-through while a block drag or a space-pan is active so the
+            // host receives the pointer events. Single declarative owner — no
+            // imperative toggling that could desync across the two gestures.
+            pointerEvents:
+              dragSpec || movingId || panReady ? "none" : undefined,
           }}
-        >
-          <iframe
-            ref={iframeRef}
-            src={previewUrl}
-            title="plumix-editor-canvas"
-            onLoad={measureContent}
-            style={{
-              display: "block",
-              width: frameWidth,
-              height: contentHeight ?? CANVAS_HEIGHT,
-              border: 0,
-              // Click-through while a block drag or a space-pan is active so the
-              // host receives the pointer events. Single declarative owner — no
-              // imperative toggling that could desync across the two gestures.
-              pointerEvents:
-                dragSpec || movingId || panReady ? "none" : undefined,
-            }}
-          />
-        </div>
-        {/* Clip layer pinned over the visible canvas column. Its overflow:hidden
+        />
+      </div>
+      {/* Clip layer pinned over the visible canvas column. Its overflow:hidden
           keeps the absolutely-positioned overlays + toolbar from spilling onto
           the side rails when the iframe renders wider than the column. Hidden
           mid-gesture: the overlays read stale geometry while the transform is
           live, and re-measuring per frame is the cost we're avoiding. They snap
           back on commit. */}
-        {!readOnly && container && !gesturing && (
-          <div
-            data-testid="plumix-overlay-clip"
-            style={{
-              position: "fixed",
-              left: container.left,
-              top: container.top,
-              width: container.width,
-              height: container.height,
-              overflow: "hidden",
-              pointerEvents: "none",
-              zIndex: 10,
-            }}
-          >
-            {overlay(hoverId, HOVER_OUTLINE, "plumix-overlay-hover")}
-            {[...selectedIds]
-              .filter((id) => id !== activeId)
-              .map((id) =>
-                overlay(id, MEMBER_OUTLINE, `plumix-overlay-member-${id}`),
-              )}
-            {overlay(activeId, SELECTED_OUTLINE, "plumix-overlay-selected")}
-            {activeBox && <SelectionToolbar box={activeBox} />}
-            {dropSlot && (
-              <div
-                data-testid="plumix-slot-drop-indicator"
-                style={{
-                  position: "absolute",
-                  left: dropSlot.box.left - container.left,
-                  top: dropSlot.box.top - container.top,
-                  width: dropSlot.box.width,
-                  height: dropSlot.box.height,
-                  outline: `2px dashed ${SELECTED_OUTLINE}`,
-                  background: "rgba(37,99,235,0.08)",
-                  pointerEvents: "none",
-                  zIndex: 20,
-                }}
-              />
+      {!readOnly && container && !gesturing && (
+        <div
+          data-testid="plumix-overlay-clip"
+          style={{
+            position: "fixed",
+            left: container.left,
+            top: container.top,
+            width: container.width,
+            height: container.height,
+            overflow: "hidden",
+            pointerEvents: "none",
+            zIndex: 10,
+          }}
+        >
+          {overlay(hoverId, HOVER_OUTLINE, "plumix-overlay-hover")}
+          {[...selectedIds]
+            .filter((id) => id !== activeId)
+            .map((id) =>
+              overlay(id, MEMBER_OUTLINE, `plumix-overlay-member-${id}`),
             )}
-            {dropY !== null && geometry.frame && (
-              <div
-                data-testid="plumix-drop-indicator"
-                style={{
-                  position: "absolute",
-                  left: geometry.frame.left - container.left,
-                  top: dropY - container.top,
-                  width: frameWidth * zoom,
-                  height: 2,
-                  background: SELECTED_OUTLINE,
-                  pointerEvents: "none",
-                  zIndex: 20,
-                }}
-              />
-            )}
-          </div>
-        )}
-
-        {/* Slot-scoped inserter: opened by the in-canvas "Add a block" affordance,
-          anchored over the slot, listing only that slot's permitted blocks. A
-          pick inserts into the slot (or at the root) and closes it. */}
-        {!readOnly && pendingAdd && (
-          <Popover
-            open
-            onOpenChange={(next) => {
-              if (!next) setPendingAdd(null);
-            }}
-          >
-            <PopoverAnchor
+          {overlay(activeId, SELECTED_OUTLINE, "plumix-overlay-selected")}
+          {activeBox && <SelectionToolbar box={activeBox} />}
+          {dropSlot && (
+            <div
+              data-testid="plumix-slot-drop-indicator"
               style={{
-                position: "fixed",
-                left: pendingAnchor?.left ?? 0,
-                top: pendingAnchor?.top ?? 0,
-                width: pendingAnchor?.width ?? 0,
-                height: pendingAnchor?.height ?? 0,
+                position: "absolute",
+                left: dropSlot.box.left - container.left,
+                top: dropSlot.box.top - container.top,
+                width: dropSlot.box.width,
+                height: dropSlot.box.height,
+                outline: `2px dashed ${SELECTED_OUTLINE}`,
+                background: "rgba(37,99,235,0.08)",
                 pointerEvents: "none",
+                zIndex: 20,
               }}
             />
-            <PopoverContent
-              data-testid="plumix-inserter-popover"
-              align="start"
-              className="w-72 p-0"
-            >
-              {/* Radix's viewport (height:100%) won't clamp to a max-height on
-                the Root, so cap the viewport directly — it then scrolls while
-                the popover still shrinks to fit short lists. */}
-              <ScrollArea className="[&>[data-slot=scroll-area-viewport]]:max-h-96">
-                <BlockCatalog
-                  registry={registry}
-                  capabilities={capabilities}
-                  allowed={pendingAllowed}
-                  parentName={pendingParentName}
-                  target={pendingTarget}
-                  onInsert={() => setPendingAdd(null)}
-                />
-              </ScrollArea>
-            </PopoverContent>
-          </Popover>
-        )}
+          )}
+          {dropY !== null && geometry.frame && (
+            <div
+              data-testid="plumix-drop-indicator"
+              style={{
+                position: "absolute",
+                left: geometry.frame.left - container.left,
+                top: dropY - container.top,
+                width: frameWidth * zoom,
+                height: 2,
+                background: SELECTED_OUTLINE,
+                pointerEvents: "none",
+                zIndex: 20,
+              }}
+            />
+          )}
+        </div>
+      )}
 
-        {/* Transient "can't place here" notice for a refused requiresParent drop;
-          the editor has no toast surface, so it shows inline. */}
-        {!readOnly && rejection && (
-          <div
-            role="status"
-            data-testid="plumix-add-rejection"
+      {/* Slot-scoped inserter: opened by the in-canvas "Add a block" affordance,
+          anchored over the slot, listing only that slot's permitted blocks. A
+          pick inserts into the slot (or at the root) and closes it. */}
+      {!readOnly && pendingAdd && (
+        <Popover
+          open
+          onOpenChange={(next) => {
+            if (!next) setPendingAdd(null);
+          }}
+        >
+          <PopoverAnchor
             style={{
-              position: "absolute",
-              left: "50%",
-              bottom: 16,
-              transform: "translateX(-50%)",
-              zIndex: 30,
-              padding: "0.5rem 0.75rem",
-              borderRadius: 8,
-              fontSize: "0.8125rem",
-              color: "var(--destructive-foreground, #fff)",
-              background: "var(--destructive, #dc2626)",
-              boxShadow: "0 2px 8px rgba(0,0,0,0.2)",
+              position: "fixed",
+              left: pendingAnchor?.left ?? 0,
+              top: pendingAnchor?.top ?? 0,
+              width: pendingAnchor?.width ?? 0,
+              height: pendingAnchor?.height ?? 0,
               pointerEvents: "none",
             }}
+          />
+          <PopoverContent
+            data-testid="plumix-inserter-popover"
+            align="start"
+            className="w-72 p-0"
           >
-            {rejection}
-          </div>
-        )}
-      </div>
+            {/* Radix's viewport (height:100%) won't clamp to a max-height on
+                the Root, so cap the viewport directly — it then scrolls while
+                the popover still shrinks to fit short lists. */}
+            <ScrollArea className="[&>[data-slot=scroll-area-viewport]]:max-h-96">
+              <BlockCatalog
+                registry={registry}
+                capabilities={capabilities}
+                allowed={pendingAllowed}
+                parentName={pendingParentName}
+                target={pendingTarget}
+                onInsert={() => setPendingAdd(null)}
+              />
+            </ScrollArea>
+          </PopoverContent>
+        </Popover>
+      )}
+
+      {/* Transient "can't place here" notice for a refused requiresParent drop;
+          the editor has no toast surface, so it shows inline. */}
+      {!readOnly && rejection && (
+        <div
+          role="status"
+          data-testid="plumix-add-rejection"
+          style={{
+            position: "absolute",
+            left: "50%",
+            bottom: 16,
+            transform: "translateX(-50%)",
+            zIndex: 30,
+            padding: "0.5rem 0.75rem",
+            borderRadius: 8,
+            fontSize: "0.8125rem",
+            color: "var(--destructive-foreground, #fff)",
+            background: "var(--destructive, #dc2626)",
+            boxShadow: "0 2px 8px rgba(0,0,0,0.2)",
+            pointerEvents: "none",
+          }}
+        >
+          {rejection}
+        </div>
+      )}
     </div>
   );
 }
 
-/** The frame header: the active device label, draggable to pan the canvas. */
+// The strip lives inside the stage (so it pans/zooms with the frame), offset up
+// by its own height plus a gap to clear the frame's top edge.
+const HANDLE_HEIGHT = 32;
+const HANDLE_GAP = 8;
+
+/** The draggable device-label strip that rides just above the device frame. */
 function CanvasHandle({
   device,
+  frameWidth,
   onPointerDown,
 }: {
   readonly device: EditorDevice;
+  readonly frameWidth: number;
   readonly onPointerDown: (e: ReactPointerEvent<HTMLDivElement>) => void;
 }): ReactElement {
   const { i18n } = useLingui();
@@ -1118,8 +1118,15 @@ function CanvasHandle({
         id: "editor.canvas.pan",
         message: "Drag to move the canvas",
       })}
-      className="bg-background flex h-7 shrink-0 cursor-grab items-center border-b px-3 text-xs font-medium select-none active:cursor-grabbing"
-      style={{ touchAction: "none" }}
+      className="bg-background text-foreground flex cursor-grab items-center px-4 text-sm font-medium select-none active:cursor-grabbing"
+      style={{
+        position: "absolute",
+        left: 0,
+        top: -(HANDLE_HEIGHT + HANDLE_GAP),
+        width: frameWidth,
+        height: HANDLE_HEIGHT,
+        touchAction: "none",
+      }}
     >
       {deviceLabel(i18n, device)}
     </div>


### PR DESCRIPTION
The drag-to-pan frame header shipped as a fixed full-width band welded to the top of the canvas viewport, leaving a gap down to the centered device frame. It now rides directly above the frame and follows it.

The strip moves inside the panned/zoomed stage, positioned just above the iframe at the frame's width, so the device label ("Desktop"/"Tablet"/"Mobile") pans and zooms *with* the frame — Builder's per-frame label model — and still drags to pan. Styling is a flat dark bar with a gap above the frame.

This reverts the temporary flex-column shell back to the original single container root; the inserter popover and overlay clip (both `position:fixed`) are unaffected, and the rejection notice now centers in the full canvas column.

Space+drag and scroll-to-pan are unchanged. The e2e drag test now also asserts the strip sits above the frame and left-aligned to it.

Follow-up to #1239.